### PR TITLE
Add postinstall script for dependency setup

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "postinstall": "npm install mongoose bcryptjs @types/node @types/react @types/bcryptjs --legacy-peer-deps",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
## Summary
- add postinstall script installing mongoose, bcryptjs and type definitions with legacy peer deps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ebeca0730832983a8c51083675e82