### PR TITLE
feat: add newsroom draft API and editor

### DIFF
--- a/frontend/components/BreakingTicker.tsx
+++ b/frontend/components/BreakingTicker.tsx
@@ -1,50 +1,31 @@
-import { useEffect, useState } from 'react'
-import axios from 'axios'
+import Link from "next/link";
 
-export default function BreakingTicker() {
-  const [items, setItems] = useState<Array<{ title: string; slug: string }>>([])
-
-  useEffect(() => {
-    const run = async () => {
-      try {
-        const res = await axios.get('/api/news/home')
-        const articles = res?.data?.articles || []
-        const trending = res?.data?.trending || []
-        const TAGS = ['breaking', 'alert']
-        const tagHits = (articles as any[])
-          .filter(a => Array.isArray(a.tags) && a.tags.some((t: string) => TAGS.includes((t || '').toLowerCase())))
-          .slice(0, 12)
-        const pick = (tagHits.length ? tagHits : trending).slice(0, 12)
-        setItems(pick.map((x: any) => ({ title: x.title, slug: x.slug })))
-      } catch (e) {
-        console.error('ticker load failed', e)
-      }
-    }
-    run()
-  }, [])
-
-  if (!items.length) return null
-
+export default function BreakingTicker({ items }: { items: { slug: string; title: string; tags?: string[] }[] }) {
+  if (!items?.length) return null;
   return (
-    <div className="w-full bg-red-600 text-white text-sm overflow-hidden">
-      <div className="max-w-7xl mx-auto flex items-center gap-3 px-3 py-2">
-        <span className="font-bold uppercase tracking-wide">Breaking</span>
-        <div className="relative flex-1 overflow-hidden">
-          <div className="whitespace-nowrap animate-[marquee_20s_linear_infinite]">
-            {items.map((it, i) => (
-              <span key={it.slug || i} className="mx-4 opacity-95 hover:opacity-100">
-                • {it.title}
-              </span>
-            ))}
-          </div>
+    <div className="relative overflow-hidden rounded-2xl bg-red-600 text-white">
+      <div className="px-3 py-2 text-xs font-semibold tracking-wide uppercase bg-red-700 inline-flex items-center gap-2 rounded-br-xl">
+        <span>Breaking</span>
+        <span aria-hidden>•</span>
+        <span className="text-white/80">Live</span>
+      </div>
+      <div className="whitespace-nowrap overflow-hidden [mask-image:linear-gradient(to_right,transparent,black_10%,black_90%,transparent)]">
+        <div className="inline-flex gap-6 animate-[ticker_24s_linear_infinite] will-change-transform">
+          {items.map((it) => (
+            <Link key={it.slug} href={`/news/${it.slug}`} className="py-2 px-4 inline-block hover:underline focus:outline-none focus:ring-2 focus:ring-white/70 rounded">
+              {it.title}
+            </Link>
+          ))}
+          {items.map((it, i) => (
+            <Link key={`${it.slug}-dup-${i}`} href={`/news/${it.slug}`} className="py-2 px-4 inline-block hover:underline rounded">
+              {it.title}
+            </Link>
+          ))}
         </div>
       </div>
       <style jsx>{`
-        @keyframes marquee {
-          0% { transform: translateX(0); }
-          100% { transform: translateX(-50%); }
-        }
+        @keyframes ticker { 0% { transform: translateX(0); } 100% { transform: translateX(-50%); } }
       `}</style>
     </div>
-  )
+  );
 }

