### PR TITLE
fix(ts): drop fetchpriority attr and loosen SearchBox types

### DIFF
--- a/frontend/components/MasonryCard.tsx
+++ b/frontend/components/MasonryCard.tsx
@@ -43,7 +43,6 @@ export default function MasonryCard({
             className="absolute inset-0 w-full h-full object-cover"
             loading="lazy"
             referrerPolicy="no-referrer"
-            fetchpriority="low"
           />
         </div>
       ) : null}

--- a/frontend/components/SearchBox.tsx
+++ b/frontend/components/SearchBox.tsx
@@ -1,9 +1,4 @@
-import {
-  useEffect,
-  useRef,
-  useState,
-  type KeyboardEvent as ReactKeyboardEvent,
-} from "react";
+import { useEffect, useRef, useState } from "react";
 
 function useDebounced<T>(value: T, delay = 250) {
   const [v, setV] = useState(value);
@@ -79,7 +74,8 @@ export default function SearchBox() {
     };
   }, []);
 
-  const onKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
+  // Loosen typing to avoid duplicate React module type mismatch in CI
+  const onKeyDown = (e: any) => {
     if (!open || !items.length) return;
     if (e.key === "ArrowDown") {
       e.preventDefault();

--- a/frontend/pages/news/[slug].tsx
+++ b/frontend/pages/news/[slug].tsx
@@ -129,7 +129,6 @@ export default function NewsArticlePage({ post, prev, next }: Props) {
                       alt=""
                       className="aspect-video object-cover group-hover:opacity-90"
                       loading="lazy"
-                      fetchpriority="low"
                     />
                   </button>
                 ))}


### PR DESCRIPTION
## Summary
- remove unsupported `fetchpriority` prop from image tags
- loosen `SearchBox` onKeyDown typing to avoid React type conflicts

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a24f0370e08329955a3f8852f2b201