### PR TITLE
Implement following and category filters

### DIFF
--- a/frontend/components/SmartMenu.tsx
+++ b/frontend/components/SmartMenu.tsx
@@ -2,37 +2,50 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 
 type MenuKey = 'latest' | 'trending' | 'following'
+const EXTRA_CATEGORIES = ['Regional', 'Politics', 'Sports', 'Business', 'Tech', 'Entertainment'] as const
+export type ExtraCategory = typeof EXTRA_CATEGORIES[number]
 
 /**
- * Pill-style smart menu:
- * - Grey rounded container
- * - Active pill: white bg + blue text + subtle shadow
- * - Emits a 'wn-menu-change' CustomEvent with the selected key
- * - Syncs with URL query (?sort=latest|trending|following)
+ * Pill-style smart menu with extra categories:
+ * - Emits 'wn-menu-change' when main sort changes
+ * - Emits 'wn-category-change' when a category is selected
  */
 export default function SmartMenu() {
   const router = useRouter()
   const initial = (router.query.sort as string) as MenuKey
   const [active, setActive] = useState<MenuKey>(initial || 'latest')
+  const [moreOpen, setMoreOpen] = useState(false)
+  const [category, setCategory] = useState<ExtraCategory | null>((router.query.category as ExtraCategory) || null)
 
   useEffect(() => {
-    // keep in sync if URL changes via back/forward
     const q = (router.query.sort as string) as MenuKey
     if (q && q !== active) setActive(q)
+    const cat = (router.query.category as ExtraCategory) || null
+    if (cat !== category) setCategory(cat)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.query.sort])
+  }, [router.query.sort, router.query.category])
 
   const click = (key: MenuKey) => {
     setActive(key)
-    // push to URL shallowly
     router.replace(
       { pathname: router.pathname, query: { ...router.query, sort: key } },
       undefined,
       { shallow: true }
     )
-    // broadcast to listeners (homepage) to update feed ordering
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new CustomEvent('wn-menu-change', { detail: key }))
+    }
+  }
+
+  const clickCategory = (cat: ExtraCategory | null) => {
+    setCategory(cat)
+    router.replace(
+      { pathname: router.pathname, query: { ...router.query, category: cat || undefined } },
+      undefined,
+      { shallow: true }
+    )
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('wn-category-change', { detail: cat }))
     }
   }
 
