### PR TITLE
Add SmartMenu sorting menu

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import NotificationBell from './NotificationBell'
+import SmartMenu from './SmartMenu'
 import { SearchIcon } from './icons'
 
 export default function Header() {
@@ -45,10 +46,8 @@ export default function Header() {
         </Link>
 
         {/* Smart menu (hidden when search expands on small screens) */}
-        <nav className={`ml-2 items-center gap-4 text-sm text-gray-700 ${searchOpen ? 'hidden md:flex' : 'flex'}`}>
-          <Link className="hover:text-blue-700" href="/?sort=recent">Recent</Link>
-          <Link className="hover:text-blue-700" href="/?sort=trending">Trending</Link>
-          <Link className="hover:text-blue-700" href="/?view=categories">Categories</Link>
+        <nav className={`${searchOpen ? 'hidden md:block' : 'block'} ml-2`}>
+          <SmartMenu />
         </nav>
 
         {/* Inline expanding search */}

--- a/frontend/components/SmartMenu.tsx
+++ b/frontend/components/SmartMenu.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+
+type MenuKey = 'latest' | 'trending' | 'following'
+
+/**
+ * Pill-style smart menu:
+ * - Grey rounded container
+ * - Active pill: white bg + blue text + subtle shadow
+ * - Emits a 'wn-menu-change' CustomEvent with the selected key
+ * - Syncs with URL query (?sort=latest|trending|following)
+ */
+export default function SmartMenu() {
+  const router = useRouter()
+  const initial = (router.query.sort as string) as MenuKey
+  const [active, setActive] = useState<MenuKey>(initial || 'latest')
+
+  useEffect(() => {
+    // keep in sync if URL changes via back/forward
+    const q = (router.query.sort as string) as MenuKey
+    if (q && q !== active) setActive(q)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.query.sort])
+
+  const click = (key: MenuKey) => {
+    setActive(key)
+    // push to URL shallowly
+    router.replace(
+      { pathname: router.pathname, query: { ...router.query, sort: key } },
+      undefined,
+      { shallow: true }
+    )
+    // broadcast to listeners (homepage) to update feed ordering
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('wn-menu-change', { detail: key }))
+    }
+  }
+
+  const pill = (key: MenuKey, label: string) => (
+    <button
+      key={key}
+      onClick={() => click(key)}
+      className={[
+        'px-4 py-2 text-sm font-medium rounded-md transition-colors',
+        active === key ? 'bg-white text-blue-600 shadow-sm' : 'text-gray-600 hover:text-blue-700'
+      ].join(' ')}
+      aria-pressed={active === key}
+    >
+      {label}
+    </button>
+  )
+
+  return (
+    <div className="flex bg-gray-100 rounded-full p-1">
+      {pill('latest', 'Latest')}
+      {pill('trending', 'Trending')}
+      {pill('following', 'Following')}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add SmartMenu pill navigation that syncs with URL and emits events
- replace old header nav with SmartMenu component
- update homepage to listen for SmartMenu changes and resort articles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f3707ede08329bc8f9764f313e793