### PR TITLE
feat: moderation workflow enhancements

### DIFF
--- a/frontend/pages/api/ingest/events.ts
+++ b/frontend/pages/api/ingest/events.ts
@@ -31,6 +31,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     rawTextHash,
     tags: Array.isArray(tags) ? tags : [],
     category: category || null,
+    ...(type === "moderation_note" ? { status: "open", secondReview: false } : {}),
   });
 
   return res.json({ ok: true, id: String(doc._id) });

--- a/frontend/pages/api/moderation/notes.ts
+++ b/frontend/pages/api/moderation/notes.ts
@@ -27,6 +27,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     to = "",
     page = "1",
     limit = "20",
+    status = "",
+    assignedTo = "",
   } = req.query as Record<string, string>;
 
   const p = Math.max(1, parseInt(page || "1", 10) || 1);
@@ -43,6 +45,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (actorId.trim()) {
     find.actorId = actorId.trim();
   }
+  if (status.trim()) find.status = status.trim();
+  if (assignedTo.trim()) find.assignedTo = assignedTo.trim();
   if (from || to) {
     find.createdAt = {};
     if (from) find.createdAt.$gte = new Date(from);

--- a/frontend/pages/api/moderation/notes/[id].ts
+++ b/frontend/pages/api/moderation/notes/[id].ts
@@ -1,0 +1,50 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { dbConnect } from "@/lib/server/db";
+import Event from "@/models/Event";
+
+/**
+ * PATCH /api/moderation/notes/[id]
+ * Body:
+ *   { action: "assign"|"release"|"flag_second"|"resolve"|"reopen",
+ *     assignee?: string }
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "PATCH") return res.status(405).json({ error: "Method not allowed" });
+  await dbConnect();
+
+  const { id } = req.query as { id: string };
+  const { action, assignee } = req.body || {};
+  if (!id || !action) return res.status(400).json({ error: "id and action required" });
+
+  const doc = await Event.findById(id);
+  if (!doc || doc.type !== "moderation_note" || doc.visibility !== "internal") {
+    return res.status(404).json({ error: "Note not found" });
+  }
+
+  switch (action) {
+    case "assign":
+      doc.assignedTo = String(assignee || "");
+      doc.status = "in_review";
+      break;
+    case "release":
+      doc.assignedTo = null;
+      doc.status = "open";
+      break;
+    case "flag_second":
+      doc.secondReview = true;
+      doc.status = "flagged";
+      break;
+    case "resolve":
+      doc.status = "resolved";
+      break;
+    case "reopen":
+      doc.status = "open";
+      doc.secondReview = false;
+      break;
+    default:
+      return res.status(400).json({ error: "Unknown action" });
+  }
+
+  await doc.save();
+  return res.json({ ok: true, note: doc.toObject() });
+}

--- a/frontend/pages/api/moderation/resolve-target.ts
+++ b/frontend/pages/api/moderation/resolve-target.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { dbConnect } from "@/lib/server/db";
+import Draft from "@/models/Draft";
+import Post from "@/models/Post";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") return res.status(405).json({ error: "Method not allowed" });
+  await dbConnect();
+
+  const { id = "" } = req.query as { id?: string };
+  if (!id) return res.status(400).json({ error: "id required" });
+
+  const draft = await Draft.findById(id).lean();
+  if (draft) {
+    return res.json({ kind: "draft", href: `/admin/newsroom/editor?id=${draft._id}`, title: draft.title, slug: draft.slug });
+  }
+  const post = await Post.findById(id).lean();
+  if (post) {
+    return res.json({ kind: "post", href: `/news/${post.slug}`, title: post.title, slug: post.slug });
+  }
+  return res.json({ kind: null, href: null });
+}


### PR DESCRIPTION
## Summary
- extend Event model with status, assignment, and second review fields
- add moderation note actions and filters with resolve-target helper
- enhance admin notes UI with status badges, assignee tools, and actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a003fec8cc832994253e4ff2b29f8f