--- a/frontend/components/Hero.tsx
+++ b/frontend/components/Hero.tsx
@@ -1,74 +1,42 @@
-import Link from 'next/link'
-
-type Article = {
-  _id?: string
-  slug: string
-  title: string
-  image?: string
-  summary?: string
-  tags?: string[]
-  engagement?: { likes: number; shares: number; comments: number }
-  publishedAt?: string
-}
-
-export default function Hero({ articles, category }: { articles: Article[]; category: string | null }) {
-  if (!articles?.length) return null
-  const top = pickTop(articles, category, 3)
-  const main = top[0]
-  const side = top.slice(1)
-
+export default function Hero({ primary, rail }: { primary: any; rail: any[] }) {
   return (
-    <section className="grid grid-cols-1 md:grid-cols-3 gap-3">
-      {/* main card */}
-      <Link href={`/article/${main.slug}`} className="md:col-span-2 block group">
-        <div className="relative overflow-hidden rounded-lg border bg-white">
-          {main.image && <img src={main.image} alt={main.title} className="w-full h-64 md:h-80 object-cover group-hover:scale-[1.01] transition" />}
-          <div className="p-3">
-            {category && <div className="text-xs font-semibold uppercase text-blue-700 mb-1">{category}</div>}
-            <h2 className="text-2xl md:text-3xl font-extrabold leading-tight">{main.title}</h2>
-            {main.summary && <p className="text-gray-700 mt-2 line-clamp-2">{main.summary}</p>}
+    <section className="grid lg:grid-cols-3 gap-6">
+      <article className="lg:col-span-2 rounded-3xl overflow-hidden ring-1 ring-black/5 bg-white">
+        {primary?.image ? (
+          <div className="aspect-[21/9] overflow-hidden">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={primary.image} alt={primary.title} className="w-full h-full object-cover" />
           </div>
+        ) : null}
+        <div className="p-6 md:p-8">
+          <div className="flex items-center gap-2 text-xs text-neutral-600 mb-2">
+            {primary?.category ? <span className="px-2 py-0.5 bg-neutral-100 rounded-full">{primary.category}</span> : null}
+            {primary?.publishedAt ? <time dateTime={primary.publishedAt}>{new Date(primary.publishedAt).toLocaleString()}</time> : null}
+            {typeof primary?.engagementScore === "number" ? <span aria-label="engagement">• ★ {Math.round(primary.engagementScore)}</span> : null}
+          </div>
+          <h2 className="text-2xl md:text-3xl font-semibold leading-tight mb-3">{primary?.title}</h2>
+          {primary?.excerpt ? <p className="text-neutral-700 text-base md:text-lg">{primary.excerpt}</p> : null}
         </div>
-      </Link>
-      {/* side cards */}
-      <div className="grid grid-rows-2 gap-3">
-        {side.map(s => (
-          <Link key={s.slug} href={`/article/${s.slug}`} className="block group">
-            <div className="overflow-hidden rounded-lg border bg-white">
-              {s.image && <img src={s.image} alt={s.title} className="w-full h-36 object-cover" />}
-              <div className="p-3">
-                <h3 className="text-lg font-bold leading-snug">{s.title}</h3>
-                {s.summary && <p className="text-gray-700 text-sm line-clamp-2 mt-1">{s.summary}</p>}
+      </article>
+
+      <div className="grid gap-4">
+        {rail?.slice(0, 3).map((r: any) => (
+          <a key={r.id} href={`/news/${r.slug}`} className="rounded-2xl ring-1 ring-black/5 bg-white p-4 hover:shadow-sm transition-shadow outline-none focus:ring-2 focus:ring-blue-500">
+            <div className="flex gap-3">
+              {r.image ? (
+                <div className="w-28 shrink-0 aspect-[4/3] overflow-hidden rounded-lg">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={r.image} alt="" className="w-full h-full object-cover" loading="lazy" />
+                </div>
+              ) : null}
+              <div className="min-w-0">
+                <h3 className="text-sm font-semibold leading-snug line-clamp-2">{r.title}</h3>
+                {r.publishedAt ? <time className="text-xs text-neutral-500">{new Date(r.publishedAt).toLocaleDateString()}</time> : null}
               </div>
             </div>
-          </Link>
+          </a>
         ))}
       </div>
     </section>
-  )
-}
-
-function pickTop(list: Article[], category: string | null, n: number): Article[] {
-  // score: recency (0..1) + engagement (0..1) + category bonus (0 or 0.25)
-  const now = Date.now()
-  const scored = list.map(a => {
-    const likes = a.engagement?.likes ?? 0
-    const shares = a.engagement?.shares ?? 0
-    const comments = a.engagement?.comments ?? 0
-    const e = likes + shares + comments
-    // normalize engagement roughly: map 0..300+ to 0..1
-    const engagementScore = Math.min(1, e / 300)
-    let recencyScore = 0.5
-    if (a.publishedAt) {
-      const ageHrs = Math.max(1, (now - new Date(a.publishedAt).getTime()) / 36e5)
-      // 0h -> 1.0 ; 48h -> ~0.2
-      recencyScore = Math.max(0, Math.min(1, 1 / Math.log10(ageHrs + 1.5)))
-    }
-    const hasCat = !!(category && (a.tags || []).some(t => (t || '').toLowerCase() === category.toLowerCase()))
-    const categoryBonus = hasCat ? 0.25 : 0
-    const score = 0.55 * recencyScore + 0.35 * engagementScore + categoryBonus
-    return { a, score }
-  })
-  scored.sort((x, y) => y.score - x.score)
-  return scored.slice(0, Math.max(1, n)).map(s => s.a)
+  );
 }

--- a/frontend/components/MasonryCard.tsx
+++ b/frontend/components/MasonryCard.tsx
@@ -1,0 +1,73 @@
+import Link from "next/link";
+import { useMemo } from "react";
+
+type Props = {
+  item: {
+    id: string;
+    slug: string;
+    title: string;
+    excerpt: string;
+    image?: string;
+    tags?: string[];
+    engagementScore?: number;
+    publishedAt?: string;
+    author?: { name: string; slug?: string };
+  };
+  variantSeed: number;
+  density?: "cozy" | "compact";
+  clamp?: 2 | 3;
+};
+
+export default function MasonryCard({ item, variantSeed, density = "compact", clamp = 2 }: Props) {
+  const ratioClass = useMemo(() => {
+    const v = variantSeed % 4;
+    if (v === 0) return "aspect-[4/3]";
+    if (v === 1) return "aspect-[16/9]";
+    if (v === 2) return "aspect-[3/4]";
+    return "aspect-square";
+  }, [variantSeed]);
+
+  const pad = density === "compact" ? "p-3" : "p-4";
+  const titleSize = density === "compact" ? "text-base" : "text-lg";
+  const excerptSize = density === "compact" ? "text-sm" : "text-[15px]";
+
+  return (
+    <article className={`group rounded-2xl shadow-sm ring-1 ring-black/5 bg-white overflow-hidden hover:shadow-md transition-shadow`}>
+      {item.image ? (
+        <div className={`w-full ${ratioClass} overflow-hidden`}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={item.image}
+            alt={item.title}
+            className="h-full w-full object-cover group-hover:scale-[1.02] transition-transform"
+            loading="lazy"
+          />
+        </div>
+      ) : null}
+      <div className={`${pad} grid gap-2`}>
+        <h3 className={`${titleSize} font-semibold leading-snug line-clamp-2`}>
+          <Link href={`/news/${item.slug}`} className="outline-none focus:ring-2 focus:ring-blue-500 rounded">
+            {item.title}
+          </Link>
+        </h3>
+
+        <p className={`${excerptSize} text-neutral-700 line-clamp-${clamp}`}>
+          {item.excerpt}
+        </p>
+
+        <div className="mt-1 flex items-center justify-between">
+          <div className="flex flex-wrap gap-1">
+            {item.tags?.slice(0, 3).map(t => (
+              <span key={t} className="text-xs px-2 py-0.5 bg-neutral-100 rounded-full">{t}</span>
+            ))}
+          </div>
+          {item.publishedAt ? (
+            <time className="text-xs text-neutral-500" dateTime={item.publishedAt}>
+              {new Date(item.publishedAt).toLocaleDateString()}
+            </time>
+          ) : null}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/frontend/components/MasonryFeed.tsx
+++ b/frontend/components/MasonryFeed.tsx
@@ -1,103 +1,19 @@
-import Link from 'next/link'
+import MasonryCard from "./MasonryCard";
+import { useMemo } from "react";
 
-type Article = {
-  _id?: string
-  slug: string
-  title: string
-  image?: string
-  summary?: string
-  tags?: string[]
-  engagement?: { likes: number; shares: number; comments: number }
-  titleHTML?: string
-  summaryHTML?: string
-}
-
-export default function MasonryFeed({ articles }: { articles: Article[] }) {
-  if (!articles?.length) return null
-
-  // Inject simple category blocks every ~6 cards (based on first tag if any)
-  const blocks: Array<{ key: string; label: string }> = []
-  const cards: JSX.Element[] = []
-  articles.forEach((a, i) => {
-    if (i && i % 6 === 0) {
-      const label = (a.tags && a.tags[0]) ? a.tags[0] : 'From the feed'
-      const key = `${label}-${i}`
-      blocks.push({ key, label })
-      cards.push(
-        <div key={`block-${key}`} className="break-inside-avoid bg-blue-50/70 text-blue-900 font-semibold px-2 py-1.5 rounded">
-          {label}
+export default function MasonryFeed({ items, loading }: { items: any[]; loading?: boolean }) {
+  const skeletons = useMemo(() => Array.from({ length: 8 }), []);
+  return (
+    <div className="columns-1 sm:columns-2 lg:columns-3 2xl:columns-4 gap-4 [column-fill:_balance]">
+      {(loading ? skeletons : items).map((it, i) => (
+        <div key={loading ? i : it.id} className="mb-4 break-inside-avoid">
+          {loading ? (
+            <div className="animate-pulse rounded-2xl bg-neutral-100 h-64" />
+          ) : (
+            <MasonryCard item={it} variantSeed={it.variantSeed} density="compact" clamp={2} />
+          )}
         </div>
-      )
-    }
-    cards.push(<Card key={a._id || a.slug} a={a} index={i} />)
-  })
-
-  return (
-    <div className="columns-1 sm:columns-2 lg:columns-3 gap-2 [column-fill:_balance]">
-      {cards}
+      ))}
     </div>
-  )
-}
-
-// Choose a card variant: tighter pack overall, with a mix of "headline-only" and "expanded"
-// We use a deterministic hash so the same article renders the same way across sessions.
-function variantFor(a: Article, index: number): 'headline' | 'compact' | 'expanded' {
-  const seed = hashCode(a.slug || String(index))
-  const engagement = (a.engagement?.likes || 0) + (a.engagement?.shares || 0) + (a.engagement?.comments || 0)
-  // Highly engaged stories skew to expanded
-  if (engagement > 250) return 'expanded'
-  const r = (seed % 100 + 100) % 100
-  if (r < 35) return 'headline'   // ~35% title-only
-  if (r < 70) return 'compact'    // ~35% compact (few lines)
-  return 'expanded'               // ~30% expanded
-}
-
-function Card({ a, index }: { a: Article, index: number }) {
-  const v = variantFor(a, index)
-  const showImage = !!a.image && v !== 'headline'
-  const showSummary = !!a.summary && v !== 'headline'
-  const summaryLines = v === 'compact' ? 2 : 4
-
-  return (
-    <article className="mb-2 break-inside-avoid rounded bg-white overflow-hidden border border-gray-100">
-      {showImage && (
-        <img src={a.image} alt="" className={`w-full object-cover ${v === 'expanded' ? 'max-h-64' : 'max-h-44'}`} />
-      )}
-      <div className={`px-2 ${v === 'headline' ? 'py-2' : 'py-2'}`}>
-        <Link href={`/article/${a.slug}`} className="block">
-          <h3
-            className={[
-              'leading-snug hover:underline',
-              v === 'headline' ? 'text-base font-semibold' :
-              v === 'compact' ? 'text-[15px] font-semibold' : 'text-lg font-bold'
-            ].join(' ')}
-            dangerouslySetInnerHTML={{ __html: (a as any).titleHTML || a.title }}
-          />
-        </Link>
-        {showSummary && (
-          <p
-            className={[
-              'text-gray-700 mt-1',
-              v === 'compact' ? 'text-[13px]' : 'text-sm',
-              `line-clamp-${summaryLines}`
-            ].join(' ')}
-            dangerouslySetInnerHTML={{ __html: (a as any).summaryHTML || a.summary }}
-          />
-        )}
-        {Array.isArray(a.tags) && a.tags.length > 0 && (
-          <div className="mt-1 flex flex-wrap gap-1 text-[11px] text-blue-700">
-            {a.tags.slice(0, v === 'expanded' ? 6 : 3).map(t => <span key={t}>#{t}</span>)}
-          </div>
-        )}
-      </div>
-    </article>
-  )
-}
-
-function hashCode(s: string): number {
-  let h = 0
-  for (let i = 0; i < s.length; i++) {
-    h = (Math.imul(31, h) + s.charCodeAt(i)) | 0
-  }
-  return h
+  );
 }

--- a/frontend/components/Newsroom/EditorBar.tsx
+++ b/frontend/components/Newsroom/EditorBar.tsx
@@ -1,0 +1,65 @@
+import { useMemo } from "react";
+
+export default function EditorBar({
+  value,
+  onChange,
+  onSave,
+  onPublish,
+}: {
+  value: {
+    title: string;
+    summary: string;
+    coverImage: string;
+    tags: string[];
+    type: "news" | "vip" | "post" | "ads";
+    status: "draft" | "scheduled" | "published";
+    scheduledFor?: string | null;
+  };
+  onChange: (patch: Partial<typeof value>) => void;
+  onSave: () => void;
+  onPublish: () => void;
+}) {
+  const tagText = useMemo(() => value.tags.join(", "), [value.tags]);
+  return (
+    <div className="sticky top-0 z-10 bg-white/90 backdrop-blur border-b">
+      <div className="max-w-6xl mx-auto p-3 flex flex-wrap gap-3 items-center">
+        <input
+          className="flex-1 min-w-[240px] rounded-xl border px-3 py-2"
+          placeholder="Headline..."
+          value={value.title}
+          onChange={(e) => onChange({ title: e.target.value })}
+        />
+        <input
+          className="basis-[320px] grow rounded-xl border px-3 py-2"
+          placeholder="Summary (1–2 sentences)"
+          value={value.summary}
+          onChange={(e) => onChange({ summary: e.target.value })}
+        />
+        <input
+          className="basis-[220px] grow rounded-xl border px-3 py-2"
+          placeholder="Cover image URL"
+          value={value.coverImage}
+          onChange={(e) => onChange({ coverImage: e.target.value })}
+        />
+        <input
+          className="basis-[220px] grow rounded-xl border px-3 py-2"
+          placeholder="tags (comma-separated)"
+          value={tagText}
+          onChange={(e) => onChange({ tags: e.target.value.split(",").map((t) => t.trim()).filter(Boolean) })}
+        />
+        <select
+          className="rounded-xl border px-3 py-2"
+          value={value.type}
+          onChange={(e) => onChange({ type: e.target.value as any })}
+        >
+          <option value="news">News</option>
+          <option value="vip">VIP</option>
+          <option value="post">Post</option>
+          <option value="ads">Ads</option>
+        </select>
+        <button onClick={onSave} className="rounded-xl border px-3 py-2 hover:bg-neutral-50">Save</button>
+        <button onClick={onPublish} className="rounded-xl bg-blue-600 text-white px-4 py-2 hover:bg-blue-700">Publish</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/Newsroom/MarkdownEditor.tsx
+++ b/frontend/components/Newsroom/MarkdownEditor.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useMemo, useState } from "react";
+import { marked } from "marked";
+
+export default function MarkdownEditor({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const [tab, setTab] = useState<"edit" | "preview">("edit");
+
+  const html = useMemo(() => {
+    try {
+      return marked.parse(value || "");
+    } catch {
+      return "<p>Preview unavailable.</p>";
+    }
+  }, [value]);
+
+  useEffect(() => {
+    // Simple autosize for textarea
+    const ta = document.getElementById("md-editor") as HTMLTextAreaElement | null;
+    if (!ta) return;
+    const resize = () => {
+      ta.style.height = "auto";
+      ta.style.height = Math.min(800, ta.scrollHeight) + "px";
+    };
+    resize();
+  }, [value, tab]);
+
+  return (
+    <div className="rounded-2xl border overflow-hidden">
+      <div className="flex border-b bg-neutral-50">
+        <button
+          className={`px-4 py-2 text-sm ${tab === "edit" ? "border-b-2 border-blue-600 text-blue-700" : ""}`}
+          onClick={() => setTab("edit")}
+        >
+          Edit
+        </button>
+        <button
+          className={`px-4 py-2 text-sm ${tab === "preview" ? "border-b-2 border-blue-600 text-blue-700" : ""}`}
+          onClick={() => setTab("preview")}
+        >
+          Preview
+        </button>
+      </div>
+      {tab === "edit" ? (
+        <textarea
+          id="md-editor"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="Write your story in Markdown. Paste links, use #tags in-body if you like."
+          className="w-full p-4 outline-none min-h-[280px]"
+        />
+      ) : (
+        <div className="prose max-w-none p-4" dangerouslySetInnerHTML={{ __html: html }} />
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,11 @@
+export async function api<T = any>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${res.status} ${res.statusText}: ${text}`);
+  }
+  return res.json();
+}

--- a/frontend/lib/server/db.ts
+++ b/frontend/lib/server/db.ts
@@ -1,0 +1,24 @@
+import mongoose from "mongoose";
+
+const MONGODB_URI = process.env.MONGODB_URI || process.env.MONGO_URL || "";
+
+if (!MONGODB_URI) {
+  // Non-fatal log; API routes will throw if called.
+  console.warn("⚠️  MONGODB_URI is not set");
+}
+
+let cached = (global as any)._mongooseCached;
+if (!cached) {
+  cached = (global as any)._mongooseCached = { conn: null, promise: null };
+}
+
+export async function dbConnect() {
+  if (cached.conn) return cached.conn;
+  if (!cached.promise) {
+    cached.promise = mongoose
+      .connect(MONGODB_URI, { dbName: process.env.MONGODB_DB || "patwua" })
+      .then((m) => m);
+  }
+  cached.conn = await cached.promise;
+  return cached.conn;
+}

--- a/frontend/lib/slugify.ts
+++ b/frontend/lib/slugify.ts
@@ -1,0 +1,8 @@
+export function slugify(input: string): string {
+  return String(input)
+    .toLowerCase()
+    .trim()
+    .replace(/['"]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/frontend/models/Draft.ts
+++ b/frontend/models/Draft.ts
@@ -1,0 +1,36 @@
+import mongoose, { Schema } from "mongoose";
+
+export type DraftDoc = {
+  _id: string;
+  title: string;
+  slug: string;
+  summary?: string;
+  body: string; // markdown
+  coverImage?: string;
+  tags: string[];
+  type: "news" | "vip" | "post" | "ads";
+  status: "draft" | "scheduled" | "published";
+  scheduledFor?: Date | null;
+  authorId?: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+const DraftSchema = new Schema<DraftDoc>(
+  {
+    title: { type: String, required: true },
+    slug: { type: String, required: true, index: true, unique: true },
+    summary: { type: String },
+    body: { type: String, default: "" },
+    coverImage: { type: String },
+    tags: { type: [String], default: [] },
+    type: { type: String, enum: ["news", "vip", "post", "ads"], default: "news" },
+    status: { type: String, enum: ["draft", "scheduled", "published"], default: "draft", index: true },
+    scheduledFor: { type: Date, default: null },
+    authorId: { type: String, default: null },
+  },
+  { timestamps: true }
+);
+
+export default (mongoose.models.Draft as mongoose.Model<DraftDoc>) ||
+  mongoose.model<DraftDoc>("Draft", DraftSchema);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "next": "13.4.19",
     "next-auth": "^4.24.7",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "marked": "^12.0.2"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.14",

--- a/frontend/pages/admin/newsroom/editor.tsx
+++ b/frontend/pages/admin/newsroom/editor.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/router";
+import { api } from "@/lib/api";
+import EditorBar from "@/components/Newsroom/EditorBar";
+import MarkdownEditor from "@/components/Newsroom/MarkdownEditor";
+import { slugify } from "@/lib/slugify";
+
+export default function EditorPage() {
+  const router = useRouter();
+  const { id } = router.query as { id?: string };
+
+  const [draftId, setDraftId] = useState<string | null>(null);
+  const [title, setTitle] = useState("");
+  const [summary, setSummary] = useState("");
+  const [coverImage, setCoverImage] = useState("");
+  const [tags, setTags] = useState<string[]>([]);
+  const [type, setType] = useState<"news" | "vip" | "post" | "ads">("news");
+  const [status, setStatus] = useState<"draft" | "scheduled" | "published">("draft");
+  const [body, setBody] = useState("");
+
+  useEffect(() => {
+    if (!id) return;
+    (async () => {
+      const res = await api<{ draft: any }>(`/api/newsroom/drafts/${id}`);
+      const d = res.draft;
+      setDraftId(d._id);
+      setTitle(d.title || "");
+      setSummary(d.summary || "");
+      setCoverImage(d.coverImage || "");
+      setTags(d.tags || []);
+      setType(d.type || "news");
+      setStatus(d.status || "draft");
+      setBody(d.body || "");
+    })();
+  }, [id]);
+
+  async function save() {
+    const res = await api<{ draft: any; ok: boolean }>(`/api/newsroom/drafts`, {
+      method: "POST",
+      body: JSON.stringify({
+        id: draftId,
+        title,
+        summary,
+        body,
+        coverImage,
+        tags,
+        type,
+        status,
+      }),
+    });
+    setDraftId(res.draft._id);
+    // optional: toast
+  }
+
+  async function publish() {
+    if (!draftId) {
+      await save();
+    }
+    const realId = draftId ?? (await api<{ draft: any; ok: boolean }>(`/api/newsroom/drafts`, {
+      method: "POST",
+      body: JSON.stringify({ title, summary, body, coverImage, tags, type, status }),
+    })).draft._id;
+
+    await api(`/api/newsroom/drafts/${realId}?action=publish`, { method: "POST" });
+    // Redirect to the public news page (assumes /news/[slug])
+    const slug = slugify(title);
+    router.push(`/news/${slug}`);
+  }
+
+  const barValue = useMemo(
+    () => ({ title, summary, coverImage, tags, type, status }),
+    [title, summary, coverImage, tags, type, status]
+  );
+
+  return (
+    <main className="max-w-6xl mx-auto pb-24">
+      <EditorBar
+        value={barValue as any}
+        onChange={(patch) => {
+          if (patch.title !== undefined) setTitle(patch.title);
+          if (patch.summary !== undefined) setSummary(patch.summary);
+          if (patch.coverImage !== undefined) setCoverImage(patch.coverImage);
+          if (patch.tags !== undefined) setTags(patch.tags as string[]);
+          if (patch.type !== undefined) setType(patch.type as any);
+          if (patch.status !== undefined) setStatus(patch.status as any);
+        }}
+        onSave={save}
+        onPublish={publish}
+      />
+
+      {coverImage ? (
+        <div className="max-w-4xl mx-auto mt-6 rounded-3xl overflow-hidden ring-1 ring-black/5">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={coverImage} alt="" className="w-full h-auto object-cover" />
+        </div>
+      ) : null}
+
+      <section className="max-w-4xl mx-auto mt-6 p-3">
+        <MarkdownEditor value={body} onChange={setBody} />
+        <div className="mt-4 flex gap-3">
+          <button onClick={save} className="rounded-xl border px-4 py-2 hover:bg-neutral-50">Save Draft</button>
+          <button onClick={publish} className="rounded-xl bg-blue-600 text-white px-4 py-2 hover:bg-blue-700">Publish</button>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/pages/admin/newsroom/index.tsx
+++ b/frontend/pages/admin/newsroom/index.tsx
@@ -1,0 +1,78 @@
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+type Row = {
+  _id: string;
+  title: string;
+  slug: string;
+  status: "draft" | "scheduled" | "published";
+  updatedAt: string;
+  type: "news" | "vip" | "post" | "ads";
+};
+
+export default function NewsroomListPage() {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [q, setQ] = useState("");
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  async function refresh() {
+    const res = await api<{ rows: Row[] }>("/api/newsroom/drafts");
+    setRows(res.rows);
+  }
+
+  async function search() {
+    const res = await api<{ rows: Row[] }>(`/api/newsroom/drafts?q=${encodeURIComponent(q)}`);
+    setRows(res.rows);
+  }
+
+  return (
+    <main className="max-w-6xl mx-auto p-4">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-semibold">Newsroom</h1>
+        <Link href="/admin/newsroom/editor" className="rounded-xl bg-blue-600 text-white px-4 py-2 hover:bg-blue-700">New Draft</Link>
+      </div>
+
+      <div className="flex items-center gap-2 mb-4">
+        <input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search title..." className="rounded-xl border px-3 py-2" />
+        <button onClick={search} className="rounded-xl border px-3 py-2 hover:bg-neutral-50">Search</button>
+        <button onClick={refresh} className="rounded-xl border px-3 py-2 hover:bg-neutral-50">Reset</button>
+      </div>
+
+      <div className="overflow-auto rounded-2xl border">
+        <table className="min-w-[680px] w-full">
+          <thead className="bg-neutral-50 text-left text-sm">
+            <tr>
+              <th className="p-3">Title</th>
+              <th className="p-3">Type</th>
+              <th className="p-3">Status</th>
+              <th className="p-3">Updated</th>
+              <th className="p-3"></th>
+            </tr>
+          </thead>
+          <tbody className="text-sm">
+            {rows.map((r) => (
+              <tr key={r._id} className="border-t">
+                <td className="p-3">{r.title}</td>
+                <td className="p-3">{r.type}</td>
+                <td className="p-3">{r.status}</td>
+                <td className="p-3">{new Date(r.updatedAt).toLocaleString()}</td>
+                <td className="p-3 text-right">
+                  <Link href={`/admin/newsroom/editor?id=${r._id}`} className="text-blue-600 hover:underline">Edit</Link>
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td className="p-6 text-neutral-600" colSpan={5}>No drafts yet.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </main>
+  );
+}

--- a/frontend/pages/api/newsroom/drafts/[id].ts
+++ b/frontend/pages/api/newsroom/drafts/[id].ts
@@ -1,0 +1,41 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { dbConnect } from "@/lib/server/db";
+import Draft from "@/models/Draft";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  await dbConnect();
+
+  const { id } = req.query as { id: string };
+
+  if (req.method === "GET") {
+    const doc = await Draft.findById(id).lean();
+    if (!doc) return res.status(404).json({ error: "Not found" });
+    return res.json({ draft: doc });
+  }
+
+  if (req.method === "PUT") {
+    const payload = req.body || {};
+    const doc = await Draft.findByIdAndUpdate(id, payload, { new: true });
+    if (!doc) return res.status(404).json({ error: "Not found" });
+    return res.json({ ok: true, draft: doc });
+  }
+
+  if (req.method === "DELETE") {
+    await Draft.findByIdAndDelete(id);
+    return res.json({ ok: true });
+  }
+
+  // Simple publish stub (promote to "published")
+  if (req.method === "POST") {
+    const action = (req.query as any).action;
+    if (action === "publish") {
+      const doc = await Draft.findByIdAndUpdate(id, { status: "published", scheduledFor: null }, { new: true });
+      if (!doc) return res.status(404).json({ error: "Not found" });
+      // TODO: create a Post document / trigger feed reindex
+      return res.json({ ok: true, draft: doc });
+    }
+    return res.status(400).json({ error: "Unknown action" });
+  }
+
+  return res.status(405).json({ error: "Method not allowed" });
+}

--- a/frontend/pages/api/newsroom/drafts/index.ts
+++ b/frontend/pages/api/newsroom/drafts/index.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { dbConnect } from "@/lib/server/db";
+import Draft from "@/models/Draft";
+import { slugify } from "@/lib/slugify";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  await dbConnect();
+
+  if (req.method === "GET") {
+    const { q, status = "draft" } = req.query as { q?: string; status?: string };
+    const find: any = {};
+    if (status) find.status = status;
+    if (q) find.title = { $regex: q, $options: "i" };
+    const rows = await Draft.find(find).sort({ updatedAt: -1 }).limit(200).lean();
+    return res.json({ rows });
+  }
+
+  if (req.method === "POST") {
+    const { id, title, summary, body, coverImage, tags = [], type, status, scheduledFor } = req.body || {};
+    if (!title) return res.status(400).json({ error: "title required" });
+
+    const slug = slugify(title);
+    const payload = {
+      title,
+      slug,
+      summary: summary || "",
+      body: body || "",
+      coverImage: coverImage || "",
+      tags: Array.isArray(tags) ? tags : [],
+      type: type || "news",
+      status: status || "draft",
+      scheduledFor: scheduledFor ? new Date(scheduledFor) : null,
+    };
+
+    const doc = id
+      ? await Draft.findByIdAndUpdate(id, payload, { new: true, upsert: false })
+      : await new Draft(payload).save();
+
+    return res.json({ ok: true, draft: doc });
+  }
+
+  return res.status(405).json({ error: "Method not allowed" });
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -10,3 +10,10 @@ mark {
   text-decoration-thickness: 2px;
   text-underline-offset: 2px;
 }
+
+:root { --leading-tight: 1.25; --leading-normal: 1.5; }
+h1,h2,h3 { line-height: var(--leading-tight); letter-spacing: -0.01em; }
+p { line-height: var(--leading-normal); }
+.line-clamp-2 { display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
+.line-clamp-3 { display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical; overflow:hidden; }
+.line-clamp-4 { display:-webkit-box; -webkit-line-clamp:4; -webkit-box-orient:vertical; overflow:hidden; }

--- a/frontend/utils/follow.ts
+++ b/frontend/utils/follow.ts
@@ -75,3 +75,20 @@ export async function syncFollowsIfAuthed(): Promise<void> {
   // Push merged back to server
   await pushServerFollows()
 }
+
+let bootMerged = false;
+let bootTimer: any;
+
+export async function mergeFollowsOnBoot(fetchServerList: ()=>Promise<string[]>, readLocalList: ()=>string[], writeLocalList: (ids: string[])=>void) {
+  if (bootMerged) return;
+  bootMerged = true;
+
+  const run = async () => {
+    const [server, local] = await Promise.all([fetchServerList(), Promise.resolve(readLocalList())]);
+    const set = new Set<string>([...server, ...local]);
+    writeLocalList(Array.from(set));
+  };
+
+  clearTimeout(bootTimer);
+  bootTimer = setTimeout(run, 120);
+}


### PR DESCRIPTION
## Summary
- add shared utilities and MongoDB draft model
- implement newsroom draft API and admin editor UI
- update homepage components and typography

## Testing
- `npm install --package-lock-only` *(fails: 403 Forbidden)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ff4c3bea083299c0470a7aa56f360