### PR TITLE
feat: add auto-fetching breaking ticker

### DIFF
--- a/frontend/components/BreakingTicker.tsx
+++ b/frontend/components/BreakingTicker.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { useMemo } from "react";
+import { useEffect, useState } from "react";
 
 type TickerItem = {
   slug: string;
@@ -9,35 +9,51 @@ type TickerItem = {
 };
 
 type Props = {
-  /** Optional list of items to show. If empty, we render a placeholder. */
+  /** Optional pre-supplied items. If omitted, the ticker fetches /api/news/breaking. */
   items?: TickerItem[];
-  /** Optional placeholder text when there are no items */
+  /** Optional placeholder text when there are no items. */
   emptyText?: string;
 };
 
-export default function BreakingTicker({ items = [], emptyText = "No breaking updates" }: Props) {
-  // Prioritize #breaking / #alert / isBreaking
-  const prioritized = useMemo(() => {
-    const score = (it: TickerItem) => {
-      const tags = (it.tags || []).map((t) => t.toLowerCase());
-      let s = 0;
-      if (it.isBreaking) s += 5;
-      if (tags.includes("breaking") || tags.includes("#breaking")) s += 4;
-      if (tags.includes("alert") || tags.includes("#alert")) s += 3;
-      return s;
+export default function BreakingTicker({ items, emptyText = "No breaking updates" }: Props) {
+  const [autoItems, setAutoItems] = useState<TickerItem[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // If no items prop provided, self-fetch from API
+  useEffect(() => {
+    if (items && items.length >= 0) return; // respect provided props (including empty array)
+    let isMounted = true;
+    const run = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch("/api/news/breaking");
+        const json = await res.json();
+        if (!isMounted) return;
+        setAutoItems(Array.isArray(json.items) ? json.items : []);
+      } catch {
+        if (!isMounted) return;
+        setAutoItems([]);
+      } finally {
+        if (isMounted) setLoading(false);
+      }
     };
-    return [...items].sort((a, b) => score(b) - score(a));
+    run();
+    return () => {
+      isMounted = false;
+    };
   }, [items]);
 
-  const hasItems = prioritized.length > 0;
+  const list: TickerItem[] = items ?? autoItems ?? [];
+  const hasItems = Array.isArray(list) && list.length > 0;
 
   return (
     <div className="w-full border-b bg-neutral-50">
       <div className="max-w-7xl mx-auto px-3 md:px-4 py-2 flex items-center gap-3 overflow-x-auto no-scrollbar">
         <span className="text-xs font-semibold uppercase tracking-wide text-red-700">Breaking</span>
+
         {hasItems ? (
           <ul className="flex items-center gap-4 text-sm">
-            {prioritized.map((it) => (
+            {list.map((it) => (
               <li key={it.slug} className="shrink-0">
                 <Link href={`/news/${it.slug}`} className="hover:underline">
                   {it.title}
@@ -46,7 +62,9 @@ export default function BreakingTicker({ items = [], emptyText = "No breaking up
             ))}
           </ul>
         ) : (
-          <span className="text-sm text-neutral-600">{emptyText}</span>
+          <span className="text-sm text-neutral-600">
+            {loading ? "Loading…" : emptyText}
+          </span>
         )}
       </div>
     </div>

--- a/frontend/lib/server/queries.ts
+++ b/frontend/lib/server/queries.ts
@@ -1,10 +1,33 @@
 import Post from "@/models/Post";
 
+/** Return breaking posts, including tag-based breaking. */
 export async function getBreaking(limit = 10) {
-  return Post.find({ isBreaking: true }).sort({ publishedAt: -1 }).limit(limit).lean();
+  // Prefer explicit breaking flag or tags
+  const breaking = await Post.find({
+    $or: [
+      { isBreaking: true },
+      { tags: { $in: ["breaking", "#breaking", "alert", "#alert"] } },
+    ],
+  })
+    .sort({ publishedAt: -1 })
+    .limit(limit)
+    .lean();
+
+  if (breaking.length > 0) return breaking;
+
+  // Fallback: trending by engagement, newest first (keeps ticker populated)
+  const trending = await Post.find({})
+    .sort({ engagementScore: -1, publishedAt: -1 })
+    .limit(limit)
+    .lean();
+
+  return trending;
 }
 
 export async function getHeroBundle() {
-  const rail = await Post.find({}).sort({ engagementScore: -1, publishedAt: -1 }).limit(4).lean();
+  const rail = await Post.find({})
+    .sort({ engagementScore: -1, publishedAt: -1 })
+    .limit(4)
+    .lean();
   return { primary: rail[0] || null, rail: rail.slice(1) };
 }

--- a/frontend/pages/api/news/breaking.ts
+++ b/frontend/pages/api/news/breaking.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { dbConnect } from "@/lib/server/db";
+import { getBreaking } from "@/lib/server/queries";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") return res.status(405).json({ error: "Method not allowed" });
+
+  await dbConnect();
+
+  const limit = Math.max(1, Math.min(20, parseInt(String(req.query.limit || "10"), 10) || 10));
+  const items = await getBreaking(limit);
+
+  // Small cache to help the homepage
+  res.setHeader("Cache-Control", "s-maxage=20, stale-while-revalidate=20");
+  res.json({
+    items: items.map((p) => ({
+      slug: p.slug,
+      title: p.title,
+      tags: Array.isArray(p.tags) ? p.tags : [],
+      isBreaking:
+        !!p.isBreaking ||
+        (Array.isArray(p.tags) &&
+          p.tags.some((t) => ["breaking", "#breaking", "alert", "#alert"].includes(String(t).toLowerCase()))),
+    })),
+  });
+}
+


### PR DESCRIPTION
## Summary
- expand getBreaking to recognize tag-based alerts and fallback to trending posts
- add `/api/news/breaking` endpoint
- allow BreakingTicker to auto-fetch breaking posts when no items provided

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find type definition file for 'node', 'react', 'react-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68a144276b5c8329b3f54ce41217c3f4