### PR TITLE
feat: strongly type user model

### DIFF
--- a/frontend/models/User.ts
+++ b/frontend/models/User.ts
@@ -1,6 +1,17 @@
-import { Schema, models, model } from 'mongoose'
+import { Schema, models, model, Model, Document } from 'mongoose'
 
-const UserSchema = new Schema({
+export interface IUser {
+  name?: string
+  email: string
+  passwordHash: string
+  bio: string
+  avatarUrl: string
+  role: 'author' | 'admin'
+}
+
+export type IUserDoc = IUser & Document
+
+const UserSchema = new Schema<IUser>({
   name: { type: String, trim: true },
   email: { type: String, unique: true, required: true, lowercase: true, index: true },
   passwordHash: { type: String, required: true },
@@ -9,4 +20,5 @@ const UserSchema = new Schema({
   role: { type: String, enum: ['author','admin'], default: 'author' },
 }, { timestamps: true })
 
-export default models.User || model('User', UserSchema)
+const UserModel: Model<IUserDoc> = (models.User as Model<IUserDoc>) || model<IUserDoc>('User', UserSchema)
+export default UserModel

--- a/frontend/pages/api/auth/[...nextauth].ts
+++ b/frontend/pages/api/auth/[...nextauth].ts
@@ -15,7 +15,8 @@ export const authOptions: NextAuthOptions = {
       async authorize(credentials) {
         if (!credentials?.email || !credentials.password) return null
         await dbConnect()
-        const user = await User.findOne({ email: credentials.email })
+        // Use the typed model to avoid Mongoose union-callable type error
+        const user = await User.findOne({ email: credentials.email }).exec()
         if (!user) return null
         const ok = await bcrypt.compare(credentials.password, user.passwordHash)
         if (!ok) return null


### PR DESCRIPTION
## Summary
- add TypeScript interfaces for User model and export typed model
- ensure NextAuth authorize uses typed User model with `.exec`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ec3c5e75c8329afe62446c9130047