### PR TITLE
Add reader preferences and improve auth UI

### DIFF
--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -2,18 +2,21 @@ import Link from 'next/link'
 
 export default function Footer() {
   return (
-    <footer className="mt-10 w-full bg-black text-neutral-200">
-      <div className="max-w-7xl mx-auto px-4 py-6 text-sm">
-        <div className="flex flex-wrap items-center gap-4">
-          <Link href="/about" className="hover:underline text-neutral-200">About</Link>
-          <Link href="/contact" className="hover:underline text-neutral-200">Contact</Link>
-          <Link href="/suggest" className="hover:underline text-neutral-200">Suggest a Story</Link>
-          <Link href="/privacy" className="hover:underline text-neutral-200">Privacy Policy</Link>
-          <span className="opacity-50">•</span>
-          <Link href="/login" className="hover:underline text-neutral-200">Login</Link>
+    <footer className="mt-8 border-t bg-black text-neutral-200">
+      <div className="max-w-7xl mx-auto px-3 md:px-4 py-6 text-sm">
+        <nav className="flex flex-wrap gap-4 mb-2">
+          <Link href="/about" className="hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 rounded">About</Link>
+          <Link href="/contact" className="hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 rounded">Contact</Link>
+          <Link href="/suggest" className="hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 rounded">Suggest a Story</Link>
+          <Link href="/privacy" className="hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 rounded">Privacy Policy</Link>
+          <Link href="/prefs" className="hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 rounded">Preferences</Link>
+          <Link href="/login" className="hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 rounded">Login</Link>
+        </nav>
+        <div className="text-neutral-400">
+          © {new Date().getFullYear()} WaterNewsGY
         </div>
-        <div className="mt-2 text-xs text-neutral-400">© {new Date().getFullYear()} WaterNewsGY</div>
       </div>
     </footer>
   )
 }
+

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,58 +1,186 @@
-import { useState } from 'react'
+import { useEffect, useId, useState } from 'react'
 import { signIn, signOut, useSession } from 'next-auth/react'
 import Link from 'next/link'
 
 export default function Login() {
-  const { data: session } = useSession()
+  const { data: session, status } = useSession()
+
+  const [mode, setMode] = useState<'login'|'register'>('login')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const [mode, setMode] = useState<'login'|'register'>('login')
+  const [showPw, setShowPw] = useState(false)
   const [err, setErr] = useState<string>('')
+
+  const emailId = useId()
+  const pwId = useId()
+  const errId = useId()
+
+  useEffect(() => setErr(''), [mode])
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setErr('')
+
     if (mode === 'register') {
-      const res = await fetch('/api/auth/register', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password })
-      })
-      const json = await res.json()
-      if (!res.ok) return setErr(json.error || 'Registration failed')
+      try {
+        const res = await fetch('/api/auth/register', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password })
+        })
+        const json = await res.json()
+        if (!res.ok) return setErr(json?.error || 'Registration failed')
+      } catch {
+        return setErr('Network error during registration')
+      }
     }
-    const res = await signIn('credentials', { email, password, redirect: true, callbackUrl: '/profile' })
+
+    const res = await signIn('credentials', {
+      email,
+      password,
+      redirect: true,
+      callbackUrl: '/profile'
+    })
+
+    // next-auth returns an object with error in some cases
     if ((res as any)?.error) setErr((res as any).error)
