### PR TITLE
chore: add local type stubs

### DIFF
--- a/frontend/components/SearchBox.tsx
+++ b/frontend/components/SearchBox.tsx
@@ -1,4 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 
 function useDebounced<T>(value: T, delay = 250) {
   const [v, setV] = useState(value);
@@ -74,7 +79,7 @@ export default function SearchBox() {
     };
   }, []);
 
-  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const onKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
     if (!open || !items.length) return;
     if (e.key === "ArrowDown") {
       e.preventDefault();

--- a/frontend/components/icons.tsx
+++ b/frontend/components/icons.tsx
@@ -1,13 +1,13 @@
-import React from 'react'
+import type { SVGProps } from 'react'
 
-export const SearchIcon = (props: React.SVGProps<SVGSVGElement>) => (
+export const SearchIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" {...props}>
     <circle cx="11" cy="11" r="7"></circle>
     <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
   </svg>
 )
 
-export const BellIcon = (props: React.SVGProps<SVGSVGElement>) => (
+export const BellIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" {...props}>
     <path d="M6 8a6 6 0 1 1 12 0c0 7 3 7 3 9H3c0-2 3-2 3-9"></path>
     <path d="M10 21a2 2 0 0 0 4 0"></path>

--- a/frontend/models/Audit.ts
+++ b/frontend/models/Audit.ts
@@ -1,7 +1,6 @@
-import mongoose from "mongoose";
-const { Schema, models, model } = (mongoose as any);
+import mongoose, { Schema, models, model, type Model } from "mongoose";
 
-export type AuditDoc = {
+export interface AuditDoc {
   _id: string;
   action:
     | "ingest_create"
@@ -17,17 +16,17 @@ export type AuditDoc = {
   next?: any;                  // minimal next state snapshot
   meta?: Record<string, any>;  // arbitrary context (e.g., reason)
   createdAt: Date;
-};
+}
 
-const AuditSchema = new (Schema as any)(
+const AuditSchema = new Schema<AuditDoc>(
   {
     action: { type: String, required: true },
     actorId: { type: String, default: null, index: true },
     targetKind: { type: String, required: true, index: true },
     targetId: { type: String, required: true, index: true },
-    prev: { type: (Schema as any).Types.Mixed },
-    next: { type: (Schema as any).Types.Mixed },
-    meta: { type: (Schema as any).Types.Mixed },
+    prev: { type: Schema.Types.Mixed },
+    next: { type: Schema.Types.Mixed },
+    meta: { type: Schema.Types.Mixed },
   },
   { timestamps: { createdAt: true, updatedAt: false } }
 );
@@ -35,5 +34,5 @@ const AuditSchema = new (Schema as any)(
 AuditSchema.index({ targetKind: 1, targetId: 1, createdAt: -1 });
 AuditSchema.index({ action: 1, createdAt: -1 });
 
-export default (models && (models as any).Audit) ||
-  (model as any)("Audit", AuditSchema);
+const Audit = (models.Audit as Model<AuditDoc>) || model<AuditDoc>("Audit", AuditSchema);
+export default Audit;

--- a/frontend/models/Draft.ts
+++ b/frontend/models/Draft.ts
@@ -1,14 +1,13 @@
-import mongoose from "mongoose";
-const { Schema, models, model } = (mongoose as any);
+import mongoose, { Schema, models, model, type Model } from "mongoose";
 
-export type DraftSource = {
+export interface DraftSource {
   kind: "thread" | "post" | "note" | "external";
   refId: string;      // e.g., thread id, post id, URL, etc.
   hash: string;       // stable hash of source payload
   label?: string;     // human label shown in UI
-};
+}
 
-export type DraftDoc = {
+export interface DraftDoc {
   _id: string;
   title: string;
   slug: string;
@@ -23,16 +22,16 @@ export type DraftDoc = {
   sources?: DraftSource[]; // NEW
   createdAt: Date;
   updatedAt: Date;
-};
+}
 
-const DraftSourceSchema = new (Schema as any)({
+const DraftSourceSchema = new Schema<DraftSource>({
   kind: { type: String, enum: ["thread", "post", "note", "external"], required: true },
   refId: { type: String, required: true },
   hash: { type: String, required: true },
   label: { type: String },
 });
 
-const DraftSchema = new (Schema as any)(
+const DraftSchema = new Schema<DraftDoc>(
   {
     title: { type: String, required: true },
     slug: { type: String, required: true, index: true, unique: true },
@@ -49,5 +48,5 @@ const DraftSchema = new (Schema as any)(
   { timestamps: true }
 );
 
-export default (models && (models as any).Draft) ||
-  (model as any)("Draft", DraftSchema);
+const Draft = (models.Draft as Model<DraftDoc>) || model<DraftDoc>("Draft", DraftSchema);
+export default Draft;

--- a/frontend/models/Event.ts
+++ b/frontend/models/Event.ts
@@ -1,7 +1,6 @@
-import mongoose from "mongoose";
-const { Schema, models, model } = (mongoose as any);
+import mongoose, { Schema, models, model, type Model } from "mongoose";
 
-export type EventDoc = {
+export interface EventDoc {
   _id: string;
   type:
     | "article_published"
@@ -24,9 +23,9 @@ export type EventDoc = {
 
   createdAt: Date;
   updatedAt: Date;
-};
+}
 
-const EventSchema = new (Schema as any)(
+const EventSchema = new Schema<EventDoc>(
   {
     type: { type: String, required: true },
     actorId: { type: String, default: null },
@@ -51,5 +50,5 @@ EventSchema.index({ actorId: 1, createdAt: -1 });
 EventSchema.index({ status: 1, updatedAt: -1 });
 EventSchema.index({ assignedTo: 1, status: 1 });
 
-export default (models && (models as any).Event) ||
-  (model as any)("Event", EventSchema);
+const Event = (models.Event as Model<EventDoc>) || model<EventDoc>("Event", EventSchema);
+export default Event;

--- a/frontend/models/Post.ts
+++ b/frontend/models/Post.ts
@@ -1,7 +1,6 @@
-import mongoose from "mongoose";
-const { Schema, models, model } = (mongoose as any);
+import mongoose, { Schema, models, model, type Model } from "mongoose";
 
-export type PostDoc = {
+export interface PostDoc {
   _id: string;
   slug: string;
   title: string;
@@ -14,9 +13,9 @@ export type PostDoc = {
   authorId?: string | null;
   engagementScore?: number;
   isBreaking?: boolean;
-};
+}
 
-const PostSchema = new (Schema as any)(
+const PostSchema = new Schema<PostDoc>(
   {
     slug: { type: String, required: true, index: true, unique: true },
     title: { type: String, required: true },
@@ -38,5 +37,5 @@ PostSchema.index({ tags: 1, publishedAt: -1 });
 PostSchema.index({ title: "text", excerpt: "text" }); // requires MongoDB text index support
 PostSchema.index({ slug: 1 }, { unique: true });
 
-export default (models && (models as any).Post) ||
-  (model as any)("Post", PostSchema);
+const Post = (models.Post as Model<PostDoc>) || model<PostDoc>("Post", PostSchema);
+export default Post;

--- a/frontend/models/User.ts
+++ b/frontend/models/User.ts
@@ -1,4 +1,4 @@
-import { Schema, models, model, type Model } from 'mongoose'
+import mongoose, { Schema, models, model, type Model } from 'mongoose'
 
 export interface IUser {
   name?: string

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useState } from 'react'
+import { useEffect, useId, useState, type FormEvent } from 'react'
 import { signIn, signOut, useSession } from 'next-auth/react'
 import Link from 'next/link'
 
@@ -17,7 +17,7 @@ export default function Login() {
 
   useEffect(() => setErr(''), [mode])
 
-  const onSubmit = async (e: React.FormEvent) => {
+  const onSubmit = async (e: FormEvent) => {
     e.preventDefault()
     setErr('')
 

--- a/frontend/pages/profile.tsx
+++ b/frontend/pages/profile.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type FormEvent } from 'react'
 import { useSession } from 'next-auth/react'
 import Link from 'next/link'
 
@@ -21,7 +21,7 @@ export default function Profile() {
     load()
   }, [session])
 
-  const save = async (e: React.FormEvent) => {
+  const save = async (e: FormEvent) => {
     e.preventDefault()
     setMsg('')
     const res = await fetch('/api/users/update', {

--- a/frontend/types/ambient-mods.d.ts
+++ b/frontend/types/ambient-mods.d.ts
@@ -1,4 +1,8 @@
 // Loosen unresolved packages when registry blocks installs
-declare module "mongoose" { const v: any; export default v; export = v; }
 declare module "marked" { const v: any; export default v; export = v; }
+declare module "prop-types" { const v: any; export default v; export = v; }
+declare module "webidl-conversions" { const v: any; export default v; export = v; }
+declare module "whatwg-url" { const v: any; export default v; export = v; }
+declare module "axios" { const v: any; export default v; export = v; }
+declare module "bcryptjs" { const v: any; export default v; export = v; }
 

--- a/frontend/types/mongoose/index.d.ts
+++ b/frontend/types/mongoose/index.d.ts
@@ -1,0 +1,35 @@
+// Minimal mongoose declarations for local typechecking
+declare module "mongoose" {
+  export const Types: {
+    ObjectId: any;
+    Mixed: any;
+    [key: string]: any;
+  };
+
+  export class Schema<T = any> {
+    constructor(definition?: any, options?: any);
+    index(fields: any, options?: any): void;
+    static Types: typeof Types;
+  }
+
+  export interface Model<T = any> {
+    new (doc?: any): T & { save: (...args: any[]) => Promise<T> };
+    [key: string]: any;
+  }
+
+  export const model: <T = any>(name: string, schema?: Schema<any>) => Model<T>;
+  export const models: Record<string, Model<any>>;
+
+  export function connect(uri: string, options?: any): Promise<any>;
+  export const connection: any;
+
+  const mongoose: {
+    model: typeof model;
+    models: typeof models;
+    Schema: typeof Schema;
+    Types: typeof Types;
+    connect: typeof connect;
+    connection: any;
+  };
+  export default mongoose;
+}

--- a/frontend/types/next-auth/index.d.ts
+++ b/frontend/types/next-auth/index.d.ts
@@ -1,0 +1,24 @@
+// Lightweight NextAuth helpers for local typechecking
+declare module "next-auth" {
+  export interface NextAuthOptions {
+    [key: string]: any;
+  }
+  const NextAuth: (options: NextAuthOptions) => any;
+  export default NextAuth;
+  export function getServerSession(...args: any[]): Promise<any>;
+}
+
+declare module "next-auth/react" {
+  export function useSession(): any;
+  export function signIn(provider?: string, options?: any): Promise<any>;
+  export function signOut(options?: any): Promise<any>;
+  export const SessionProvider: any;
+}
+
+declare module "next-auth/providers/credentials" {
+  export default function Credentials(config?: any): any;
+}
+
+declare module "next-auth/next" {
+  export function getServerSession(...args: any[]): Promise<any>;
+}

--- a/frontend/types/next/index.d.ts
+++ b/frontend/types/next/index.d.ts
@@ -16,11 +16,8 @@ declare module "next/router" {
   const _default: any;
   export default _default;
 }
-declare module "next-auth/react" {
-  export const useSession: any;
-  export const signIn: any;
-  export const signOut: any;
-  export const SessionProvider: any;
+declare module "next/app" {
+  export type AppProps = any;
 }
 declare module "next" {
   export interface NextApiRequest {

--- a/frontend/types/react/index.d.ts
+++ b/frontend/types/react/index.d.ts
@@ -1,11 +1,15 @@
 // Extremely minimal React types to allow TS to typecheck without @types/react
 declare namespace JSX {
   interface IntrinsicElements { [elemName: string]: any }
+  interface IntrinsicAttributes { key?: any }
 }
 
 declare module "react" {
   export type ReactNode = any;
   export type FC<P = {}> = (props: P & { children?: ReactNode }) => any;
+  export interface SVGProps<T> { [key: string]: any }
+  export interface KeyboardEvent<T = Element> { key: string; target: T; preventDefault(): void; [key: string]: any }
+  export interface FormEvent<T = Element> { currentTarget: T; preventDefault(): void; [key: string]: any }
 
   export function useState<S = any>(initial?: S): [S, (s: S | ((p: S) => S)) => void];
   export function useEffect(effect: (...args: any[]) => any, deps?: any[]): void;


### PR DESCRIPTION
## Summary
- add lightweight module declarations and stub packages
- type domain models and components with local stubs
- include minimal typings for Next.js, NextAuth, React, and Mongoose

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a247fb191c832980f2949bf5713a43