### PR TITLE
Add TypeScript type deps for Next.js build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,8 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.2.0",
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.21",
     "tailwindcss": "^3.3.2",


### PR DESCRIPTION
## Summary
- add @types/react and @types/node to dev dependencies to support Next.js build

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to install required TypeScript dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689eb052b1f48329b4a609c9f6ae4e01