### PR TITLE
Implement follow sync and engagement-based ranking

### DIFF
--- a/frontend/components/BreakingTicker.tsx
+++ b/frontend/components/BreakingTicker.tsx
@@ -8,8 +8,14 @@ export default function BreakingTicker() {
     const run = async () => {
       try {
         const res = await axios.get('/api/news/home')
+        const articles = res?.data?.articles || []
         const trending = res?.data?.trending || []
-        setItems(trending.slice(0, 10))
+        const TAGS = ['breaking', 'alert']
+        const tagHits = (articles as any[])
+          .filter(a => Array.isArray(a.tags) && a.tags.some((t: string) => TAGS.includes((t || '').toLowerCase())))
+          .slice(0, 12)
+        const pick = (tagHits.length ? tagHits : trending).slice(0, 12)
+        setItems(pick.map((x: any) => ({ title: x.title, slug: x.slug })))
       } catch (e) {
         console.error('ticker load failed', e)
       }

--- a/frontend/models/User.ts
+++ b/frontend/models/User.ts
@@ -7,6 +7,8 @@ export interface IUser {
   bio: string
   avatarUrl: string
   role: 'author' | 'admin'
+  followedAuthors: string[]
+  followedTags: string[]
 }
 
 const UserSchema = new Schema<IUser>({
@@ -16,6 +18,8 @@ const UserSchema = new Schema<IUser>({
   bio: { type: String, default: '' },
   avatarUrl: { type: String, default: '' },
   role: { type: String, enum: ['author','admin'], default: 'author' },
+  followedAuthors: { type: [String], default: [] },
+  followedTags: { type: [String], default: [] },
 }, { timestamps: true })
 
 // Keep typing minimal to avoid Mongoose 8 generic incompatibilities in CI

--- a/frontend/pages/api/follow.ts
+++ b/frontend/pages/api/follow.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from './auth/[...nextauth]'
+import { dbConnect } from '../../lib/mongodb'
+import User from '../../models/User'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session: any = await getServerSession(req, res, authOptions as any)
+  if (!session?.user?.email) return res.status(401).json({ error: 'Unauthorized' })
+  await dbConnect()
+  const email = session.user.email as string
+  const user = await (User as any).findOne({ email }).exec()
+  if (!user) return res.status(404).json({ error: 'User not found' })
+
+  if (req.method === 'GET') {
+    return res.status(200).json({
+      authors: user.followedAuthors || [],
+      tags: user.followedTags || []
+    })
+  }
+
+  if (req.method === 'POST') {
+    try {
+      const body = (req.body || {}) as { authors?: string[]; tags?: string[] }
+      const authors = Array.isArray(body.authors) ? body.authors : []
+      const tags = Array.isArray(body.tags) ? body.tags : []
+      // merge unique (case-insensitive for tags)
+      const sAuthors = new Set([...(user.followedAuthors || []), ...authors])
+      const norm = (t: string) => (t || '').toLowerCase()
+      const sTags = new Set([...(user.followedTags || []).map(norm), ...tags.map(norm)])
+      user.followedAuthors = Array.from(sAuthors)
+      user.followedTags = Array.from(sTags)
+      await user.save()
+      return res.status(200).json({ authors: user.followedAuthors, tags: user.followedTags })
+    } catch (e) {
+      console.error('follow sync failed', e)
+      return res.status(400).json({ error: 'Bad Request' })
+    }
+  }
+
+  res.setHeader('Allow', 'GET, POST')
+  return res.status(405).end('Method Not Allowed')
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -6,7 +6,7 @@ import Footer from '../components/Footer'
 import BreakingTicker from '../components/BreakingTicker'
 import Hero from '../components/Hero'
 import MasonryFeed from '../components/MasonryFeed'
-import { getFollowedAuthors, getFollowedTags } from '../utils/follow'
+import { getFollowedAuthors, getFollowedTags, toggleFollowAuthor, toggleFollowTag, syncFollowsIfAuthed, pushServerFollows } from '../utils/follow'
 
 type Article = {
   _id?: string
@@ -29,6 +29,8 @@ export default function HomePage() {
   const [resultCount, setResultCount] = useState<number | null>(null)
   const [activeSort, setActiveSort] = useState<'latest' | 'trending' | 'following'>('latest')
   const [activeCategory, setActiveCategory] = useState<string | null>(null)
+  const [followAuthors, setFollowAuthors] = useState<Set<string>>(new Set())
+  const [followTags, setFollowTags] = useState<Set<string>>(new Set())
 
   useEffect(() => {
     const run = async () => {
@@ -47,6 +49,18 @@ export default function HomePage() {
       }
     }
     run()
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    setFollowAuthors(getFollowedAuthors())
+    setFollowTags(getFollowedTags())
+    // best-effort sync with server (if logged in)
+    syncFollowsIfAuthed().then(() => {
+      setFollowAuthors(getFollowedAuthors())
+      setFollowTags(getFollowedTags())
+      if (activeSort === 'following') applyMenuAndCategory(allArticles, activeSort, activeCategory)
+    })
   }, [])
 
   // Instant client-side filter on URL ?q= and on 'type' events


### PR DESCRIPTION
## Summary
- score hero articles by recency, engagement and category match
- show breaking/alert tagged articles in ticker before trending
- add notification badge and track new items since last visit
- store followed authors/tags on user and sync via /api/follow endpoint
- utilities to merge/push follows and home page sync on mount

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fc7644cd48329a510b95b1e47dc51