### PR TITLE
Add news article page with SEO, related rail, and XML feeds

### DIFF
--- a/frontend/components/RelatedRail.tsx
+++ b/frontend/components/RelatedRail.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+
+function readAffinity() {
+  if (typeof window === "undefined") return { tagList: [], authorList: [] };
+  try {
+    const tagList = JSON.parse(localStorage.getItem("wn:follows:tags") || "[]");
+    const authorList = JSON.parse(localStorage.getItem("wn:follows:authors") || "[]");
+    return {
+      tagList: Array.isArray(tagList) ? tagList : [],
+      authorList: Array.isArray(authorList) ? authorList : [],
+    };
+  } catch {
+    return { tagList: [], authorList: [] };
+  }
+}
+
+export default function RelatedRail({
+  slug,
+  title,
+  tags,
+  limit = 6,
+}: {
+  slug?: string;
+  title?: string;
+  tags?: string[];
+  limit?: number;
+}) {
+  const [items, setItems] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const run = async () => {
+      setLoading(true);
+      try {
+        const { tagList, authorList } = readAffinity();
+        const qs = new URLSearchParams({
+          limit: String(limit),
+        });
+        if (slug) qs.set("slug", slug);
+        if (title) qs.set("title", title);
+        if (tags?.length) qs.set("tags", tags.join(","));
+        if (tagList.length) qs.set("affinityTags", tagList.join(","));
+        if (authorList.length) qs.set("affinityAuthors", authorList.join(","));
+        const res = await fetch(`/api/recs/related?` + qs.toString());
+        const json = await res.json();
+        setItems(json.items || []);
+      } catch {
+        setItems([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+    run();
+  }, [slug, title, JSON.stringify(tags), limit]);
+
+  if (loading) {
+    return (
+      <div>
+        <h3 className="text-sm font-semibold mb-2">Related stories</h3>
+        <div className="grid sm:grid-cols-2 gap-3">
+          <div className="h-24 rounded-xl bg-neutral-200 animate-pulse" />
+          <div className="h-24 rounded-xl bg-neutral-200 animate-pulse" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!items.length) return null;
+
+  return (
+    <div>
+      <h3 className="text-sm font-semibold mb-2">Related stories</h3>
+      <ul className="grid sm:grid-cols-2 gap-3">
+        {items.map((it: any) => (
+          <li key={it.slug} className="p-3 rounded-xl bg-white ring-1 ring-black/5 hover:bg-neutral-50">
+            <a href={`/news/${it.slug}`} className="block">
+              <div className="text-sm font-medium line-clamp-2">{it.title}</div>
+              <div className="text-xs text-neutral-600 mt-1">{it.excerpt}</div>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/frontend/pages/api/rss.xml.ts
+++ b/frontend/pages/api/rss.xml.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { dbConnect } from "@/lib/server/db";
+import Post from "@/models/Post";
+
+const SITE = "https://waternews.patwua.com"; // set to your prod origin
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  await dbConnect();
+  const posts = await Post.find({}).sort({ publishedAt: -1 }).limit(50).lean();
+
+  const items = posts
+    .map((p) => {
+      const url = `${SITE}/news/${p.slug}`;
+      return `\n<item>\n  <title><![CDATA[${p.title}]]></title>\n  <link>${url}</link>\n  <guid isPermaLink="true">${url}</guid>\n  <pubDate>${new Date(p.publishedAt || Date.now()).toUTCString()}</pubDate>\n  <description><![CDATA[${p.excerpt || ""}]]></description>\n</item>`;
+    })
+    .join("");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0">\n  <channel>\n    <title>WaterNews</title>\n    <link>${SITE}</link>\n    <description>Latest stories from WaterNewsGY</description>\n    ${items}\n  </channel>\n</rss>`;
+
+  res.setHeader("Content-Type", "application/rss+xml; charset=utf-8");
+  res.setHeader("Cache-Control", "s-maxage=600, stale-while-revalidate=300");
+  res.status(200).send(xml);
+}
+

--- a/frontend/pages/api/sitemap.xml.ts
+++ b/frontend/pages/api/sitemap.xml.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { dbConnect } from "@/lib/server/db";
+import Post from "@/models/Post";
+
+const SITE = "https://waternews.patwua.com"; // set to your prod origin
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  await dbConnect();
+  const posts = await Post.find({}).sort({ publishedAt: -1 }).limit(5000).lean();
+
+  const urls = posts
+    .map((p) => {
+      const loc = `${SITE}/news/${p.slug}`;
+      const lastmod = new Date(p.publishedAt || Date.now()).toISOString();
+      return `<url><loc>${loc}</loc><lastmod>${lastmod}</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>`;
+    })
+    .join("");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n  <url><loc>${SITE}</loc><changefreq>hourly</changefreq><priority>1.0</priority></url>\n  ${urls}\n</urlset>`;
+
+  res.setHeader("Content-Type", "application/xml; charset=utf-8");
+  res.setHeader("Cache-Control", "s-maxage=600, stale-while-revalidate=300");
+  res.status(200).send(xml);
+}
+

--- a/frontend/pages/news/[slug].tsx
+++ b/frontend/pages/news/[slug].tsx
@@ -1,0 +1,153 @@
+import Head from "next/head";
+import { GetServerSideProps } from "next";
+import { dbConnect } from "@/lib/server/db";
+import Post from "@/models/Post";
+import type { PostDoc } from "@/models/Post";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+type Props = {
+  ok: boolean;
+  post?: any;
+};
+
+function fmtDate(d?: string | Date) {
+  if (!d) return "";
+  const dt = new Date(d);
+  return dt.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function Markdown({ source }: { source: string }) {
+  // lightweight client-side markdown render using marked (already in pkg.json per your logs)
+  const [html, setHtml] = useState<string>("");
+  useEffect(() => {
+    (async () => {
+      const { marked } = await import("marked");
+      setHtml(marked.parse(source || "", { breaks: true }) as string);
+    })();
+  }, [source]);
+  // eslint-disable-next-line react/no-danger
+  return <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: html }} />;
+}
+
+export default function NewsArticle({ ok, post }: Props) {
+  if (!ok || !post) {
+    return (
+      <main className="max-w-3xl mx-auto p-6">
+        <h1 className="text-2xl font-semibold">Article not found</h1>
+        <p className="mt-2 text-neutral-600">This story may have been removed or unpublished.</p>
+        <div className="mt-6"><Link href="/" className="text-blue-600 hover:underline">Back to home</Link></div>
+      </main>
+    );
+  }
+
+  const {
+    title,
+    excerpt,
+    body,
+    coverImage,
+    tags = [],
+    slug,
+    publishedAt,
+  } = post as PostDoc;
+
+  const canonical = `/news/${slug}`;
+  const site = "https://waternews.patwua.com"; // change to your prod origin
+  const fullUrl = `${site}${canonical}`;
+  const ogImg = coverImage || `${site}/og-default.jpg`;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "NewsArticle",
+    headline: title,
+    datePublished: new Date(publishedAt || Date.now()).toISOString(),
+    dateModified: new Date(publishedAt || Date.now()).toISOString(),
+    description: excerpt,
+    mainEntityOfPage: fullUrl,
+    image: ogImg,
+    author: post.authorId ? { "@type": "Person", name: String(post.authorId) } : undefined,
+    articleSection: post.category || "news",
+    keywords: (tags || []).join(", "),
+  };
+
+  return (
+    <>
+      <Head>
+        <title>{title} — WaterNews</title>
+        <link rel="canonical" href={fullUrl} />
+        {/* OpenGraph / Twitter */}
+        <meta property="og:type" content="article" />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={excerpt || title} />
+        <meta property="og:url" content={fullUrl} />
+        <meta property="og:image" content={ogImg} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={excerpt || title} />
+        <meta name="twitter:image" content={ogImg} />
+        {/* JSON-LD */}
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      </Head>
+
+      <article className="max-w-3xl mx-auto px-4 md:px-6 py-6">
+        <header className="mb-4">
+          <div className="flex flex-wrap items-center gap-2 text-xs text-neutral-600">
+            <Link href="/" className="hover:underline">Home</Link>
+            <span>·</span>
+            <span>{fmtDate(publishedAt)}</span>
+            {post.isBreaking && (<><span>·</span><span className="px-2 py-0.5 rounded-full bg-red-600/10 text-red-700 font-medium">Breaking</span></>)}
+          </div>
+          <h1 className="mt-2 text-3xl md:text-4xl font-bold tracking-tight">{title}</h1>
+          {excerpt ? <p className="mt-2 text-neutral-700">{excerpt}</p> : null}
+          {tags?.length ? (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {tags.map((t: string) => (
+                <span key={t} className="text-xs px-2 py-0.5 rounded-full bg-neutral-100 text-neutral-700">#{t.replace(/^#/, "")}</span>
+              ))}
+            </div>
+          ) : null}
+          {coverImage ? (
+            <div className="mt-4 rounded-2xl overflow-hidden ring-1 ring-black/5">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={coverImage} alt="" className="w-full h-auto object-cover" />
+            </div>
+          ) : null}
+        </header>
+
+        <section className="mt-6 prose prose-neutral max-w-none">
+          <Markdown source={body || ""} />
+        </section>
+
+        <footer className="mt-8 border-t pt-6">
+          <RelatedRail slug={slug} tags={tags} title={title} />
+        </footer>
+      </article>
+    </>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+  const slug = String(ctx.params?.slug || "");
+  await dbConnect();
+  const doc = await Post.findOne({ slug }).lean();
+  if (!doc) {
+    return { props: { ok: false } };
+  }
+  // minimal serialization
+  const post = {
+    ...doc,
+    _id: String(doc._id),
+    publishedAt: doc.publishedAt ? new Date(doc.publishedAt).toISOString() : null,
+  };
+  return { props: { ok: true, post: JSON.parse(JSON.stringify(post)) } };
+};
+
+// Local component import placed at bottom to avoid SSR circular deps
+import RelatedRail from "@/components/RelatedRail";
+

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://waternews.patwua.com/api/sitemap.xml
+


### PR DESCRIPTION
## Summary
- add public reader page with SEO metadata and related stories rail
- create RelatedRail component and XML endpoints for RSS and sitemap
- expose sitemap via robots.txt

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0094ebbac8329beadfc078f9cf068