### PR TITLE
Harden Masonry components and add typecheck

### DIFF
--- a/frontend/components/MasonryCard.tsx
+++ b/frontend/components/MasonryCard.tsx
@@ -13,12 +13,12 @@ type Props = {
     publishedAt?: string;
     author?: { name: string; slug?: string };
   };
-  variantSeed: number;
+  variantSeed?: number;
   density?: "cozy" | "compact";
   clamp?: 2 | 3;
 };
 
-export default function MasonryCard({ item, variantSeed, density = "compact", clamp = 2 }: Props) {
+export default function MasonryCard({ item, variantSeed = 0, density = "compact", clamp = 2 }: Props) {
   const ratioClass = useMemo(() => {
     const v = variantSeed % 4;
     if (v === 0) return "aspect-[4/3]";

--- a/frontend/components/MasonryFeed.tsx
+++ b/frontend/components/MasonryFeed.tsx
@@ -1,7 +1,7 @@
 import MasonryCard from "./MasonryCard";
 import { useMemo } from "react";
 
-export default function MasonryFeed({ items, loading }: { items: any[]; loading?: boolean }) {
+export default function MasonryFeed({ items = [], loading }: { items?: any[]; loading?: boolean }) {
   const skeletons = useMemo(() => Array.from({ length: 8 }), []);
   return (
     <div className="columns-1 sm:columns-2 lg:columns-3 2xl:columns-4 gap-4 [column-fill:_balance]">

--- a/frontend/components/NotificationsBellMenu.tsx
+++ b/frontend/components/NotificationsBellMenu.tsx
@@ -3,16 +3,18 @@ import { useEffect, useState } from "react";
 type FetchFn = (ts?: number) => Promise<any[]>;
 type FetchAllFn = () => Promise<any[]>;
 
-export default function NotificationsBellMenu({ fetchSince, fetchAll }: { fetchSince?: FetchFn; fetchAll?: FetchAllFn }) {
+export default function NotificationsBellMenu({
+  fetchSince = async () => [],
+  fetchAll = async () => [],
+}: { fetchSince?: FetchFn; fetchAll?: FetchAllFn }) {
   const [open, setOpen] = useState(false);
   const [unread, setUnread] = useState(0);
   const [sinceItems, setSinceItems] = useState<any[]>([]);
   const lastVisitKey = "wn:lastVisit";
 
   useEffect(() => {
-    const fn: FetchFn = fetchSince ?? (async () => []);
     const last = Number((typeof window !== "undefined" && localStorage.getItem(lastVisitKey)) || 0);
-    fn(last || undefined)
+    fetchSince(last || undefined)
       .then(rows => { setSinceItems(rows || []); setUnread((rows || []).length); })
       .catch(() => { setSinceItems([]); setUnread(0); });
   }, []);

--- a/frontend/models/Post.ts
+++ b/frontend/models/Post.ts
@@ -35,6 +35,7 @@ const PostSchema = new Schema<PostDoc>(
 PostSchema.index({ publishedAt: -1 });
 PostSchema.index({ tags: 1, publishedAt: -1 });
 PostSchema.index({ title: "text", excerpt: "text" }); // requires MongoDB text index support
+PostSchema.index({ slug: 1 }, { unique: true });
 
 export default (mongoose.models.Post as mongoose.Model<PostDoc>) ||
   mongoose.model<PostDoc>("Post", PostSchema);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "typecheck": "tsc --noEmit",
+    "build": "tsc --noEmit && next build",
     "start": "next start",
     "test": "echo \"No tests yet\" && exit 0",
     "postinstall": "node -v && npm -v"

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -174,7 +174,7 @@ export default function HomePage() {
         {loading
           ? <div className="text-gray-500 text-sm mt-4" role="status">Loading latest stories…</div>
           : <div className="mt-3">
-              <MasonryFeed articles={articles} />
+              <MasonryFeed items={articles} />
             </div>
         }
       </main>

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -9,11 +9,13 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "types": ["node", "react", "react-dom"],
+    "typeRoots": ["./node_modules/@types"],
 
     // 🔧 Alias fix
     "baseUrl": ".",


### PR DESCRIPTION
## Summary
- make MasonryFeed items prop optional with default
- support missing variantSeed and safe defaults for NotificationsBellMenu
- add typecheck script and enforce slug uniqueness

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*
- `npm start` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a3c55ea483299a1753c822c02e33