### PR TITLE
Refactor masonry feed with mixed-density cards

### DIFF
--- a/frontend/components/MasonryFeed.tsx
+++ b/frontend/components/MasonryFeed.tsx
@@ -24,40 +24,80 @@ export default function MasonryFeed({ articles }: { articles: Article[] }) {
       const key = `${label}-${i}`
       blocks.push({ key, label })
       cards.push(
-        <div key={`block-${key}`} className="break-inside-avoid bg-blue-50 text-blue-900 font-semibold px-3 py-2 rounded">
+        <div key={`block-${key}`} className="break-inside-avoid bg-blue-50/70 text-blue-900 font-semibold px-2 py-1.5 rounded">
           {label}
         </div>
       )
     }
-    cards.push(<Card key={a._id || a.slug} a={a} />)
+    cards.push(<Card key={a._id || a.slug} a={a} index={i} />)
   })
 
   return (
-    <div className="columns-1 sm:columns-2 lg:columns-3 gap-3 [column-fill:_balance]">
+    <div className="columns-1 sm:columns-2 lg:columns-3 gap-2 [column-fill:_balance]">
       {cards}
     </div>
   )
 }
 
-function Card({ a }: { a: Article }) {
+// Choose a card variant: tighter pack overall, with a mix of "headline-only" and "expanded"
+// We use a deterministic hash so the same article renders the same way across sessions.
+function variantFor(a: Article, index: number): 'headline' | 'compact' | 'expanded' {
+  const seed = hashCode(a.slug || String(index))
+  const engagement = (a.engagement?.likes || 0) + (a.engagement?.shares || 0) + (a.engagement?.comments || 0)
+  // Highly engaged stories skew to expanded
+  if (engagement > 250) return 'expanded'
+  const r = (seed % 100 + 100) % 100
+  if (r < 35) return 'headline'   // ~35% title-only
+  if (r < 70) return 'compact'    // ~35% compact (few lines)
+  return 'expanded'               // ~30% expanded
+}
+
+function Card({ a, index }: { a: Article, index: number }) {
+  const v = variantFor(a, index)
+  const showImage = !!a.image && v !== 'headline'
+  const showSummary = !!a.summary && v !== 'headline'
+  const summaryLines = v === 'compact' ? 2 : 4
+
   return (
-    <article className="mb-3 break-inside-avoid rounded border bg-white overflow-hidden">
-      {a.image && <img src={a.image} alt="" className="w-full object-cover" />}
-      <div className="p-2">
+    <article className="mb-2 break-inside-avoid rounded bg-white overflow-hidden border border-gray-100">
+      {showImage && (
+        <img src={a.image} alt="" className={`w-full object-cover ${v === 'expanded' ? 'max-h-64' : 'max-h-44'}`} />
+      )}
+      <div className={`px-2 ${v === 'headline' ? 'py-2' : 'py-2'}`}>
         <Link href={`/article/${a.slug}`} className="block">
-          <h3 className="text-base font-semibold leading-snug hover:underline"
-              dangerouslySetInnerHTML={{ __html: (a as any).titleHTML || a.title }} />
+          <h3
+            className={[
+              'leading-snug hover:underline',
+              v === 'headline' ? 'text-base font-semibold' :
+              v === 'compact' ? 'text-[15px] font-semibold' : 'text-lg font-bold'
+            ].join(' ')}
+            dangerouslySetInnerHTML={{ __html: (a as any).titleHTML || a.title }}
+          />
         </Link>
-        {a.summary && (
-          <p className="text-sm text-gray-700 mt-1"
-             dangerouslySetInnerHTML={{ __html: (a as any).summaryHTML || a.summary }} />
+        {showSummary && (
+          <p
+            className={[
+              'text-gray-700 mt-1',
+              v === 'compact' ? 'text-[13px]' : 'text-sm',
+              `line-clamp-${summaryLines}`
+            ].join(' ')}
+            dangerouslySetInnerHTML={{ __html: (a as any).summaryHTML || a.summary }}
+          />
         )}
-        {Array.isArray(a.tags) && (
-          <div className="mt-1 flex flex-wrap gap-1 text-xs text-blue-700">
-            {a.tags.map(t => <span key={t}>#{t}</span>)}
+        {Array.isArray(a.tags) && a.tags.length > 0 && (
+          <div className="mt-1 flex flex-wrap gap-1 text-[11px] text-blue-700">
+            {a.tags.slice(0, v === 'expanded' ? 6 : 3).map(t => <span key={t}>#{t}</span>)}
           </div>
         )}
       </div>
     </article>
   )
+}
+
+function hashCode(s: string): number {
+  let h = 0
+  for (let i = 0; i < s.length; i++) {
+    h = (Math.imul(31, h) + s.charCodeAt(i)) | 0
+  }
+  return h
 }


### PR DESCRIPTION
## Summary
- Add deterministic variant selection for article cards (headline/compact/expanded)
- Render cards with tighter spacing and mixed density, skipping images & summaries for headline-only
- Insert softer category blocks for feed separation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f4c0f0f3083298133954dde12f7ea