### PR TITLE
Add modern feed with header, footer, and follow button

### DIFF
--- a/frontend/components/FollowButton.tsx
+++ b/frontend/components/FollowButton.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+
+export default function FollowButton() {
+  const [following, setFollowing] = useState(false)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+    try {
+      const v = window.localStorage.getItem('wn_following')
+      setFollowing(v === 'true')
+    } catch {}
+  }, [])
+
+  const toggle = () => {
+    const next = !following
+    setFollowing(next)
+    try { window.localStorage.setItem('wn_following', String(next)) } catch {}
+  }
+
+  if (!mounted) return null
+
+  return (
+    <button
+      onClick={toggle}
+      className="text-sm px-3 py-1 rounded border border-blue-600 text-blue-600 hover:bg-blue-50"
+      aria-label={following ? 'Following WaterNews' : 'Follow WaterNews'}
+      title={following ? 'Following WaterNews' : 'Follow WaterNews'}
+    >
+      {following ? '🔔' : 'Follow'}
+    </button>
+  )
+}

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+
+export default function Footer() {
+  return (
+    <footer className="border-t bg-white">
+      <div className="max-w-7xl mx-auto px-4 py-6 text-sm text-gray-600">
+        <div className="flex flex-wrap items-center gap-4">
+          <Link href="/about" className="hover:text-blue-700">About</Link>
+          <Link href="/contact" className="hover:text-blue-700">Contact</Link>
+          <Link href="/suggest" className="hover:text-blue-700">Suggest a Story</Link>
+          <Link href="/privacy" className="hover:text-blue-700">Privacy Policy</Link>
+          <span className="opacity-50">•</span>
+          <Link href="/login" className="hover:text-blue-700">Login</Link>
+        </div>
+        <div className="mt-2 text-xs text-gray-400">© {new Date().getFullYear()} WaterNewsGY</div>
+      </div>
+    </footer>
+  )
+}

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+import Link from 'next/link'
+import FollowButton from './FollowButton'
+
+export default function Header() {
+  const [showSearch, setShowSearch] = useState(false)
+
+  return (
+    <header className="border-b bg-white">
+      <div className="max-w-7xl mx-auto px-4 py-3 flex items-center gap-4">
+        <Link href="/" className="font-extrabold text-xl tracking-tight">
+          WaterNews
+        </Link>
+
+        <nav className="ml-2 flex items-center gap-3 text-sm text-gray-700">
+          <Link className="hover:text-blue-700" href="/?sort=recent">Recent</Link>
+          <Link className="hover:text-blue-700" href="/?sort=trending">Trending</Link>
+          <Link className="hover:text-blue-700" href="/?view=categories">Categories</Link>
+        </nav>
+
+        <div className="ml-auto flex items-center gap-3">
+          <div className="relative">
+            <button
+              onClick={() => setShowSearch((s) => !s)}
+              className="text-sm px-2 py-1 rounded hover:bg-gray-100"
+              aria-label="Toggle search"
+              title="Search"
+            >
+              🔍
+            </button>
+            {showSearch && (
+              <div className="absolute right-0 mt-2 w-64 bg-white border rounded shadow p-2">
+                <input
+                  type="search"
+                  placeholder="Search WaterNews..."
+                  className="w-full border rounded px-2 py-1 text-sm outline-none focus:ring-2 focus:ring-blue-200"
+                />
+              </div>
+            )}
+          </div>
+
+          <FollowButton />
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,9 +1,138 @@
-import React from 'react'
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import axios from 'axios'
+import Header from '../components/Header'
+import Footer from '../components/Footer'
 
-export default function Home() {
+type Article = {
+  _id?: string
+  slug: string
+  title: string
+  image?: string
+  summary?: string
+  tags?: string[]
+  engagement?: { likes: number; shares: number; comments: number }
+  publishedAt?: string
+}
+
+export default function HomePage() {
+  const [articles, setArticles] = useState<Article[]>([])
+  const [trending, setTrending] = useState<Article[]>([])
+  const [diaspora, setDiaspora] = useState<Article[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const run = async () => {
+      try {
+        const res = await axios.get('/api/news/home')
+        const data = res?.data || {}
+        setArticles(Array.isArray(data.articles) ? data.articles : [])
+        setTrending(Array.isArray(data.trending) ? data.trending : [])
+        setDiaspora(Array.isArray(data.diaspora) ? data.diaspora : [])
+      } catch (e) {
+        // fail silently but render empty states
+        console.error('Failed to load /api/news/home', e)
+      } finally {
+        setLoading(false)
+      }
+    }
+    run()
+  }, [])
+
   return (
-    <main className="min-h-screen p-8">
-      <h1 className="text-2xl font-bold">Welcome to WaterNews</h1>
-    </main>
+    <div className="min-h-screen bg-gray-50">
+      <Header />
+
+      <main className="grid grid-cols-1 md:grid-cols-4 gap-6 px-4 py-8 max-w-7xl mx-auto">
+        <section className="md:col-span-3 space-y-8">
+          {loading && (
+            <div className="text-gray-500 text-sm">Loading latest stories…</div>
+          )}
+
+          {!loading && articles.length === 0 && (
+            <div className="text-gray-500 text-sm">
+              No stories yet. Check back shortly.
+            </div>
+          )}
+
+          {articles.map((article) => (
+            <article key={article._id || article.slug} className="bg-white border rounded p-4 shadow-sm">
+              <Link href={`/article/${article.slug}`}>
+                <h2 className="text-2xl font-semibold mb-2 hover:underline cursor-pointer">
+                  {article.title}
+                </h2>
+              </Link>
+
+              {article.image && (
+                <img
+                  src={article.image}
+                  alt={article.title}
+                  className="w-full h-auto mb-4 rounded"
+                />
+              )}
+
+              {article.summary && (
+                <p className="text-gray-700 mb-3">{article.summary}</p>
+              )}
+
+              <div className="text-sm text-blue-600 space-x-2 mb-1">
+                {Array.isArray(article.tags) &&
+                  article.tags.map((tag) => (
+                    <span key={tag} className="inline-block">#{tag}</span>
+                  ))}
+              </div>
+
+              {article.engagement && (
+                <div className="text-xs text-gray-500">
+                  👍 {article.engagement.likes} | 🔁 {article.engagement.shares} | 💬 {article.engagement.comments}
+                </div>
+              )}
+            </article>
+          ))}
+        </section>
+
+        <aside className="space-y-6">
+          <div className="bg-white border rounded p-4 shadow-sm">
+            <h3 className="text-lg font-semibold border-b pb-2 mb-3">Trending Stories</h3>
+            <ul className="space-y-3 text-sm">
+              {trending.map((t) => (
+                <li key={t._id || t.slug}>
+                  <Link href={`/article/${t.slug}`} className="text-blue-700 hover:underline">
+                    {t.title}
+                  </Link>
+                  {t.publishedAt && (
+                    <div className="text-xs text-gray-400">{t.publishedAt}</div>
+                  )}
+                </li>
+              ))}
+              {trending.length === 0 && (
+                <li className="text-gray-500">No trending stories yet.</li>
+              )}
+            </ul>
+          </div>
+
+          <div className="bg-white border rounded p-4 shadow-sm">
+            <h3 className="text-lg font-semibold border-b pb-2 mb-3">Diaspora Highlights 🌍</h3>
+            <ul className="space-y-3 text-sm">
+              {diaspora.map((d) => (
+                <li key={d._id || d.slug}>
+                  <Link href={`/article/${d.slug}`} className="text-blue-700 hover:underline">
+                    {d.title}
+                  </Link>
+                  {d.publishedAt && (
+                    <div className="text-xs text-gray-400">{d.publishedAt}</div>
+                  )}
+                </li>
+              ))}
+              {diaspora.length === 0 && (
+                <li className="text-gray-500">No diaspora stories yet.</li>
+              )}
+            </ul>
+          </div>
+        </aside>
+      </main>
+
+      <Footer />
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- Replace placeholder homepage with feed from `/api/news/home` and trending/diaspora sidebars
- Add responsive header with search toggle and follow button backed by localStorage
- Add site footer with helpful navigation links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689eb463d66483299a8c3f3d227e0e04