### PR TITLE
Add Post model and publish flow

### DIFF
--- a/frontend/lib/server/publish.ts
+++ b/frontend/lib/server/publish.ts
@@ -1,0 +1,48 @@
+import Draft from "@/models/Draft";
+import Post from "@/models/Post";
+import { slugify } from "@/lib/slugify";
+
+function makeExcerpt(markdown: string, fallback: string, max = 240) {
+  const text = (markdown || "")
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/`[^`]*`/g, "")
+    .replace(/!\[[^\]]*]\([^)]*\)/g, "")
+    .replace(/\[[^\]]*]\([^)]*\)/g, "")
+    .replace(/[#>*_\-\+]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  const base = text || fallback || "";
+  return base.length > max ? base.slice(0, max - 1).trimEnd() + "…" : base;
+}
+
+export async function publishDraftById(id: string) {
+  const d = await Draft.findById(id);
+  if (!d) throw new Error("Draft not found");
+
+  const slug = d.slug || slugify(d.title);
+  const tags = Array.isArray(d.tags) ? d.tags : [];
+  const isBreaking = tags.some(t => /^#?(breaking|alert)$/i.test(t));
+
+  const post = await Post.findOneAndUpdate(
+    { slug },
+    {
+      slug,
+      title: d.title,
+      excerpt: d.summary || makeExcerpt(d.body, d.title),
+      body: d.body || "",
+      coverImage: d.coverImage || "",
+      tags,
+      category: (d.type as any) || "news",
+      publishedAt: new Date(),
+      authorId: d.authorId || null,
+      isBreaking,
+    },
+    { new: true, upsert: true }
+  );
+
+  d.status = "published";
+  d.scheduledFor = null;
+  await d.save();
+
+  return { postSlug: post.slug, postId: String(post._id) };
+}

--- a/frontend/lib/server/queries.ts
+++ b/frontend/lib/server/queries.ts
@@ -1,0 +1,10 @@
+import Post from "@/models/Post";
+
+export async function getBreaking(limit = 10) {
+  return Post.find({ isBreaking: true }).sort({ publishedAt: -1 }).limit(limit).lean();
+}
+
+export async function getHeroBundle() {
+  const rail = await Post.find({}).sort({ engagementScore: -1, publishedAt: -1 }).limit(4).lean();
+  return { primary: rail[0] || null, rail: rail.slice(1) };
+}

--- a/frontend/models/Post.ts
+++ b/frontend/models/Post.ts
@@ -1,0 +1,36 @@
+import mongoose, { Schema } from "mongoose";
+
+export type PostDoc = {
+  _id: string;
+  slug: string;
+  title: string;
+  excerpt: string;
+  body: string;            // markdown (raw)
+  coverImage?: string;
+  tags: string[];
+  category: "news" | "vip" | "post" | "ads";
+  publishedAt: Date;
+  authorId?: string | null;
+  engagementScore?: number;
+  isBreaking?: boolean;
+};
+
+const PostSchema = new Schema<PostDoc>(
+  {
+    slug: { type: String, required: true, index: true, unique: true },
+    title: { type: String, required: true },
+    excerpt: { type: String, default: "" },
+    body: { type: String, default: "" },
+    coverImage: { type: String },
+    tags: { type: [String], default: [] },
+    category: { type: String, enum: ["news", "vip", "post", "ads"], default: "news", index: true },
+    publishedAt: { type: Date, required: true, index: true },
+    authorId: { type: String, default: null },
+    engagementScore: { type: Number, default: 0 },
+    isBreaking: { type: Boolean, default: false, index: true },
+  },
+  { timestamps: true }
+);
+
+export default (mongoose.models.Post as mongoose.Model<PostDoc>) ||
+  mongoose.model<PostDoc>("Post", PostSchema);

--- a/frontend/pages/api/newsroom/drafts/index.ts
+++ b/frontend/pages/api/newsroom/drafts/index.ts
@@ -7,9 +7,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   await dbConnect();
 
   if (req.method === "GET") {
-    const { q, status = "draft" } = req.query as { q?: string; status?: string };
+    const { q, status } = req.query as { q?: string; status?: string };
     const find: any = {};
-    if (status) find.status = status;
+    if (status && status !== "all") find.status = status;
     if (q) find.title = { $regex: q, $options: "i" };
     const rows = await Draft.find(find).sort({ updatedAt: -1 }).limit(200).lean();
     return res.json({ rows });


### PR DESCRIPTION
## Summary
- add Post model and helper to publish drafts
- support publishing via API and editor redirect
- expose basic Post queries and flexible draft list filtering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ff84c036c8329998beca1c02d3f82