+  }
+
+  if (status === 'loading') {
+    return (
+      <main className="max-w-md mx-auto p-6">
+        <div className="h-40 rounded-2xl bg-neutral-200 animate-pulse" />
+      </main>
+    )
   }
 
   if (session?.user) {
     return (
-      <div className="max-w-md mx-auto px-4 py-10 space-y-6">
-        <h1 className="text-3xl font-bold">You’re signed in</h1>
-        <div className="text-gray-700 text-sm">Signed in as {(session.user as any).email}</div>
-        <div className="flex gap-4">
-          <Link className="text-blue-700 underline" href="/profile">Go to Profile</Link>
-          <button onClick={() => signOut({ callbackUrl: '/' })} className="text-red-600 underline">Sign out</button>
+      <main className="max-w-md mx-auto p-6">
+        <div className="rounded-2xl ring-1 ring-black/5 bg-white p-6">
+          <h1 className="text-2xl font-semibold">You’re signed in</h1>
+          <p className="text-sm text-neutral-700 mt-1">Signed in as {(session.user as any).email}</p>
+          <div className="mt-4 flex gap-2">
+            <Link
+              href="/profile"
+              className="inline-flex items-center rounded-lg px-3 py-2 text-sm font-medium bg-neutral-900 text-white hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500"
+            >
+              Go to Profile
+            </Link>
+            <button
+              type="button"
+              onClick={() => signOut({ callbackUrl: '/' })}
+              className="inline-flex items-center rounded-lg px-3 py-2 text-sm font-medium bg-white ring-1 ring-black/10 hover:bg-neutral-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 text-red-700"
+            >
+              Sign out
+            </button>
+          </div>
         </div>
-      </div>
+        <div className="mt-4">
+          <Link href="/" className="text-blue-700 underline">← Back to Home</Link>
+        </div>
+      </main>
     )
   }
 
   return (
-    <div className="max-w-md mx-auto px-4 py-10 space-y-6">
-      <h1 className="text-3xl font-bold">Author {mode === 'login' ? 'Login' : 'Register'}</h1>
-      {err && <div className="text-red-600 text-sm">{err}</div>}
-      <form onSubmit={onSubmit} className="space-y-3">
-        <input className="w-full border rounded px-3 py-2" type="email" placeholder="Email" value={email} onChange={e=>setEmail(e.target.value)} required />
-        <input className="w-full border rounded px-3 py-2" type="password" placeholder="Password" value={password} onChange={e=>setPassword(e.target.value)} required />
-        <button className="px-4 py-2 bg-blue-600 text-white rounded">{mode === 'login' ? 'Sign in' : 'Create account'}</button>
-      </form>
-      <button onClick={() => setMode(mode === 'login' ? 'register' : 'login')} className="text-sm text-blue-700 underline">
-        {mode === 'login' ? 'Create an author account' : 'I already have an account'}
-      </button>
-      <div className="pt-6">
+    <main className="max-w-md mx-auto p-6">
+      <div className="rounded-2xl ring-1 ring-black/5 bg-white p-6">
+        <h1 className="text-2xl font-semibold">Author {mode === 'login' ? 'Login' : 'Register'}</h1>
+        <p className="text-sm text-neutral-600 mt-1">
+          Readers don’t need an account. Authors sign in to create and publish.
+        </p>
+
+        {err && (
+          <div
+            id={errId}
+            role="alert"
+            className="mt-3 rounded-lg bg-red-50 text-red-800 text-sm px-3 py-2 ring-1 ring-red-200"
+          >
+            {err}
+          </div>
+        )}
+
+        <form className="mt-4 space-y-3" onSubmit={onSubmit} noValidate>
+          <div>
+            <label htmlFor={emailId} className="block text-sm font-medium">
+              Email <span aria-hidden="true" className="text-red-600">*</span>
+              <span className="sr-only">required</span>
+            </label>
+            <input
+              id={emailId}
+              name="email"
+              type="email"
+              required
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              aria-invalid={Boolean(err)}
+              aria-describedby={err ? errId : undefined}
+              className="mt-1 w-full rounded-lg border px-3 py-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500"
+              placeholder="you@example.com"
+            />
+          </div>
+
+          <div>
+            <label htmlFor={pwId} className="block text-sm font-medium">
+              Password <span aria-hidden="true" className="text-red-600">*</span>
+              <span className="sr-only">required</span>
+            </label>
+            <div className="mt-1 flex rounded-lg border overflow-hidden focus-within:ring-2 focus-within:ring-neutral-500">
+              <input
+                id={pwId}
+                name="password"
+                type={showPw ? 'text' : 'password'}
+                required
+                autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full px-3 py-2 outline-none"
+                placeholder={mode === 'login' ? 'Your password' : 'Create a password'}
+                aria-invalid={Boolean(err)}
+                aria-describedby={err ? errId : undefined}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPw(s => !s)}
+                className="px-3 text-sm text-neutral-700 hover:bg-neutral-50"
+                aria-pressed={showPw}
+                aria-label={showPw ? 'Hide password' : 'Show password'}
+              >
+                {showPw ? 'Hide' : 'Show'}
+              </button>
+            </div>
+            {mode === 'register' && (
+              <p className="mt-1 text-xs text-neutral-600">
+                Tip: Use a strong phrase; you’ll see any server-side requirements if they apply.
+              </p>
+            )}
+          </div>
+
+          <div className="pt-2 flex items-center justify-between">
+            <button
+              type="submit"
+              className="inline-flex items-center rounded-lg px-4 py-2 text-sm font-medium bg-neutral-900 text-white hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500"
+            >
+              {mode === 'login' ? 'Sign in' : 'Create account'}
+            </button>
+
+            <button
+              type="button"
+              onClick={() => setMode(mode === 'login' ? 'register' : 'login')}
+              className="text-sm text-blue-700 underline focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 rounded"
+            >
+              {mode === 'login' ? 'Create an author account' : 'I already have an account'}
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <div className="mt-4">
         <Link href="/" className="text-blue-700 underline">← Back to Home</Link>
       </div>
-    </div>
+    </main>
   )
 }
