### PR TITLE
Revamp homepage hero and article layouts

### DIFF
--- a/frontend/components/MasonryCard.tsx
+++ b/frontend/components/MasonryCard.tsx
@@ -1,73 +1,54 @@
 import Link from "next/link";
-import { useMemo } from "react";
 
 type Props = {
-  item: {
-    id: string;
-    slug: string;
-    title: string;
-    excerpt: string;
-    image?: string;
-    tags?: string[];
-    engagementScore?: number;
-    publishedAt?: string;
-    author?: { name: string; slug?: string };
-  };
-  variantSeed?: number;
-  density?: "cozy" | "compact";
-  clamp?: 2 | 3;
+  slug: string;
+  title: string;
+  excerpt?: string;
+  coverImage?: string;
+  tags?: string[];
+  publishedAt?: string | Date;
 };
 
-export default function MasonryCard({ item, variantSeed = 0, density = "compact", clamp = 2 }: Props) {
-  const ratioClass = useMemo(() => {
-    const v = variantSeed % 4;
-    if (v === 0) return "aspect-[4/3]";
-    if (v === 1) return "aspect-[16/9]";
-    if (v === 2) return "aspect-[3/4]";
-    return "aspect-square";
-  }, [variantSeed]);
-
-  const pad = density === "compact" ? "p-3" : "p-4";
-  const titleSize = density === "compact" ? "text-base" : "text-lg";
-  const excerptSize = density === "compact" ? "text-sm" : "text-[15px]";
-
+export default function MasonryCard({
+  slug,
+  title,
+  excerpt,
+  coverImage,
+  tags = [],
+  publishedAt,
+}: Props) {
   return (
-    <article className={`group rounded-2xl shadow-sm ring-1 ring-black/5 bg-white overflow-hidden hover:shadow-md transition-shadow`}>
-      {item.image ? (
-        <div className={`w-full ${ratioClass} overflow-hidden`}>
+    <article className="rounded-xl overflow-hidden ring-1 ring-black/5 bg-white hover:bg-neutral-50">
+      {coverImage ? (
+        <div className="relative w-full" style={{ paddingTop: "56.25%" }}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={item.image}
-            alt={item.title}
-            className="h-full w-full object-cover group-hover:scale-[1.02] transition-transform"
-            loading="lazy"
-          />
+          <img src={coverImage} alt="" className="absolute inset-0 w-full h-full object-cover" />
         </div>
       ) : null}
-      <div className={`${pad} grid gap-2`}>
-        <h3 className={`${titleSize} font-semibold leading-snug line-clamp-2`}>
-          <Link href={`/news/${item.slug}`} className="outline-none focus:ring-2 focus:ring-blue-500 rounded">
-            {item.title}
+      <div className="p-3">
+        <h3 className="text-sm font-semibold leading-snug">
+          <Link href={`/news/${slug}`} className="hover:underline">
+            {title}
           </Link>
         </h3>
-
-        <p className={`${excerptSize} text-neutral-700 line-clamp-${clamp}`}>
-          {item.excerpt}
-        </p>
-
-        <div className="mt-1 flex items-center justify-between">
-          <div className="flex flex-wrap gap-1">
-            {item.tags?.slice(0, 3).map(t => (
-              <span key={t} className="text-xs px-2 py-0.5 bg-neutral-100 rounded-full">{t}</span>
+        {excerpt ? <p className="mt-1 text-xs text-neutral-700 line-clamp-2">{excerpt}</p> : null}
+        {tags.length ? (
+          <div className="mt-1 flex flex-wrap gap-1">
+            {tags.slice(0, 3).map((t) => (
+              <span
+                key={t}
+                className="text-[10px] px-1.5 py-0.5 rounded bg-neutral-100 text-neutral-700"
+              >
+                #{String(t).replace(/^#/, "")}
+              </span>
             ))}
           </div>
-          {item.publishedAt ? (
-            <time className="text-xs text-neutral-500" dateTime={item.publishedAt}>
-              {new Date(item.publishedAt).toLocaleDateString()}
-            </time>
-          ) : null}
+        ) : null}
+        <div className="mt-1 text-[11px] text-neutral-500">
+          {publishedAt ? new Date(publishedAt).toLocaleDateString() : ""}
         </div>
       </div>
     </article>
   );
 }
+

--- a/frontend/components/MasonryFeed.tsx
+++ b/frontend/components/MasonryFeed.tsx
@@ -1,19 +1,22 @@
 import MasonryCard from "./MasonryCard";
-import { useMemo } from "react";
 
-export default function MasonryFeed({ items = [], loading }: { items?: any[]; loading?: boolean }) {
-  const skeletons = useMemo(() => Array.from({ length: 8 }), []);
+type Item = {
+  slug: string;
+  title: string;
+  excerpt?: string;
+  coverImage?: string;
+  tags?: string[];
+  publishedAt?: string | Date;
+};
+
+export default function MasonryFeed({ items = [] as Item[] }) {
+  if (!items.length) return null;
   return (
-    <div className="columns-1 sm:columns-2 lg:columns-3 2xl:columns-4 gap-4 [column-fill:_balance]">
-      {(loading ? skeletons : items).map((it, i) => (
-        <div key={loading ? i : it.id} className="mb-4 break-inside-avoid">
-          {loading ? (
-            <div className="animate-pulse rounded-2xl bg-neutral-100 h-64" />
-          ) : (
-            <MasonryCard item={it} variantSeed={it.variantSeed} density="compact" clamp={2} />
-          )}
-        </div>
+    <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+      {items.map((it) => (
+        <MasonryCard key={it.slug} {...it} />
       ))}
-    </div>
+    </section>
   );
 }
+

--- a/frontend/components/ShareRow.tsx
+++ b/frontend/components/ShareRow.tsx
@@ -1,23 +1,32 @@
-export default function ShareRow({ title, url }: { title: string; url: string }) {
+type Props = {
+  title?: string;
+  url?: string;
+  className?: string;
+};
+
+export default function ShareRow({ title, url, className = "" }: Props) {
+  const currentUrl = url || (typeof window !== "undefined" ? window.location.href : "");
+  const currentTitle = title || (typeof document !== "undefined" ? document.title : "");
+
   async function nativeShare() {
     if ((navigator as any).share) {
       try {
-        await (navigator as any).share({ title, url });
+        await (navigator as any).share({ title: currentTitle, url: currentUrl });
       } catch {}
     } else {
       try {
-        await navigator.clipboard.writeText(url);
+        await navigator.clipboard.writeText(currentUrl);
       } catch {}
       alert("Link copied!");
     }
   }
   const enc = encodeURIComponent;
-  const tw = `https://twitter.com/intent/tweet?text=${enc(title)}&url=${enc(url)}`;
-  const wa = `https://api.whatsapp.com/send?text=${enc(title + " " + url)}`;
-  const fb = `https://www.facebook.com/sharer/sharer.php?u=${enc(url)}`;
+  const tw = `https://twitter.com/intent/tweet?text=${enc(currentTitle)}&url=${enc(currentUrl)}`;
+  const wa = `https://api.whatsapp.com/send?text=${enc(currentTitle + " " + currentUrl)}`;
+  const fb = `https://www.facebook.com/sharer/sharer.php?u=${enc(currentUrl)}`;
 
   return (
-    <div className="mt-3 flex items-center gap-3 text-sm">
+    <div className={`flex items-center gap-3 text-sm ${className}`.trim()}>
       <button onClick={nativeShare} className="rounded-xl border px-3 py-1.5 hover:bg-neutral-50">
         Share
       </button>

--- a/frontend/pages/author/[slug].tsx
+++ b/frontend/pages/author/[slug].tsx
@@ -1,0 +1,186 @@
+import { GetServerSideProps } from "next";
+import Link from "next/link";
+import { dbConnect } from "@/lib/server/db";
+import Post from "@/models/Post";
+import User from "@/models/User";
+
+type Props = {
+  author: {
+    name: string;
+    bio?: string;
+    avatarUrl?: string;
+    slug: string;
+    counts: { posts: number; followers?: number };
+  };
+  posts: Array<{ slug: string; title: string; publishedAt?: string; tags?: string[] }>;
+};
+
+export default function AuthorProfile({ author, posts }: Props) {
+  return (
+    <main className="max-w-4xl mx-auto px-4 py-6">
+      <header className="flex items-start gap-4 mb-6">
+        {author.avatarUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={author.avatarUrl}
+            alt=""
+            className="h-16 w-16 rounded-full ring-1 ring-black/5 object-cover"
+          />
+        ) : (
+          <div className="h-16 w-16 rounded-full ring-1 ring-black/5 bg-neutral-100" />
+        )}
+        <div className="min-w-0">
+          <h1 className="text-2xl font-bold leading-tight">{author.name}</h1>
+          {author.bio ? (
+            <p className="text-sm text-neutral-700 mt-1">{author.bio}</p>
+          ) : (
+            <p className="text-sm text-neutral-600 mt-1">Reporter at WaterNewsGY.</p>
+          )}
+          <div className="mt-2 text-xs text-neutral-600">
+            {author.counts.posts} {author.counts.posts === 1 ? "story" : "stories"}
+            {typeof author.counts.followers === "number"
+              ? ` • ${author.counts.followers} followers`
+              : ""}
+          </div>
+          {/* Local follow toggle (visitors use localStorage; no auth required) */}
+          <FollowButton name={author.name} />
+        </div>
+      </header>
+
+      {posts.length === 0 ? (
+        <div className="rounded-2xl ring-1 ring-black/5 bg-white p-6">
+          <h2 className="text-lg font-semibold">No stories yet</h2>
+          <p className="text-sm text-neutral-600 mt-1">
+            When {author.name} publishes, stories will appear here.
+          </p>
+          <div className="mt-4">
+            <Link
+              href="/"
+              className="inline-flex items-center rounded-lg px-3 py-2 text-sm font-medium bg-neutral-900 text-white hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500"
+            >
+              Browse latest stories
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <section className="space-y-2">
+          {posts.map((p) => (
+            <article key={p.slug} className="p-3 rounded-xl ring-1 ring-black/5 bg-white hover:bg-neutral-50">
+              <Link
+                href={`/news/${p.slug}`}
+                className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 rounded"
+              >
+                <div className="text-sm font-medium line-clamp-1">{p.title}</div>
+                <div className="mt-1 text-[11px] text-neutral-500">
+                  {p.publishedAt ? new Date(p.publishedAt).toLocaleDateString() : ""}
+                </div>
+                {Array.isArray(p.tags) && p.tags.length ? (
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {p.tags.slice(0, 3).map((t) => (
+                      <span
+                        key={t}
+                        className="text-[10px] px-1.5 py-0.5 rounded bg-neutral-100 text-neutral-700"
+                      >
+                        #{String(t).replace(/^#/, "")}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+              </Link>
+            </article>
+          ))}
+        </section>
+      )}
+    </main>
+  );
+}
+
+function FollowButton({ name }: { name: string }) {
+  // Minimal localStorage follow; merge with server later if user logs in
+  const key = "waternews_follows_authors";
+  const id = `author:${name.toLowerCase()}`;
+  const isBrowser = typeof window !== "undefined";
+  const followed = isBrowser
+    ? (() => {
+        try {
+          const raw = localStorage.getItem(key);
+          const arr = raw ? (JSON.parse(raw) as string[]) : [];
+          return arr.includes(id);
+        } catch {
+          return false;
+        }
+      })()
+    : false;
+
+  function toggle() {
+    if (!isBrowser) return;
+    try {
+      const raw = localStorage.getItem(key);
+      const arr = raw ? (JSON.parse(raw) as string[]) : [];
+      const set = new Set(arr);
+      if (set.has(id)) set.delete(id);
+      else set.add(id);
+      localStorage.setItem(key, JSON.stringify([...set]));
+      // quick visual feedback; in real UI, this would re-render
+      alert(set.has(id) ? "Followed" : "Unfollowed");
+    } catch {}
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      className="mt-2 inline-flex items-center rounded-lg px-3 py-1.5 text-sm font-medium bg-white ring-1 ring-black/10 hover:bg-neutral-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500"
+    >
+      {followed ? "Following" : "Follow"}
+    </button>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ params }) => {
+  await dbConnect();
+  const slug = String(params?.slug || "").toLowerCase();
+
+  // Try to find a User with a compatible slug/username field
+  let user = await User.findOne({
+    $or: [{ slug }, { username: slug }],
+  })
+    .select("name bio avatarUrl slug followersCount")
+    .lean()
+    .catch(() => null as any);
+
+  // Find posts that match author by slug or approximate name
+  const nameRegex = new RegExp("^" + slug.replace(/-/g, "\\s+"), "i");
+  const posts = await Post.find({
+    $or: [{ authorSlug: slug }, { author: nameRegex }, { byline: nameRegex }],
+  })
+    .sort({ publishedAt: -1 })
+    .limit(50)
+    .select("slug title publishedAt tags author byline")
+    .lean();
+
+  const derivedName: string =
+    user?.name ||
+    posts[0]?.author ||
+    posts[0]?.byline ||
+    slug
+      .split("-")
+      .map((s: string) => s.charAt(0).toUpperCase() + s.slice(1))
+      .join(" ");
+
+  const author = {
+    name: derivedName,
+    bio: user?.bio || "",
+    avatarUrl: user?.avatarUrl || "",
+    slug: user?.slug || slug,
+    counts: { posts: posts.length, followers: user?.followersCount },
+  };
+
+  return {
+    props: {
+      author: JSON.parse(JSON.stringify(author)),
+      posts: JSON.parse(JSON.stringify(posts)),
+    },
+  };
+};
+


### PR DESCRIPTION
## Summary
- Improve homepage hero scoring and layout with fixed image ratios
- Simplify Masonry feed cards and grid layout
- Redesign article page with readable prose, author links, and sharing
- Add author profile page with local follow toggle
- Generalize ShareRow for default title/url handling

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68a155b7de988329902508d877c3306e