### PR TITLE
Add credential-based author authentication

### DIFF
--- a/frontend/lib/mongodb.ts
+++ b/frontend/lib/mongodb.ts
@@ -1,0 +1,22 @@
+import mongoose from 'mongoose'
+
+const MONGODB_URI = process.env.MONGODB_URI as string
+
+if (!MONGODB_URI) {
+  throw new Error('Missing MONGODB_URI env var')
+}
+
+let cached = (global as any)._mongoose
+if (!cached) cached = (global as any)._mongoose = { conn: null, promise: null }
+
+export async function dbConnect() {
+  if (cached.conn) return cached.conn
+  if (!cached.promise) {
+    cached.promise = mongoose.connect(MONGODB_URI, {
+      // @ts-ignore: mongoose types allow object options
+      bufferCommands: false
+    }).then((m) => m)
+  }
+  cached.conn = await cached.promise
+  return cached.conn
+}

--- a/frontend/models/User.ts
+++ b/frontend/models/User.ts
@@ -1,0 +1,12 @@
+import { Schema, models, model } from 'mongoose'
+
+const UserSchema = new Schema({
+  name: { type: String, trim: true },
+  email: { type: String, unique: true, required: true, lowercase: true, index: true },
+  passwordHash: { type: String, required: true },
+  bio: { type: String, default: '' },
+  avatarUrl: { type: String, default: '' },
+  role: { type: String, enum: ['author','admin'], default: 'author' },
+}, { timestamps: true })
+
+export default models.User || model('User', UserSchema)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,10 @@
     "axios": "^1.6.8",
     "next": "13.4.19",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "next-auth": "^4.24.6",
+    "mongoose": "^8.1.0",
+    "bcryptjs": "^2.4.3"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",
@@ -21,6 +24,7 @@
     "postcss": "^8.4.21",
     "tailwindcss": "^3.3.2",
     "typescript": "^5.1.3",
-    "@types/react-dom": "^18.2.18"
+    "@types/react-dom": "^18.2.18",
+    "@types/bcryptjs": "^2.4.2"
   }
 }

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,6 +1,11 @@
 import type { AppProps } from 'next/app'
+import { SessionProvider } from 'next-auth/react'
 import '../styles/globals.css'
 
-export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+export default function App({ Component, pageProps: { session, ...pageProps } }: AppProps) {
+  return (
+    <SessionProvider session={session}>
+      <Component {...pageProps} />
+    </SessionProvider>
+  )
 }

--- a/frontend/pages/api/auth/[...nextauth].ts
+++ b/frontend/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,43 @@
+import NextAuth, { NextAuthOptions } from 'next-auth'
+import Credentials from 'next-auth/providers/credentials'
+import { dbConnect } from '../../../../lib/mongodb'
+import User from '../../../../models/User'
+import bcrypt from 'bcryptjs'
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    Credentials({
+      name: 'Email & Password',
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' }
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials.password) return null
+        await dbConnect()
+        const user = await User.findOne({ email: credentials.email })
+        if (!user) return null
+        const ok = await bcrypt.compare(credentials.password, user.passwordHash)
+        if (!ok) return null
+        return { id: user._id.toString(), name: user.name || '', email: user.email, image: user.avatarUrl || '' }
+      }
+    })
+  ],
+  session: { strategy: 'jwt' },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) token.uid = (user as any).id
+      return token
+    },
+    async session({ session, token }) {
+      if (token?.uid) (session.user as any).id = token.uid
+      return session
+    }
+  },
+  pages: {
+    signIn: '/login'
+  },
+  secret: process.env.NEXTAUTH_SECRET
+}
+
+export default NextAuth(authOptions)

--- a/frontend/pages/api/auth/register.ts
+++ b/frontend/pages/api/auth/register.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import bcrypt from 'bcryptjs'
+import { dbConnect } from '../../../lib/mongodb'
+import User from '../../../models/User'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+  const { name, email, password } = req.body || {}
+  if (!email || !password) return res.status(400).json({ error: 'Email and password required' })
+
+  await dbConnect()
+  const exists = await User.findOne({ email })
+  if (exists) return res.status(409).json({ error: 'Email already in use' })
+
+  const passwordHash = await bcrypt.hash(password, 10)
+  const user = await User.create({ name: name || '', email, passwordHash })
+  return res.status(201).json({ id: user._id, email: user.email })
+}

--- a/frontend/pages/api/users/me.ts
+++ b/frontend/pages/api/users/me.ts
@@ -1,0 +1,14 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '../auth/[...nextauth]'
+import { dbConnect } from '../../../lib/mongodb'
+import User from '../../../models/User'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession(req, res, authOptions)
+  if (!session?.user?.email) return res.status(401).json({ error: 'Unauthorized' })
+  await dbConnect()
+  const user = await User.findOne({ email: session.user.email })
+  if (!user) return res.status(404).json({ error: 'Not found' })
+  return res.status(200).json({ email: user.email, name: user.name, bio: user.bio, avatarUrl: user.avatarUrl, role: user.role })
+}

