### PR TITLE
feat: add search suggestions and inline results

### DIFF
--- a/frontend/components/SearchBox.tsx
+++ b/frontend/components/SearchBox.tsx
@@ -24,6 +24,8 @@ export default function SearchBox() {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [active, setActive] = useState(0);
+  const [suggestions, setSuggestions] = useState<{ tags: { tag: string; count: number }[]; headlines: { slug: string; title: string; publishedAt?: string }[] }>({ tags: [], headlines: [] });
+  const [showSuggestions, setShowSuggestions] = useState(false);
 
   const dq = useDebounced(q, 250);
   const dt = useDebounced(tag, 250);
@@ -31,12 +33,29 @@ export default function SearchBox() {
   const rootRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
+  // Fetch suggestions on mount (popular tags + trending headlines)
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/search/suggestions");
+        const json = await res.json();
+        setSuggestions({
+          tags: Array.isArray(json.tags) ? json.tags : [],
+          headlines: Array.isArray(json.headlines) ? json.headlines : [],
+        });
+      } catch {
+        setSuggestions({ tags: [], headlines: [] });
+      }
+    })();
+  }, []);
+
   // Fetch results
   useEffect(() => {
     const run = async () => {
       if (!dq && !dt) {
         setItems([]);
-        setOpen(false);
+        setOpen(true);       // keep panel open to show suggestions
+        setShowSuggestions(true);
         return;
       }
       setLoading(true);
@@ -50,9 +69,11 @@ export default function SearchBox() {
         setItems(json.items || []);
         setOpen(true);
         setActive(0);
+        setShowSuggestions(false);
       } catch {
         setItems([]);
-        setOpen(false);
+        setOpen(true);
+        setShowSuggestions(true);
       } finally {
         setLoading(false);
       }
@@ -78,7 +99,8 @@ export default function SearchBox() {
   }, []);
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (!open || !items.length) return;
+    if (!open) return;
+    if (showSuggestions) return; // don't arrow through suggestions; use mouse/click
     if (e.key === "ArrowDown") {
       e.preventDefault();
       setActive((i) => Math.min(items.length - 1, i + 1));
@@ -103,7 +125,7 @@ export default function SearchBox() {
           placeholder={`Search ${hint}…`}
           value={q}
           onChange={(e) => setQ(e.target.value)}
-          onFocus={() => { if (items.length) setOpen(true); }}
+          onFocus={() => { setOpen(true); setShowSuggestions(!q && !tag); }}
           onKeyDown={onKeyDown}
           aria-label="Search stories"
         />
@@ -112,7 +134,7 @@ export default function SearchBox() {
           placeholder="tag"
           value={tag}
           onChange={(e) => setTag(e.target.value)}
-          onFocus={() => { if (items.length) setOpen(true); }}
+          onFocus={() => { setOpen(true); setShowSuggestions(!q && !tag); }}
           aria-label="Filter by tag"
         />
       </div>
@@ -123,32 +145,77 @@ export default function SearchBox() {
           aria-label="Search results"
           className="absolute z-40 mt-2 w-full rounded-2xl bg-white shadow-lg ring-1 ring-black/5 overflow-hidden"
         >
-          <div className="px-3 py-2 text-xs text-neutral-600 border-b">
-            {loading ? "Searching…" : items.length ? `Results (${items.length})` : "No results"}
-          </div>
-          <ul className="max-h-96 overflow-auto">
-            {items.map((it, i) => (
-              <li key={it.slug}>
-                <a
-                  href={`/news/${it.slug}`}
-                  className={`block px-3 py-2 text-sm ${i === active ? "bg-neutral-50" : ""}`}
-                  onMouseEnter={() => setActive(i)}
-                  role="option"
-                  aria-selected={i === active}
-                >
-                  <div className="font-medium line-clamp-1">{it.title}</div>
-                  <div className="text-xs text-neutral-600 line-clamp-2">{it.excerpt}</div>
-                  <div className="mt-0.5 text-[11px] text-neutral-500">
-                    {it.publishedAt ? new Date(it.publishedAt).toLocaleString() : ""}
-                    {it.tags?.length ? <> · {it.tags.slice(0, 3).map(t => `#${String(t).replace(/^#/, "")}`).join(" ")} </> : null}
-                  </div>
-                </a>
-              </li>
-            ))}
-          </ul>
-          <div className="px-3 py-2 text-xs text-neutral-600 border-t">
-            Press <kbd className="border px-1 rounded">↵</kbd> to open · <a className="text-blue-600 hover:underline" href={`/search?q=${encodeURIComponent(q)}${tag ? `&tags=${encodeURIComponent(tag)}` : ""}`}>Open full search</a>
-          </div>
+          {showSuggestions ? (
+            <div className="p-3">
+              <div className="text-xs text-neutral-600 mb-2">Suggestions</div>
+              <div className="mb-3">
+                <div className="text-xs font-semibold text-neutral-700 mb-1">Popular tags</div>
+                <div className="flex flex-wrap gap-1.5">
+                  {suggestions.tags.length === 0 ? (
+                    <span className="text-xs text-neutral-500">No tags yet</span>
+                  ) : (
+                    suggestions.tags.map((t) => (
+                      <button
+                        key={t.tag}
+                        onClick={() => { setTag(String(t.tag).replace(/^#/, "")); inputRef.current?.focus(); }}
+                        className="text-xs px-2 py-1 rounded-full bg-neutral-100 hover:bg-neutral-200"
+                        aria-label={`Use tag ${t.tag}`}
+                      >
+                        #{String(t.tag).replace(/^#/, "")}
+                        <span className="ml-1 text-[10px] text-neutral-500">{t.count}</span>
+                      </button>
+                    ))
+                  )}
+                </div>
+              </div>
+              <div>
+                <div className="text-xs font-semibold text-neutral-700 mb-1">Trending stories</div>
+                <ul className="max-h-72 overflow-auto divide-y">
+                  {suggestions.headlines.length === 0 ? (
+                    <li className="py-2 text-xs text-neutral-500">No recent stories</li>
+                  ) : (
+                    suggestions.headlines.map((h) => (
+                      <li key={h.slug} className="py-2">
+                        <a href={`/news/${h.slug}`} className="block">
+                          <div className="text-sm font-medium line-clamp-1">{h.title}</div>
+                          <div className="text-[11px] text-neutral-500">{h.publishedAt ? new Date(h.publishedAt).toLocaleString() : ""}</div>
+                        </a>
+                      </li>
+                    ))
+                  )}
+                </ul>
+              </div>
+            </div>
+          ) : (
+            <>
+              <div className="px-3 py-2 text-xs text-neutral-600 border-b">
+                {loading ? "Searching…" : items.length ? `Results (${items.length})` : "No results"}
+              </div>
+              <ul className="max-h-96 overflow-auto">
+                {items.map((it, i) => (
+                  <li key={it.slug}>
+                    <a
+                      href={`/news/${it.slug}`}
+                      className={`block px-3 py-2 text-sm ${i === active ? "bg-neutral-50" : ""}`}
+                      onMouseEnter={() => setActive(i)}
+                      role="option"
+                      aria-selected={i === active}
+                    >
+                      <div className="font-medium line-clamp-1">{it.title}</div>
+                      <div className="text-xs text-neutral-600 line-clamp-2">{it.excerpt}</div>
+                      <div className="mt-0.5 text-[11px] text-neutral-500">
+                        {it.publishedAt ? new Date(it.publishedAt).toLocaleString() : ""}
+                        {it.tags?.length ? <> · {it.tags.slice(0, 3).map(t => `#${String(t).replace(/^#/, "")}`).join(" ")} </> : null}
+                      </div>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+              <div className="px-3 py-2 text-xs text-neutral-600 border-t">
+                Press <kbd className="border px-1 rounded">↵</kbd> to open · <a className="text-blue-600 hover:underline" href={`/search?q=${encodeURIComponent(q)}${tag ? `&tags=${encodeURIComponent(tag)}` : ""}`}>Open full search</a>
+              </div>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,10 +13,10 @@
     "axios": "^1.6.8",
     "bcryptjs": "^2.4.3",
     "mongoose": "^8.6.0",
-    "next": "13.4.19",
+    "next": "^14.2.5",
     "next-auth": "^4.24.7",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "marked": "^12.0.2"
   },
   "devDependencies": {

--- a/frontend/pages/api/search.ts
+++ b/frontend/pages/api/search.ts
@@ -38,6 +38,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     })
     .lean();
 
+  res.setHeader("Cache-Control", "s-maxage=20, stale-while-revalidate=30");
   res.json({
     items: rows.map((r) => ({
       id: String(r._id),

--- a/frontend/pages/api/search/suggestions.ts
+++ b/frontend/pages/api/search/suggestions.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { dbConnect } from "@/lib/server/db";
+import Post from "@/models/Post";
+
+/**
+ * GET /api/search/suggestions
+ * Returns:
+ *  - tags: [{ tag, count }]
+ *  - headlines: [{ slug, title, publishedAt }]
+ *
+ * Notes:
+ *  - Popular tags are aggregated from recent posts (last 90 days, up to 2000 docs).
+ *  - Headlines are recent posts (limit 8), newest first.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  await dbConnect();
+
+  // recent horizon: 90d
+  const since = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+
+  // Aggregate popular tags
+  const tagAgg = await Post.aggregate([
+    { $match: { publishedAt: { $gte: since } } },
+    { $project: { tags: 1 } },
+    { $unwind: "$tags" },
+    { $group: { _id: { $toLower: "$tags" }, count: { $sum: 1 } } },
+    { $sort: { count: -1 } },
+    { $limit: 12 },
+  ]);
+
+  // Recent headlines
+  const recents = await Post.find({ publishedAt: { $gte: since } })
+    .sort({ publishedAt: -1 })
+    .limit(8)
+    .select({ slug: 1, title: 1, publishedAt: 1 })
+    .lean();
+
+  res.setHeader("Cache-Control", "s-maxage=120, stale-while-revalidate=60");
+  res.json({
+    tags: tagAgg.map(t => ({ tag: t._id, count: t.count })),
+    headlines: recents.map(r => ({
+      slug: r.slug,
+      title: r.title,
+      publishedAt: r.publishedAt,
+    })),
+  });
+}

--- a/frontend/pages/search.tsx
+++ b/frontend/pages/search.tsx
@@ -9,16 +9,31 @@ function useDebounced<T>(value: T, delay = 350) {
   return v;
 }
 
+type Suggestions = { tags: { tag: string; count: number }[]; headlines: { slug: string; title: string; publishedAt?: string }[] };
+
 export default function SearchPage() {
   const [q, setQ] = useState("");
   const [tag, setTag] = useState("");
   const [items, setItems] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
+  const [suggestions, setSuggestions] = useState<Suggestions>({ tags: [], headlines: [] });
 
   const dq = useDebounced(q);
   const dt = useDebounced(tag);
 
   useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/search/suggestions");
+        const json = await res.json();
+        setSuggestions({
+          tags: Array.isArray(json.tags) ? json.tags : [],
+          headlines: Array.isArray(json.headlines) ? json.headlines : [],
+        });
+      } catch {
+        setSuggestions({ tags: [], headlines: [] });
+      }
+    })();
     const run = async () => {
       setLoading(true);
       try {
@@ -60,8 +75,47 @@ export default function SearchPage() {
           <div className="h-16 rounded-xl bg-neutral-200 animate-pulse" />
           <div className="h-16 rounded-xl bg-neutral-200 animate-pulse" />
         </div>
+      ) : (items.length === 0 && !q && !tag) ? (
+        <section className="space-y-4">
+          <div>
+            <div className="text-xs font-semibold text-neutral-700 mb-2">Popular tags</div>
+            <div className="flex flex-wrap gap-1.5">
+              {suggestions.tags.length === 0 ? (
+                <span className="text-xs text-neutral-500">No tags yet</span>
+              ) : (
+                suggestions.tags.map((t) => (
+                  <button
+                    key={t.tag}
+                    onClick={() => setTag(String(t.tag).replace(/^#/, ""))}
+                    className="text-xs px-2 py-1 rounded-full bg-neutral-100 hover:bg-neutral-200"
+                  >
+                    #{String(t.tag).replace(/^#/, "")}
+                    <span className="ml-1 text-[10px] text-neutral-500">{t.count}</span>
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+          <div>
+            <div className="text-xs font-semibold text-neutral-700 mb-2">Trending stories</div>
+            <ul className="space-y-2">
+              {suggestions.headlines.length === 0 ? (
+                <li className="text-xs text-neutral-500">No recent stories</li>
+              ) : (
+                suggestions.headlines.map((h) => (
+                  <li key={h.slug} className="p-3 rounded-xl ring-1 ring-black/5 hover:bg-neutral-50">
+                    <a href={`/news/${h.slug}`} className="block">
+                      <div className="text-sm font-medium line-clamp-1">{h.title}</div>
+                      <div className="text-[11px] text-neutral-500">{h.publishedAt ? new Date(h.publishedAt).toLocaleString() : ""}</div>
+                    </a>
+                  </li>
+                ))
+              )}
+            </ul>
+          </div>
+        </section>
       ) : items.length === 0 ? (
-        <p className="text-neutral-600">No results yet. Try searching by headline or tag.</p>
+        <p className="text-neutral-600">No results. Try a different keyword or tag.</p>
       ) : (
         <ul className="space-y-2">
           {items.map((it) => (


### PR DESCRIPTION
## Summary
- expose `/api/search/suggestions` for popular tags and recent headlines
- show inline suggestions in header search box and full search page
- lightly cache search API responses and bump Next/React deps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a00e8d98d083298006a5ff17dba551