### PR TITLE
Add footer placeholder pages

### DIFF
--- a/frontend/pages/about.tsx
+++ b/frontend/pages/about.tsx
@@ -1,0 +1,12 @@
+export default function About() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-10 space-y-4">
+      <h1 className="text-3xl font-bold">About WaterNews</h1>
+      <p className="text-gray-700">
+        WaterNewsGY is a modern news hub focused on Guyana, the Caribbean, South America,
+        and the wider diaspora. We blend verified reporting with community-driven
+        conversations from Patwua.
+      </p>
+    </div>
+  )
+}

--- a/frontend/pages/contact.tsx
+++ b/frontend/pages/contact.tsx
@@ -1,0 +1,12 @@
+export default function Contact() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-10 space-y-4">
+      <h1 className="text-3xl font-bold">Contact</h1>
+      <p className="text-gray-700">Tip us a story or reach out for partnerships.</p>
+      <ul className="list-disc ml-6 text-gray-700">
+        <li>Email: tips@waternewsgy.com</li>
+        <li>Suggest a Story: <a className="text-blue-700 underline" href="/suggest">use the form</a></li>
+      </ul>
+    </div>
+  )
+}

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+export default function Login() {
+  return (
+    <div className="max-w-md mx-auto px-4 py-10 space-y-6">
+      <h1 className="text-3xl font-bold">Author Login</h1>
+      <p className="text-gray-700">
+        Author accounts coming soon. You’ll be able to sign in, manage your profile & bio,
+        and publish stories via a professional editor.
+      </p>
+      <div className="text-sm text-gray-500">
+        Want early access? <a className="text-blue-700 underline" href="/contact">Contact us</a>.
+      </div>
+      <div className="pt-6">
+        <Link href="/" className="text-blue-700 underline">← Back to Home</Link>
+      </div>
+    </div>
+  )
+}

--- a/frontend/pages/privacy.tsx
+++ b/frontend/pages/privacy.tsx
@@ -1,0 +1,11 @@
+export default function Privacy() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-10 space-y-4">
+      <h1 className="text-3xl font-bold">Privacy Policy</h1>
+      <p className="text-gray-700">
+        We value your privacy. We use local storage for the Follow feature and do not track
+        personal data unless you explicitly provide it (e.g., via Suggest a Story). Full policy coming soon.
+      </p>
+    </div>
+  )
+}

--- a/frontend/pages/suggest.tsx
+++ b/frontend/pages/suggest.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+export default function Suggest() {
+  const [sent, setSent] = useState(false)
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-10 space-y-4">
+      <h1 className="text-3xl font-bold">Suggest a Story</h1>
+      {!sent ? (
+        <form
+          onSubmit={(e)=>{e.preventDefault(); setSent(true)}}
+          className="space-y-3"
+        >
+          <input className="w-full border rounded px-3 py-2" placeholder="Your name (optional)" />
+          <input className="w-full border rounded px-3 py-2" placeholder="Contact (email or phone)" />
+          <textarea className="w-full border rounded px-3 py-2 h-32" placeholder="What happened? Add links if you have them." />
+          <button className="px-4 py-2 bg-blue-600 text-white rounded">Submit</button>
+        </form>
+      ) : (
+        <div className="text-green-700">Thanks! We'll review your suggestion.</div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add About page placeholder
- add Contact page placeholder
- add Suggest a Story page with simple form stub
- add Privacy Policy placeholder
- add Author Login placeholder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689eb9896c9c83299b5953bcdee659ba