@@ -51,10 +64,41 @@ export default function SmartMenu() {
   )
 
   return (
-    <div className="flex bg-gray-100 rounded-full p-1">
-      {pill('latest', 'Latest')}
-      {pill('trending', 'Trending')}
-      {pill('following', 'Following')}
+    <div className="flex items-center gap-2">
+      <div className="flex bg-gray-100 rounded-full p-1">
+        {pill('latest', 'Latest')}
+        {pill('trending', 'Trending')}
+        {pill('following', 'Following')}
+      </div>
+      <div className="relative">
+        <button
+          onClick={() => setMoreOpen(o => !o)}
+          className="px-3 py-2 text-sm rounded-md border border-gray-200 text-gray-700 hover:bg-gray-50"
+          aria-expanded={moreOpen}
+          aria-haspopup="true"
+        >
+          More ▾
+        </button>
+        {moreOpen && (
+          <div className="absolute z-20 mt-2 bg-white border rounded-md shadow p-2 grid grid-cols-2 gap-2 min-w-[220px]">
+            <button
+              className={`px-3 py-2 text-sm rounded ${!category ? 'bg-gray-100' : 'hover:bg-gray-50'}`}
+              onClick={() => { clickCategory(null); setMoreOpen(false) }}
+            >
+              All
+            </button>
+            {EXTRA_CATEGORIES.map(cat => (
+              <button
+                key={cat}
+                className={`px-3 py-2 text-sm rounded ${category === cat ? 'bg-blue-50 text-blue-700' : 'hover:bg-gray-50'}`}
+                onClick={() => { clickCategory(cat); setMoreOpen(false) }}
+              >
+                {cat}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/frontend/data/mockContent.ts
+++ b/frontend/data/mockContent.ts
@@ -7,6 +7,8 @@ export type Article = {
   tags?: string[]
   engagement?: { likes: number; shares: number; comments: number }
   publishedAt?: string
+  authorId?: string
+  authorName?: string
 }
 
 export const mockArticles: Article[] = [
@@ -17,6 +19,8 @@ export const mockArticles: Article[] = [
     image: 'https://via.placeholder.com/800x400?text=India+Summit',
     summary: 'India presented eco-tech innovations during the global biodiversity summit, highlighting sustainability solutions.',
     tags: ['India', 'Science'],
+    authorId: 'auth-india',
+    authorName: 'Priya Deshmukh',
     engagement: { likes: 145, shares: 72, comments: 18 }
   },
   {
@@ -25,7 +29,9 @@ export const mockArticles: Article[] = [
     slug: 'ali-clean-energy',
     image: 'https://via.placeholder.com/800x400?text=Clean+Energy+Plan',
     summary: 'President Irfaan Ali unveils a bold renewable energy policy aiming to transform Guyana’s energy sector by 2030.',
-    tags: ['GreenEnergy', 'Guyana'],
+    tags: ['GreenEnergy', 'Guyana', 'Politics'],
+    authorId: 'auth-ali',
+    authorName: 'WaterNews Desk',
     engagement: { likes: 240, shares: 108, comments: 36 }
   },
   {
@@ -34,7 +40,9 @@ export const mockArticles: Article[] = [
     slug: 'guyanese-artists-awards',
     image: 'https://via.placeholder.com/800x400?text=Caribbean+Awards',
     summary: 'Guyanese artists were among top winners celebrated at a Caribbean regional awards ceremony.',
-    tags: ['Culture', 'Art', 'Awards'],
+    tags: ['Culture', 'Art', 'Awards', 'Entertainment'],
+    authorId: 'auth-culture',
+    authorName: 'Alicia Persaud',
     engagement: { likes: 98, shares: 44, comments: 12 }
   }
 ]

--- a/frontend/utils/follow.ts
+++ b/frontend/utils/follow.ts
@@ -1,0 +1,41 @@
+const AUTHORS_KEY = 'wn_follow_authors'
+const TAGS_KEY = 'wn_follow_tags'
+
+function readSet(key: string): Set<string> {
+  try {
+    const raw = localStorage.getItem(key)
+    const arr = raw ? JSON.parse(raw) as string[] : []
+    return new Set(arr)
+  } catch {
+    return new Set()
+  }
+}
+
+function writeSet(key: string, set: Set<string>) {
+  try {
+    localStorage.setItem(key, JSON.stringify(Array.from(set)))
+  } catch {}
+}
+
+export function getFollowedAuthors(): Set<string> {
+  return readSet(AUTHORS_KEY)
+}
+export function getFollowedTags(): Set<string> {
+  return readSet(TAGS_KEY)
+}
+
+export function toggleFollowAuthor(id: string): boolean {
+  const s = readSet(AUTHORS_KEY)
+  let following: boolean
+  if (s.has(id)) { s.delete(id); following = false } else { s.add(id); following = true }
+  writeSet(AUTHORS_KEY, s)
+  return following
+}
+export function toggleFollowTag(tag: string): boolean {
+  const s = readSet(TAGS_KEY)
+  const t = tag.trim().toLowerCase()
+  let following: boolean
+  if (s.has(t)) { s.delete(t); following = false } else { s.add(t); following = true }
+  writeSet(TAGS_KEY, s)
+  return following
+}


### PR DESCRIPTION
## Summary
- add localStorage helpers to manage followed authors and tags
- enable menu category toggle and follow-based filtering on homepage
- annotate mock content with author details for follow support

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f3aaabc00832993991e58a377ad9a