--- a/frontend/pages/api/users/update.ts
+++ b/frontend/pages/api/users/update.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '../auth/[...nextauth]'
+import { dbConnect } from '../../../lib/mongodb'
+import User from '../../../models/User'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+  const session = await getServerSession(req, res, authOptions)
+  if (!session?.user?.email) return res.status(401).json({ error: 'Unauthorized' })
+
+  const { name, bio } = req.body || {}
+  await dbConnect()
+  const user = await User.findOneAndUpdate(
+    { email: session.user.email },
+    { $set: { name: name || '', bio: bio || '' } },
+    { new: true }
+  )
+  return res.status(200).json({ ok: true, name: user?.name, bio: user?.bio })
+}

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react'
+import { signIn, signOut, useSession } from 'next-auth/react'
+import Link from 'next/link'
+
+export default function Login() {
+  const { data: session } = useSession()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [mode, setMode] = useState<'login'|'register'>('login')
+  const [err, setErr] = useState<string>('')
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setErr('')
+    if (mode === 'register') {
+      const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      })
+      const json = await res.json()
+      if (!res.ok) return setErr(json.error || 'Registration failed')
+      // auto sign-in after register
+    }
+    const res = await signIn('credentials', { email, password, redirect: true, callbackUrl: '/profile' })
+    if (res?.error) setErr(res.error)
+  }
+
+  if (session?.user) {
+    return (
+      <div className="max-w-md mx-auto px-4 py-10 space-y-6">
+        <h1 className="text-3xl font-bold">You’re signed in</h1>
+        <div className="text-gray-700 text-sm">Signed in as {(session.user as any).email}</div>
+        <div className="flex gap-4">
+          <Link className="text-blue-700 underline" href="/profile">Go to Profile</Link>
+          <button onClick={() => signOut({ callbackUrl: '/' })} className="text-red-600 underline">Sign out</button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-md mx-auto px-4 py-10 space-y-6">
+      <h1 className="text-3xl font-bold">Author {mode === 'login' ? 'Login' : 'Register'}</h1>
+      {err && <div className="text-red-600 text-sm">{err}</div>}
+      <form onSubmit={onSubmit} className="space-y-3">
+        <input className="w-full border rounded px-3 py-2" type="email" placeholder="Email" value={email} onChange={e=>setEmail(e.target.value)} required />
+        <input className="w-full border rounded px-3 py-2" type="password" placeholder="Password" value={password} onChange={e=>setPassword(e.target.value)} required />
+        <button className="px-4 py-2 bg-blue-600 text-white rounded">{mode === 'login' ? 'Sign in' : 'Create account'}</button>
+      </form>
+      <button onClick={() => setMode(mode === 'login' ? 'register' : 'login')} className="text-sm text-blue-700 underline">
+        {mode === 'login' ? 'Create an author account' : 'I already have an account'}
+      </button>
+      <div className="pt-6">
+        <Link href="/" className="text-blue-700 underline">← Back to Home</Link>
+      </div>
+    </div>
+  )
+}

--- a/frontend/pages/profile.tsx
+++ b/frontend/pages/profile.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import Link from 'next/link'
+
+export default function Profile() {
+  const { data: session, status } = useSession()
+  const [name, setName] = useState('')
+  const [bio, setBio] = useState('')
+  const [msg, setMsg] = useState('')
+
+  useEffect(() => {
+    const load = async () => {
+      if (!session?.user) return
+      const res = await fetch('/api/users/me')
+      const json = await res.json()
+      if (res.ok) {
+        setName(json.name || '')
+        setBio(json.bio || '')
+      }
+    }
+    load()
+  }, [session])
+
+  const save = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setMsg('')
+    const res = await fetch('/api/users/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, bio })
+    })
+    if (res.ok) setMsg('Saved ✓')
+  }
+
+  if (status === 'loading') return <div className="p-6 text-gray-500">Loading…</div>
+  if (!session?.user) return (
+    <div className="p-6">
+      <p className="text-gray-700">Please <Link href="/login" className="text-blue-700 underline">sign in</Link> to view your profile.</p>
+    </div>
+  )
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-10 space-y-6">
+      <h1 className="text-3xl font-bold">Author Profile</h1>
+      <form onSubmit={save} className="space-y-3">
+        <input className="w-full border rounded px-3 py-2" placeholder="Your display name" value={name} onChange={e=>setName(e.target.value)} />
+        <textarea className="w-full border rounded px-3 py-2 h-32" placeholder="Short bio (shown under your articles)" value={bio} onChange={e=>setBio(e.target.value)} />
+        <button className="px-4 py-2 bg-blue-600 text-white rounded">Save</button>
+        {msg && <span className="text-green-700 text-sm ml-3">{msg}</span>}
+      </form>
+      <div>
+        <Link href="/" className="text-blue-700 underline">← Back to Home</Link>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add MongoDB connection helper and user model
- configure NextAuth credentials provider and registration endpoint
- add login and profile pages with APIs to fetch/update user info

## Testing
- ⚠️ `npm install next-auth mongoose bcryptjs` (403 Forbidden)
- ✅ `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ebaf89b4c832998d2ada633dd585f