### PR TITLE
chore: add mongoose and marked type stubs

### DIFF
--- a/frontend/types/marked.d.ts
+++ b/frontend/types/marked.d.ts
@@ -1,0 +1,1 @@
+declare module 'marked';

--- a/frontend/types/mongoose.d.ts
+++ b/frontend/types/mongoose.d.ts
@@ -1,0 +1,1 @@
+declare module 'mongoose';


### PR DESCRIPTION
## Summary
- add type stubs for `mongoose` and `marked` to satisfy the compiler

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'prop-types', 'webidl-conversions', and 'whatwg-url')*

------
https://chatgpt.com/codex/tasks/task_e_68a1ed1335cc83299c59452e15973b7e