### PR TITLE
Add affinity boosts & moderation notes drawer

### DIFF
--- a/frontend/components/Newsroom/EditorSidePanel.tsx
+++ b/frontend/components/Newsroom/EditorSidePanel.tsx
@@ -1,5 +1,19 @@
 import { useEffect, useState } from "react";
 
+function readAffinity() {
+  if (typeof window === "undefined") return { tagList: [], authorList: [] };
+  try {
+    const tagList = JSON.parse(localStorage.getItem("wn:follows:tags") || "[]");
+    const authorList = JSON.parse(localStorage.getItem("wn:follows:authors") || "[]");
+    return {
+      tagList: Array.isArray(tagList) ? tagList : [],
+      authorList: Array.isArray(authorList) ? authorList : [],
+    };
+  } catch {
+    return { tagList: [], authorList: [] };
+  }
+}
+
 export default function EditorSidePanel({
   title,
   tags,
@@ -16,9 +30,12 @@ export default function EditorSidePanel({
     const run = async () => {
       setLoading(true);
       try {
+        const { tagList, authorList } = readAffinity();
         const qs = new URLSearchParams({
           title: title || "",
           tags: (tags || []).join(","),
+          affinityTags: tagList.join(","),
+          affinityAuthors: authorList.join(","),
         });
         const res = await fetch(`/api/recs/related?${qs}`);
         const json = await res.json();

--- a/frontend/components/Newsroom/ModerationNotesDrawer.tsx
+++ b/frontend/components/Newsroom/ModerationNotesDrawer.tsx
@@ -1,0 +1,82 @@
+import { useState } from "react";
+
+export default function ModerationNotesDrawer({
+  targetId,       // draftId or postId
+  defaultOpen = false,
+}: {
+  targetId: string | null;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(!!defaultOpen);
+  const [text, setText] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [ok, setOk] = useState<null | "ok" | "err">(null);
+
+  async function saveNote() {
+    if (!targetId || !text.trim()) return;
+    setSaving(true);
+    setOk(null);
+    try {
+      await fetch("/api/ingest/events", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: "moderation_note",
+          targetId,
+          text,
+          visibility: "internal",
+        }),
+      });
+      setOk("ok");
+      setText("");
+    } catch {
+      setOk("err");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="fixed bottom-4 right-4 z-40 rounded-full bg-amber-600 text-white px-4 py-2 shadow-lg hover:bg-amber-700"
+      >
+        Mod Notes
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 z-50">
+          <div className="absolute inset-0 bg-black/30" onClick={() => setOpen(false)} />
+          <div className="absolute right-0 top-0 h-full w-full max-w-md bg-white shadow-xl p-4 grid grid-rows-[auto,1fr,auto]">
+            <header className="flex items-center justify-between">
+              <h3 className="text-base font-semibold">Moderation notes (internal)</h3>
+              <button className="text-sm text-neutral-600 hover:underline" onClick={() => setOpen(false)}>Close</button>
+            </header>
+            <div className="mt-3">
+              <textarea
+                className="w-full h-64 border rounded-xl p-3"
+                placeholder="Leave a private note for moderators/editors. Sensitive data will be redacted on ingest."
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+              />
+              {ok === "ok" && <p className="text-xs text-green-700 mt-2">Saved.</p>}
+              {ok === "err" && <p className="text-xs text-red-700 mt-2">Failed to save.</p>}
+            </div>
+            <footer className="flex items-center justify-end gap-2">
+              <button className="rounded-xl border px-3 py-1.5 hover:bg-neutral-50" onClick={() => setOpen(false)}>Done</button>
+              <button
+                className="rounded-xl bg-amber-600 text-white px-4 py-2 hover:bg-amber-700 disabled:opacity-60"
+                onClick={saveNote}
+                disabled={!targetId || !text.trim() || saving}
+              >
+                {saving ? "Saving…" : "Save note"}
+              </button>
+            </footer>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+

--- a/frontend/pages/admin/newsroom/editor.tsx
+++ b/frontend/pages/admin/newsroom/editor.tsx
@@ -4,7 +4,23 @@ import { api } from "@/lib/api";
 import EditorBar from "@/components/Newsroom/EditorBar";
 import MarkdownEditor from "@/components/Newsroom/MarkdownEditor";
 import EditorSidePanel from "@/components/Newsroom/EditorSidePanel";
+import ModerationNotesDrawer from "@/components/Newsroom/ModerationNotesDrawer";
 import { slugify } from "@/lib/slugify";
+
+// Helper to pull follow affinities from local (merged elsewhere by your boot util)
+function readAffinity() {
+  if (typeof window === "undefined") return { tagList: [], authorList: [] };
+  try {
+    const tagList = JSON.parse(localStorage.getItem("wn:follows:tags") || "[]");
+    const authorList = JSON.parse(localStorage.getItem("wn:follows:authors") || "[]");
+    return {
+      tagList: Array.isArray(tagList) ? tagList : [],
+      authorList: Array.isArray(authorList) ? authorList : [],
+    };
+  } catch {
+    return { tagList: [], authorList: [] };
+  }
+}
 
 export default function EditorPage() {
   const router = useRouter();
@@ -74,6 +90,8 @@ export default function EditorPage() {
     [title, summary, coverImage, tags, type, status]
   );
 
+  const { tagList, authorList } = readAffinity();
+
   return (
     <main className="max-w-7xl mx-auto pb-24">
       <EditorBar
@@ -116,6 +134,9 @@ export default function EditorPage() {
           }}
         />
       </section>
+
+      {/* Moderation notes (internal) */}
+      <ModerationNotesDrawer targetId={draftId} />
     </main>
   );
 }

--- a/frontend/pages/api/recs/related.ts
+++ b/frontend/pages/api/recs/related.ts
@@ -1,18 +1,31 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { dbConnect } from "@/lib/server/db";
 import Post from "@/models/Post";
-import { scoreRelated } from "@/lib/server/similarity";
+import { scoreRelated, applyAffinityBoosts } from "@/lib/server/similarity";
 
 /**
- * GET /api/recs/related?slug=... | title=...&tags=a,b,c
- * Returns top related live posts (excludes exact slug).
+ * GET /api/recs/related
+ * Query:
+ *  - slug=... (optional; if present, seeds from that post)
+ *  - title=...&tags=a,b,c (optional; used if slug not provided)
+ *  - affinityTags=t1,t2 (optional; boosts)
+ *  - affinityAuthors=u1,u2 (optional; boosts)
+ *  - limit=10 (optional)
  */
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   await dbConnect();
 
-  const { slug, title = "", tags = "" } = req.query as { slug?: string; title?: string; tags?: string };
+  const {
+    slug,
+    title = "",
+    tags = "",
+    affinityTags = "",
+    affinityAuthors = "",
+    limit = "10",
+  } = req.query as Record<string, string | undefined>;
+
   let seedTitle = String(title || "");
-  let seedTags = (String(tags || ""))
+  let seedTags = String(tags || "")
     .split(",")
     .map(s => s.trim())
     .filter(Boolean);
@@ -25,18 +38,37 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
   }
 
-  // Fetch recent pool to score against (adjust size as needed)
+  const affTags = String(affinityTags || "")
+    .split(",")
+    .map(s => s.trim())
+    .filter(Boolean);
+
+  const affAuthors = String(affinityAuthors || "")
+    .split(",")
+    .map(s => s.trim())
+    .filter(Boolean);
+
+  const lim = Math.max(1, Math.min(20, parseInt(String(limit || "10"), 10) || 10));
+
+  // Pool size 200 keeps it snappy; adjust as your DB grows
   const pool = await Post.find({}).sort({ publishedAt: -1 }).limit(200).lean();
 
   const scored = pool
     .filter(p => !slug || p.slug !== slug)
-    .map(p => ({
-      p,
-      s: scoreRelated(seedTitle, seedTags, p.title || "", p.tags || []),
-    }))
-    .filter(x => x.s > 0) // only keep meaningful relations
+    .map(p => {
+      const base = scoreRelated(seedTitle, seedTags, p.title || "", p.tags || []);
+      const boosted = applyAffinityBoosts(base, {
+        postTags: p.tags || [],
+        postAuthorId: p.authorId || null,
+        affinityTags: affTags,
+        affinityAuthors: affAuthors,
+        engagementScore: typeof p.engagementScore === "number" ? p.engagementScore : null,
+      });
+      return { p, s: boosted };
+    })
+    .filter(x => x.s > 0.01)
     .sort((a, b) => b.s - a.s)
-    .slice(0, 10)
+    .slice(0, lim)
     .map(({ p, s }) => ({
       id: String(p._id),
       slug: p.slug,
@@ -50,3 +82,4 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   return res.json({ items: scored });
 }
+


### PR DESCRIPTION
## Summary
- enhance similarity scoring with affinity boosts
- personalize related stories API and side panel suggestions
- add moderation notes drawer to newsroom editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fffaa552883298ba3aefd7e3bad19