### PR TITLE
Add global search and static news pages

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,43 +1,12 @@
-import { useState, useRef, useEffect } from 'react'
 import Link from 'next/link'
-import { useRouter } from 'next/router'
 import NotificationsBellMenu from './NotificationsBellMenu'
 import SmartMenu from './SmartMenu'
-import { SearchIcon } from './icons'
+import dynamic from 'next/dynamic'
+
+// Lazy-load to keep header JS light
+const SearchBox = dynamic(() => import('./SearchBox'), { ssr: false })
 
 export default function Header() {
-  const [searchOpen, setSearchOpen] = useState(false)
-  const inputRef = useRef<HTMLInputElement>(null)
-  const router = useRouter()
-  const [q, setQ] = useState<string>((router.query.q as string) || '')
-
-  useEffect(() => {
-    if (searchOpen) inputRef.current?.focus()
-  }, [searchOpen])
-
-  // Keep local q in sync if URL changes elsewhere
-  useEffect(() => {
-    setQ((router.query.q as string) || '')
-  }, [router.query.q])
-
-  const onType = (value: string) => {
-    setQ(value)
-    // Update URL shallowly for instant client filter
-    router.replace({ pathname: router.pathname, query: { ...router.query, q: value || undefined } }, undefined, { shallow: true })
-    // Notify listeners for instant client filter (no network)
-    if (typeof window !== 'undefined') {
-      window.dispatchEvent(new CustomEvent('wn-search-type', { detail: value }))
-    }
-  }
-
-  const onSubmit = (e?: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e) e.preventDefault()
-    // Notify listeners that user hit Enter -> perform server search
-    if (typeof window !== 'undefined') {
-      window.dispatchEvent(new CustomEvent('wn-search-submit', { detail: q }))
-    }
-  }
-
   return (
     <header className="border-b bg-white">
       <div className="max-w-7xl mx-auto px-4 py-3 flex items-center gap-3">
@@ -45,35 +14,16 @@ export default function Header() {
           <img src="/logo-waternews.svg" alt="WaterNewsGY" className="h-7 w-auto" />
         </Link>
 
-        {/* Smart menu (hidden when search expands on small screens) */}
-        <nav className={`${searchOpen ? 'hidden md:block' : 'block'} ml-2`}>
+        <nav className="ml-2 flex items-center gap-4">
           <SmartMenu />
+          <a href="/search" className="hidden md:inline-block text-sm text-neutral-700 hover:underline">Search</a>
         </nav>
 
-        {/* Inline expanding search */}
-        <div className={`flex-1 transition-all duration-200 ${searchOpen ? 'ml-2' : 'ml-auto md:ml-4'}`}>
-          <div className="flex items-center gap-2 justify-end">
-            {searchOpen && (
-              <input
-                ref={inputRef}
-                type="search"
-                value={q}
-                onChange={(e)=>onType(e.target.value)}
-                onKeyDown={(e)=>{ if (e.key === 'Enter') onSubmit(e) }}
-                placeholder="Search WaterNews…"
-                className="w-full md:w-2/3 lg:w-1/2 border rounded px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-200"
-              />
-            )}
-            <button
-              onClick={() => setSearchOpen(s => !s)}
-              aria-label="Search"
-              title="Search"
-              className="p-2 rounded hover:bg-gray-100"
-            >
-              <SearchIcon className="w-5 h-5" />
-            </button>
-            <NotificationsBellMenu />
+        <div className="ml-auto flex items-center gap-3">
+          <div className="hidden md:block">
+            <SearchBox />
           </div>
+          <NotificationsBellMenu />
         </div>
       </div>
     </header>

--- a/frontend/components/SearchBox.tsx
+++ b/frontend/components/SearchBox.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+function useDebounced<T>(value: T, delay = 250) {
+  const [v, setV] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setV(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+  return v;
+}
+
+type Item = {
+  slug: string;
+  title: string;
+  excerpt?: string;
+  publishedAt?: string;
+  tags?: string[];
+};
+
+export default function SearchBox() {
+  const [q, setQ] = useState("");
+  const [tag, setTag] = useState("");
+  const [items, setItems] = useState<Item[]>([]);
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [active, setActive] = useState(0);
+
+  const dq = useDebounced(q, 250);
+  const dt = useDebounced(tag, 250);
+
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Fetch results
+  useEffect(() => {
+    const run = async () => {
+      if (!dq && !dt) {
+        setItems([]);
+        setOpen(false);
+        return;
+      }
+      setLoading(true);
+      try {
+        const qs = new URLSearchParams();
+        if (dq) qs.set("q", dq);
+        if (dt) qs.set("tags", dt);
+        qs.set("limit", "8");
+        const res = await fetch(`/api/search?${qs}`);
+        const json = await res.json();
+        setItems(json.items || []);
+        setOpen(true);
+        setActive(0);
+      } catch {
+        setItems([]);
+        setOpen(false);
+      } finally {
+        setLoading(false);
+      }
+    };
+    run();
+  }, [dq, dt]);
+
+  // Close on outside click / ESC
+  useEffect(() => {
+    function onDocClick(e: MouseEvent) {
+      if (!rootRef.current) return;
+      if (!rootRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, []);
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!open || !items.length) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActive((i) => Math.min(items.length - 1, i + 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActive((i) => Math.max(0, i - 1));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const it = items[active];
+      if (it) window.location.href = `/news/${it.slug}`;
+    }
+  };
+
+  const hint = useMemo(() => (tag ? `#${tag}` : "headline or tag"), [tag]);
+
+  return (
+    <div ref={rootRef} className="relative w-full max-w-md">
+      <div className="flex gap-1">
+        <input
+          ref={inputRef}
+          className="w-full rounded-xl border px-3 py-2"
+          placeholder={`Search ${hint}…`}
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          onFocus={() => { if (items.length) setOpen(true); }}
+          onKeyDown={onKeyDown}
+          aria-label="Search stories"
+        />
+        <input
+          className="w-32 rounded-xl border px-3 py-2"
+          placeholder="tag"
+          value={tag}
+          onChange={(e) => setTag(e.target.value)}
+          onFocus={() => { if (items.length) setOpen(true); }}
+          aria-label="Filter by tag"
+        />
+      </div>
+
+      {open && (
+        <div
+          role="listbox"
+          aria-label="Search results"
+          className="absolute z-40 mt-2 w-full rounded-2xl bg-white shadow-lg ring-1 ring-black/5 overflow-hidden"
+        >
+          <div className="px-3 py-2 text-xs text-neutral-600 border-b">
+            {loading ? "Searching…" : items.length ? `Results (${items.length})` : "No results"}
+          </div>
+          <ul className="max-h-96 overflow-auto">
+            {items.map((it, i) => (
+              <li key={it.slug}>
+                <a
+                  href={`/news/${it.slug}`}
+                  className={`block px-3 py-2 text-sm ${i === active ? "bg-neutral-50" : ""}`}
+                  onMouseEnter={() => setActive(i)}
+                  role="option"
+                  aria-selected={i === active}
+                >
+                  <div className="font-medium line-clamp-1">{it.title}</div>
+                  <div className="text-xs text-neutral-600 line-clamp-2">{it.excerpt}</div>
+                  <div className="mt-0.5 text-[11px] text-neutral-500">
+                    {it.publishedAt ? new Date(it.publishedAt).toLocaleString() : ""}
+                    {it.tags?.length ? <> · {it.tags.slice(0, 3).map(t => `#${String(t).replace(/^#/, "")}`).join(" ")} </> : null}
+                  </div>
+                </a>
+              </li>
+            ))}
+          </ul>
+          <div className="px-3 py-2 text-xs text-neutral-600 border-t">
+            Press <kbd className="border px-1 rounded">↵</kbd> to open · <a className="text-blue-600 hover:underline" href={`/search?q=${encodeURIComponent(q)}${tag ? `&tags=${encodeURIComponent(tag)}` : ""}`}>Open full search</a>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Add debounced SearchBox component with tag filtering and keyboard navigation
- Integrate SearchBox into header and link to full search page
- Convert individual news pages to incremental static generation for faster loads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a00d3dbfb4832981962ea8ddbc41e2