### PR TITLE
feat: add notifications API and page

### DIFF
--- a/frontend/components/NotificationsBellMenu.tsx
+++ b/frontend/components/NotificationsBellMenu.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { useEffect, useState } from "react";
 
 type FetchFn = (ts?: number) => Promise<any[]>;
@@ -58,7 +59,7 @@ export default function NotificationsBellMenu({
             ))}
           </ul>
           <footer className="p-2 text-right">
-            <a href="/notifications" className="text-sm text-blue-600 hover:underline">Open all</a>
+            <Link href="/notifications" className="text-sm text-blue-700 hover:underline">Open all</Link>
           </footer>
         </div>
       )}

--- a/frontend/pages/api/notifications.ts
+++ b/frontend/pages/api/notifications.ts
@@ -1,0 +1,87 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { dbConnect } from "@/lib/server/db";
+import Event from "@/models/Event";
+import Post from "@/models/Post";
+
+/**
+ * GET /api/notifications
+ * Query:
+ *   - since?: number (ms epoch)
+ *   - limit?: number (1..50) default 20
+ *
+ * Returns lightweight items suitable for the bell and full page.
+ * We surface public events only, and resolve post slugs for linking.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") return res.status(405).json({ error: "Method not allowed" });
+
+  await dbConnect();
+
+  const limit = Math.max(1, Math.min(50, parseInt(String(req.query.limit ?? "20"), 10) || 20));
+  const since = req.query.since ? new Date(Number(req.query.since)) : null;
+
+  const allowedTypes = ["article_published", "thread_hot", "follow", "like"] as const;
+
+  const match: any = {
+    visibility: "public",
+    type: { $in: allowedTypes },
+  };
+  if (since && !isNaN(since.getTime())) {
+    match.createdAt = { $gt: since };
+  }
+
+  // Pull events newest first
+  const events = await Event.find(match)
+    .sort({ createdAt: -1 })
+    .limit(limit)
+    .lean();
+
+  // Resolve posts for any targetIds that are posts
+  const targetIds = events.map((e: any) => e.targetId).filter(Boolean);
+  const posts = targetIds.length
+    ? await Post.find({ _id: { $in: targetIds } }).select("_id slug title").lean()
+    : [];
+  const postById = new Map(posts.map((p: any) => [String(p._id), p]));
+
+  const items = events.map((e: any) => {
+    const createdAt = e.createdAt instanceof Date ? e.createdAt : new Date(e.createdAt);
+    const base = {
+      id: String(e._id),
+      type: e.type as string,
+      createdAt: createdAt.toISOString(),
+    };
+
+    // Try resolve to a post href/title
+    const p = e.targetId ? postById.get(String(e.targetId)) : null;
+    if (p) {
+      return {
+        ...base,
+        href: `/news/${p.slug}`,
+        title: p.title,
+        summary:
+          e.type === "article_published"
+            ? "New story published"
+            : e.type === "thread_hot"
+            ? "Trending story update"
+            : e.redactedText || "",
+      };
+    }
+
+    // Fallback: non-post event or unresolved target
+    return {
+      ...base,
+      href: null as string | null,
+      title:
+        e.type === "follow"
+          ? "New follow activity"
+          : e.type === "like"
+          ? "Someone liked a story you follow"
+          : "Update",
+      summary: e.redactedText || "",
+    };
+  });
+
+  // Small CDN-friendly cache
+  res.setHeader("Cache-Control", "s-maxage=30, stale-while-revalidate=60");
+  res.json({ items });
+}

--- a/frontend/pages/notifications.tsx
+++ b/frontend/pages/notifications.tsx
@@ -1,0 +1,130 @@
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+type Notice = {
+  id: string;
+  type: string;
+  createdAt: string; // ISO
+  href: string | null;
+  title: string;
+  summary?: string;
+};
+
+export default function NotificationsPage() {
+  const [items, setItems] = useState<Notice[] | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    const run = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch("/api/notifications?limit=50");
+        const json = await res.json();
+        if (!alive) return;
+        setItems(Array.isArray(json.items) ? json.items : []);
+      } catch {
+        if (!alive) return;
+        setItems([]);
+      } finally {
+        if (alive) setLoading(false);
+      }
+    };
+    run();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-6">
+      <h1 className="text-2xl font-semibold mb-1">Notifications</h1>
+      <p className="text-sm text-neutral-600 mb-4">
+        Important updates from authors you follow and story alerts.
+      </p>
+
+      {loading ? (
+        <div className="space-y-2">
+          <div className="h-16 rounded-xl bg-neutral-200 animate-pulse" />
+          <div className="h-16 rounded-xl bg-neutral-200 animate-pulse" />
+          <div className="h-16 rounded-xl bg-neutral-200 animate-pulse" />
+        </div>
+      ) : !items || items.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <ul className="space-y-2">
+          {items.map((n) => (
+            <li
+              key={n.id}
+              className="rounded-xl ring-1 ring-black/5 bg-white p-3 hover:bg-neutral-50"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-sm font-medium line-clamp-1">
+                    {n.href ? (
+                      <Link href={n.href} className="hover:underline">
+                        {n.title}
+                      </Link>
+                    ) : (
+                      n.title
+                    )}
+                  </div>
+                  {n.summary ? (
+                    <div className="text-xs text-neutral-600 line-clamp-2 mt-0.5">
+                      {n.summary}
+                    </div>
+                  ) : null}
+                </div>
+                <time
+                  className="shrink-0 text-[11px] text-neutral-500"
+                  dateTime={n.createdAt}
+                  title={new Date(n.createdAt).toLocaleString()}
+                >
+                  {timeAgo(n.createdAt)}
+                </time>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="rounded-2xl ring-1 ring-black/5 bg-white p-6">
+      <h2 className="text-lg font-semibold">You’re all caught up</h2>
+      <p className="text-sm text-neutral-600 mt-1">
+        When authors you follow publish or a story trends, updates will appear here.
+      </p>
+      <div className="mt-4 flex flex-wrap gap-2">
+        <Link
+          href="/"
+          className="inline-flex items-center rounded-lg px-3 py-2 text-sm font-medium bg-neutral-900 text-white hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500"
+        >
+          Browse latest stories
+        </Link>
+        <Link
+          href="/profile"
+          className="inline-flex items-center rounded-lg px-3 py-2 text-sm font-medium bg-white ring-1 ring-black/10 hover:bg-neutral-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500"
+        >
+          Follow tags & authors
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function timeAgo(iso: string) {
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const s = Math.max(1, Math.floor((now - then) / 1000));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}


### PR DESCRIPTION
## Summary
- add API endpoint to fetch public notification events and resolve post links
- add notifications page with friendly empty state
- link bell menu to full notifications page using Next.js Link

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find type definition file for 'node', 'react', 'react-dom')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/marked)*

------
https://chatgpt.com/codex/tasks/task_e_68a14c3bf8e48329a533463bb42429ad