+

--- a/frontend/pages/prefs.tsx
+++ b/frontend/pages/prefs.tsx
@@ -1,0 +1,262 @@
+import { useEffect, useId, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { getFollowedAuthors, getFollowedTags, toggleFollowAuthor, toggleFollowTag } from '@/utils/follow'
+
+type Cadence = 'realtime' | 'daily' | 'off'
+const CADENCE_KEY = 'wn_notify_cadence'
+
+export default function PreferencesPage() {
+  const [authors, setAuthors] = useState<string[]>([])
+  const [tags, setTags] = useState<string[]>([])
+  const [cadence, setCadence] = useState<Cadence>('realtime')
+  const [authorInput, setAuthorInput] = useState('')
+  const [tagInput, setTagInput] = useState('')
+  const [json, setJson] = useState('')
+
+  const cadenceId = useId()
+
+  // Load from localStorage on mount
+  useEffect(() => {
+    try {
+      setAuthors(Array.from(getFollowedAuthors()))
+      setTags(Array.from(getFollowedTags()))
+      const c = (localStorage.getItem(CADENCE_KEY) as Cadence) || 'realtime'
+      setCadence(c)
+    } catch {}
+  }, [])
+
+  const prefsJson = useMemo(() => {
+    return JSON.stringify(
+      {
+        authors,
+        tags,
+        cadence
+      },
+      null,
+      2
+    )
+  }, [authors, tags, cadence])
+
+  const addAuthor = () => {
+    const v = authorInput.trim()
+    if (!v) return
+    const following = toggleFollowAuthor(v)
+    setAuthors((list) => {
+      const set = new Set(list)
+      if (following) set.add(v)
+      else set.delete(v)
+      return Array.from(set)
+    })
+    setAuthorInput('')
+  }
+
+  const removeAuthor = (id: string) => {
+    const following = toggleFollowAuthor(id) // toggles off if present
+    if (!following) setAuthors(list => list.filter(a => a !== id))
+  }
+
+  const addTag = () => {
+    const v = tagInput.trim().toLowerCase().replace(/^#/, '')
+    if (!v) return
+    const following = toggleFollowTag(v)
+    setTags((list) => {
+      const set = new Set(list)
+      if (following) set.add(v)
+      else set.delete(v)
+      return Array.from(set)
+    })
+    setTagInput('')
+  }
+
+  const removeTag = (t: string) => {
+    const following = toggleFollowTag(t) // toggles off if present
+    if (!following) setTags(list => list.filter(x => x !== t))
+  }
+
+  const saveCadence = (c: Cadence) => {
+    setCadence(c)
+    try { localStorage.setItem(CADENCE_KEY, c) } catch {}
+  }
+
+  const doExport = () => {
+    setJson(prefsJson)
+  }
+
+  const doImport = () => {
+    try {
+      const data = JSON.parse(json || '{}')
+      const importedAuthors: string[] = Array.isArray(data.authors) ? data.authors : []
+      const importedTags: string[] = Array.isArray(data.tags) ? data.tags : []
+      const importedCadence: Cadence = (['realtime','daily','off'].includes(data.cadence) ? data.cadence : 'realtime') as Cadence
+
+      // Replace local sets with imported values
+      // (Use utils to ensure consistent serialization)
+      for (const a of authors) toggleFollowAuthor(a) // clear existing
+      for (const t of tags) toggleFollowTag(t)
+      for (const a of importedAuthors) if (a) toggleFollowAuthor(String(a))
+      for (const t of importedTags) if (t) toggleFollowTag(String(t))
+
+      setAuthors(Array.from(getFollowedAuthors()))
+      setTags(Array.from(getFollowedTags()))
+      saveCadence(importedCadence)
+      alert('Imported preferences')
+    } catch {
+      alert('Invalid JSON — please check and try again')
+    }
+  }
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-6">
+      <header className="mb-4">
+        <h1 className="text-2xl font-semibold">Preferences</h1>
+        <p className="text-sm text-neutral-600">
+          These settings are saved on this device only. No account required.
+        </p>
+      </header>
+
+      {/* Followed authors */}
+      <section className="rounded-2xl ring-1 ring-black/5 bg-white p-4 mb-4">
+        <h2 className="text-lg font-semibold">Authors you follow</h2>
+        <div className="mt-2 flex gap-2">
+          <input
+            type="text"
+            value={authorInput}
+            onChange={(e) => setAuthorInput(e.target.value)}
+            placeholder="Add author (slug, name, or id)"
+            className="flex-1 rounded-lg border px-3 py-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500"
+          />
+          <button
+            type="button"
+            onClick={addAuthor}
+            className="rounded-lg px-3 py-2 text-sm font-medium bg-neutral-900 text-white hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500"
+          >
+            Add
+          </button>
+        </div>
+
+        {authors.length === 0 ? (
+          <p className="mt-3 text-sm text-neutral-600">
+            You’re not following any authors. Follow from an author page or add one above.
+          </p>
+        ) : (
+          <ul className="mt-3 flex flex-wrap gap-2">
+            {authors.map((a) => (
+              <li key={a} className="inline-flex items-center gap-2 rounded-full bg-neutral-100 text-neutral-800 px-3 py-1">
+                <span className="text-sm">{a}</span>
+                <button
+                  type="button"
+                  onClick={() => removeAuthor(a)}
+                  className="text-xs text-neutral-600 hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 rounded"
+                  aria-label={`Unfollow ${a}`}
+                  title="Unfollow"
+                >
+                  ✕
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Followed tags */}
+      <section className="rounded-2xl ring-1 ring-black/5 bg-white p-4 mb-4">
+        <h2 className="text-lg font-semibold">Tags you follow</h2>
+        <div className="mt-2 flex gap-2">
+          <input
+            type="text"
+            value={tagInput}
+            onChange={(e) => setTagInput(e.target.value)}
+            placeholder="Add tag (e.g., #floods)"
+            className="flex-1 rounded-lg border px-3 py-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500"
+          />
+          <button
+            type="button"
+            onClick={addTag}
+            className="rounded-lg px-3 py-2 text-sm font-medium bg-neutral-900 text-white hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500"
+          >
+            Add
+          </button>
+        </div>
+
+        {tags.length === 0 ? (
+          <p className="mt-3 text-sm text-neutral-600">
+            You’re not following any tags. Try topics like <span className="font-medium">#floods</span> or <span className="font-medium">#infrastructure</span>.
+          </p>
+        ) : (
+          <ul className="mt-3 flex flex-wrap gap-2">
+            {tags.map((t) => (
+              <li key={t} className="inline-flex items-center gap-2 rounded-full bg-neutral-100 text-neutral-800 px-3 py-1">
+                <span className="text-sm">#{t.replace(/^#/, '')}</span>
+                <button
+                  type="button"
+                  onClick={() => removeTag(t)}
+                  className="text-xs text-neutral-600 hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 rounded"
+                  aria-label={`Unfollow ${t}`}
+                  title="Unfollow"
+                >
+                  ✕
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Notification cadence */}
+      <section className="rounded-2xl ring-1 ring-black/5 bg-white p-4 mb-4">
+        <h2 className="text-lg font-semibold">Notifications</h2>
+        <label htmlFor={cadenceId} className="block text-sm font-medium">
+          Cadence
+        </label>
+        <select
+          id={cadenceId}
+          className="mt-1 rounded-lg border px-3 py-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500"
+          value={cadence}
+          onChange={(e) => saveCadence(e.target.value as Cadence)}
+        >
+          <option value="realtime">Realtime (site only)</option>
+          <option value="daily">Daily summary (site only)</option>
+          <option value="off">Off</option>
+        </select>
+        <p className="text-xs text-neutral-600 mt-1">
+          Stored locally in your browser — not sent to a server.
+        </p>
+      </section>
+
+      {/* Export / Import */}
+      <section className="rounded-2xl ring-1 ring-black/5 bg-white p-4">
+        <h2 className="text-lg font-semibold">Export / Import</h2>
+        <div className="mt-2 flex gap-2">
+          <button
+            type="button"
+            onClick={doExport}
+            className="rounded-lg px-3 py-2 text-sm font-medium bg-white ring-1 ring-black/10 hover:bg-neutral-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500"
+          >
+            Export to JSON
+          </button>
+          <button
+            type="button"
+            onClick={doImport}
+            className="rounded-lg px-3 py-2 text-sm font-medium bg-neutral-900 text-white hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500"
+          >
+            Import from JSON
+          </button>
+        </div>
+        <textarea
+          className="mt-2 w-full min-h-[140px] rounded-lg border px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500"
+          placeholder="Paste exported JSON here…"
+          value={json}
+          onChange={(e) => setJson(e.target.value)}
+        />
+        <p className="text-xs text-neutral-600 mt-1">
+          Tip: Export on one device and import on another to carry over your preferences.
+        </p>
+      </section>
+
+      <div className="mt-6">
+        <Link href="/" className="text-blue-700 underline">← Back to Home</Link>
+      </div>
+    </main>
+  )
+}
+


### PR DESCRIPTION
## Summary
- Improve author login and registration UX with accessible forms and password toggle
- Add reader preferences page for local followed authors/tags with export/import
- Link to preferences in footer and sync author follow button with shared utils

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find type definition file for 'node', 'react', 'react-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68a1dc62c2e08329ac61c20a8e404c9c