### PR TITLE
Implement global layout, theme control, and categories telemetry

### DIFF
--- a/frontend/components/DarkModeToggle.tsx
+++ b/frontend/components/DarkModeToggle.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
  * - Persists to localStorage("theme") = "dark" | "light"
  * - Applies/removes the "dark" class on <html>
  */
-export default function DarkModeToggle() {
+export default function DarkModeToggle({ variant = "icon" }: { variant?: "icon" | "button" }) {
   const [ready, setReady] = useState(false);
   const [dark, setDark] = useState(false);
 
@@ -33,7 +33,7 @@ export default function DarkModeToggle() {
 
   // Avoid layout shift until hydrated
   if (!ready) return (
-    <button aria-label="Toggle dark mode" className="w-9 h-9 rounded-full opacity-60 bg-neutral-200 dark:bg-neutral-800" />
+    <button aria-label="Toggle dark mode" className="w-9 h-9 opacity-60" />
   );
 
   return (
@@ -41,9 +41,8 @@ export default function DarkModeToggle() {
       type="button"
       aria-label={dark ? "Switch to light theme" : "Switch to dark theme"}
       onClick={toggle}
-      className="w-9 h-9 inline-flex items-center justify-center rounded-full ring-1 ring-black/10 dark:ring-white/10 hover:bg-neutral-100 dark:hover:bg-neutral-800 focus:outline-none focus-visible:ring-2"
+      className="w-9 h-9 inline-flex items-center justify-center hover:bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50"
     >
-      {/* Simple inline icons to avoid external deps */}
       {dark ? (
         <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0V5a1 1 0 0 1 1-1Zm7 7a1 1 0 0 1 1 1 8 8 0 1 1-8-8 1 1 0 1 1 0 2 6 6 0 1 0 6 6 1 1 0 0 1 1-1Z" fill="currentColor"/></svg>
       ) : (

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,32 +1,31 @@
-import Link from "next/link";
+import DarkModeToggle from "@/components/DarkModeToggle";
 import SmartMenu from "@/components/SmartMenu";
 import SearchBox from "@/components/SearchBox";
 import NotificationsBellMenu from "@/components/NotificationsBellMenu";
-import DarkModeToggle from "@/components/DarkModeToggle";
+import Link from "next/link";
 
 export default function Header() {
   return (
     <header className="sticky top-0 z-40 bg-white/90 dark:bg-neutral-950/90 backdrop-blur supports-[backdrop-filter]:bg-white/60 supports-[backdrop-filter]:dark:bg-neutral-950/60 border-b border-black/5 dark:border-white/10">
       <div className="max-w-7xl mx-auto px-3 md:px-4 h-14 flex items-center justify-between gap-3">
-        {/* Left: Logo */}
+        {/* Logo bigger */}
         <div className="flex items-center gap-3 shrink-0">
           <Link href="/" className="flex items-center gap-2">
-            {/* Use existing logo asset */}
-            <img src="/logo-waternews.svg" alt="WaterNews" className="h-7 w-auto" />
+            <img src="/logo-waternews.svg" alt="WaterNews" className="h-8 md:h-9 w-auto" />
             <span className="sr-only">WaterNews home</span>
           </Link>
         </div>
 
-        {/* Center: SmartMenu */}
+        {/* Center SmartMenu */}
         <div className="hidden md:flex flex-1 justify-center">
           <SmartMenu />
         </div>
 
-        {/* Right: Search (icon expands) · Bell · Theme */}
+        {/* Right controls: Search (icon expands left), Bell, Dark mode (no circles) */}
         <div className="flex items-center gap-2">
-          <SearchBox iconOnly />
-          <NotificationsBellMenu />
-          <DarkModeToggle />
+          <SearchBox iconOnly align="right-expand-left" />
+          <NotificationsBellMenu variant="outline" />
+          <DarkModeToggle variant="icon" />
         </div>
       </div>
     </header>

--- a/frontend/components/NotificationsBellMenu.tsx
+++ b/frontend/components/NotificationsBellMenu.tsx
@@ -7,7 +7,8 @@ type FetchAllFn = () => Promise<any[]>;
 export default function NotificationsBellMenu({
   fetchSince = async () => [],
   fetchAll = async () => [],
-}: { fetchSince?: FetchFn; fetchAll?: FetchAllFn }) {
+  variant = "outline",
+}: { fetchSince?: FetchFn; fetchAll?: FetchAllFn; variant?: string }) {
   const [open, setOpen] = useState(false);
   const [unread, setUnread] = useState(0);
   const [sinceItems, setSinceItems] = useState<any[]>([]);
@@ -28,12 +29,15 @@ export default function NotificationsBellMenu({
   return (
     <div className="relative">
       <button
-        aria-label="Notifications"
+        type="button"
+        aria-label="Open notifications"
         aria-expanded={open}
         onClick={onToggle}
-        className="relative rounded-full p-2 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className="w-9 h-9 inline-flex items-center justify-center hover:bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-6 w-6"><path d="M12 2a6 6 0 00-6 6v3.586l-1.707 1.707A1 1 0 005 15h14a1 1 0 00.707-1.707L18 11.586V8a6 6 0 00-6-6zM8 16a4 4 0 008 0H8z"/></svg>
+        <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M14 20a2 2 0 1 1-4 0m8-8a6 6 0 1 0-12 0c0 1.886-.664 3.056-1.414 3.707-.44.377-.66.565-.651.827.009.262.244.466.715.873.902.784 2.214 1.593 4.35 1.593h6c2.136 0 3.448-.809 4.35-1.593.471-.407.706-.611.715-.873.009-.262-.211-.45-.651-.827C16.664 15.056 16 13.886 16 12Z" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
         {unread > 0 && (
           <span className="absolute -top-0.5 -right-0.5 inline-flex items-center justify-center text-[10px] min-w-[18px] h-[18px] px-1 rounded-full bg-blue-600 text-white">
             {unread}

--- a/frontend/components/SearchBox.tsx
+++ b/frontend/components/SearchBox.tsx
@@ -18,10 +18,12 @@ type Item = {
 };
 
 type Props = {
-  iconOnly?: boolean; // new: renders a button that expands to input
+  iconOnly?: boolean;
+  align?: "right-expand-left" | "inline";
 };
 
 export default function SearchBox(props: Props) {
+  const { iconOnly, align = "inline" } = props;
   const [q, setQ] = useState("");
   const [items, setItems] = useState<Item[]>([]);
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -103,88 +105,89 @@ export default function SearchBox(props: Props) {
 
   const close = () => setOpen(false);
 
-  if (props.iconOnly) {
+  if (iconOnly) {
+    const container = align === "right-expand-left" ? "relative flex items-center" : "relative";
     return (
-      <div ref={rootRef} className="relative">
+      <div ref={rootRef} className={container}>
         {!open && (
           <button
             type="button"
             aria-label="Open search"
             onClick={() => setOpen(true)}
-            className="w-9 h-9 inline-flex items-center justify-center rounded-full ring-1 ring-black/10 dark:ring-white/10 hover:bg-neutral-100 dark:hover:bg-neutral-800 focus:outline-none focus-visible:ring-2"
+            className="w-9 h-9 inline-flex items-center justify-center hover:bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50"
           >
             <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M21 21l-4.35-4.35M10 18a8 8 0 1 1 0-16 8 8 0 0 1 0 16Z" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round"/>
+              <path d="M21 21l-4.35-4.35M10 18a8 8 0 1 1 0-16 8 8 0 0 1 0 16Z" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" />
             </svg>
           </button>
         )}
+
         {open && (
-          <div className="absolute right-0 top-0 w-[70vw] max-w-md">
-            <div className="flex items-center gap-2 px-3 py-2 rounded-full ring-1 ring-black/10 dark:ring-white/10 bg-white dark:bg-neutral-900 shadow-md">
-              <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M21 21l-4.35-4.35M10 18a8 8 0 1 1 0-16 8 8 0 0 1 0 16Z" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round"/>
-              </svg>
-              <input
-                ref={inputRef}
-                type="search"
-                role="combobox"
-                aria-expanded={dropdownOpen}
-                aria-controls={dropdownOpen ? listboxId : undefined}
-                aria-autocomplete="list"
-                placeholder="Search WaterNews"
-                className="flex-1 bg-transparent outline-none text-sm placeholder:opacity-70"
-                value={q}
-                onChange={(e) => setQ(e.target.value)}
-                onBlur={(e) => {
-                  setTimeout(() => setOpen(false), 100);
-                }}
-                onKeyDown={onKeyDown}
-              />
-              <button
-                type="button"
-                onClick={close}
-                aria-label="Close search"
-                className="w-7 h-7 inline-flex items-center justify-center rounded-full hover:bg-neutral-100 dark:hover:bg-neutral-800"
-              >
-                <svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round"/>
+          <div className="flex items-center gap-2">
+            <div className="relative">
+              <div className="flex items-center gap-2 ring-1 ring-black/10 dark:ring-white/10 bg-white dark:bg-neutral-900 rounded-full px-3 py-2 shadow-md origin-right transition-[width] duration-200 ease-out" style={{ width: "18rem" }}>
+                <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M21 21l-4.35-4.35M10 18a8 8 0 1 1 0-16 8 8 0 0 1 0 16Z" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" />
                 </svg>
-              </button>
-            </div>
-            {dropdownOpen && (
-              <div
-                id={listboxId}
-                role="listbox"
-                aria-label="Search results"
-                className="absolute z-40 mt-2 w-full rounded-2xl bg-white shadow-lg ring-1 ring-black/5 overflow-hidden"
-              >
-                <div className="px-3 py-2 text-xs text-neutral-600 border-b">
-                  {loading ? "Searching…" : items.length ? `Results (${items.length})` : "No results"}
-                </div>
-                <ul className="max-h-96 overflow-auto">
-                  {items.map((it, i) => (
-                    <li key={it.slug} id={optionId(i)} role="option" aria-selected={i === active}>
-                      <a
-                        href={`/news/${it.slug}`}
-                        className={["block px-3 py-2 text-sm", i === active ? "bg-neutral-50" : "", "focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500"].join(" ")}
-                        onMouseEnter={() => setActive(i)}
-                      >
-                        <div className="font-medium line-clamp-1">{it.title}</div>
-                        {it.excerpt ? (
-                          <div className="text-xs text-neutral-600 line-clamp-2">{it.excerpt}</div>
-                        ) : null}
-                        <div className="mt-0.5 text-[11px] text-neutral-500">
-                          {it.publishedAt ? new Date(it.publishedAt).toLocaleString() : ""}
-                        </div>
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-                <div className="px-3 py-2 text-xs text-neutral-600 border-t">
-                  Press <kbd className="border px-1 rounded">↵</kbd> to open
-                </div>
+                <input
+                  ref={inputRef}
+                  type="search"
+                  placeholder="Search WaterNews"
+                  className="flex-1 bg-transparent outline-none text-sm placeholder:opacity-70"
+                  value={q}
+                  onChange={(e) => setQ(e.target.value)}
+                  onBlur={() => setTimeout(() => setOpen(false), 120)}
+                  onKeyDown={onKeyDown}
+                  aria-expanded={dropdownOpen}
+                  aria-controls={dropdownOpen ? listboxId : undefined}
+                  aria-autocomplete="list"
+                />
+                <button
+                  type="button"
+                  aria-label="Close search"
+                  onClick={() => setOpen(false)}
+                  className="w-7 h-7 inline-flex items-center justify-center hover:bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50"
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" />
+                  </svg>
+                </button>
               </div>
-            )}
+              {dropdownOpen && (
+                <div
+                  id={listboxId}
+                  role="listbox"
+                  aria-label="Search results"
+                  className="absolute right-0 z-40 mt-2 w-full rounded-2xl bg-white shadow-lg ring-1 ring-black/5 overflow-hidden"
+                >
+                  <div className="px-3 py-2 text-xs text-neutral-600 border-b">
+                    {loading ? "Searching…" : items.length ? `Results (${items.length})` : "No results"}
+                  </div>
+                  <ul className="max-h-96 overflow-auto">
+                    {items.map((it, i) => (
+                      <li key={it.slug} id={optionId(i)} role="option" aria-selected={i === active}>
+                        <a
+                          href={`/news/${it.slug}`}
+                          className={["block px-3 py-2 text-sm", i === active ? "bg-neutral-50" : "", "focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500"].join(" ")}
+                          onMouseEnter={() => setActive(i)}
+                        >
+                          <div className="font-medium line-clamp-1">{it.title}</div>
+                          {it.excerpt ? (
+                            <div className="text-xs text-neutral-600 line-clamp-2">{it.excerpt}</div>
+                          ) : null}
+                          <div className="mt-0.5 text-[11px] text-neutral-500">
+                            {it.publishedAt ? new Date(it.publishedAt).toLocaleString() : ""}
+                          </div>
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                  <div className="px-3 py-2 text-xs text-neutral-600 border-t">
+                    Press <kbd className="border px-1 rounded">↵</kbd> to open
+                  </div>
+                </div>
+              )}
+            </div>
           </div>
         )}
       </div>

--- a/frontend/components/SmartMenu.tsx
+++ b/frontend/components/SmartMenu.tsx
@@ -1,14 +1,14 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 
-// Root and "More" panels
 const ROOT_ITEMS = [
   { label: "Latest", href: "/?sort=latest" },
   { label: "Trending", href: "/?sort=trending" },
   { label: "Following", href: "/?tab=following" },
 ];
 
-const MORE_ITEMS = [
+// Additional items will be appended AFTER defaults, but we keep a baked-in fallback:
+const FALLBACK_MORE = [
   { label: "Sports", href: "/?cat=sports" },
   { label: "Business", href: "/?cat=business" },
   { label: "Politics", href: "/?cat=politics" },
@@ -19,15 +19,10 @@ const MORE_ITEMS = [
 
 type Panel = "root" | "more";
 
-/**
- * SmartMenu with sliding panels:
- * - Forward arrow (→) reveals "More" categories (slides left).
- * - Back arrow (←) returns to root.
- * - Reduced motion honors prefers-reduced-motion.
- */
 export default function SmartMenu() {
   const [panel, setPanel] = useState<Panel>("root");
   const [reduced, setReduced] = useState(false);
+  const [more, setMore] = useState(FALLBACK_MORE);
 
   useEffect(() => {
     if (typeof window !== "undefined" && "matchMedia" in window) {
@@ -35,73 +30,92 @@ export default function SmartMenu() {
     }
   }, []);
 
+  // Optional server-driven categories — appended after defaults, never reorders ROOT_ITEMS
+  useEffect(() => {
+    let aborted = false;
+    (async () => {
+      try {
+        const r = await fetch("/api/categories", { headers: { "Accept": "application/json" } });
+        if (!r.ok) return;
+        const data = await r.json();
+        if (!aborted && Array.isArray(data) && data.length) {
+          // Merge while keeping FALLBACK_MORE, avoid dups by label
+          const labels = new Set(FALLBACK_MORE.map(i => i.label.toLowerCase()));
+          const merged = [...FALLBACK_MORE];
+          for (const it of data) {
+            if (!it?.label || !it?.href) continue;
+            const key = String(it.label).toLowerCase();
+            if (!labels.has(key)) {
+              labels.add(key);
+              merged.push({ label: it.label, href: it.href });
+            }
+          }
+          setMore(merged);
+        }
+      } catch { /* ignore */ }
+    })();
+    return () => { aborted = true; };
+  }, []);
+
   const transition = reduced ? "" : "transition-transform duration-300 ease-out";
-  const offset = panel === "root" ? "translate-x-0" : "-translate-x-full";
+  const baseItem =
+    "px-2 py-1.5 text-sm rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50";
 
   return (
-    <nav aria-label="Sections" className="relative overflow-hidden">
-      {/* Viewport */}
-      <div className={`w-[420px] sm:w-[520px] md:w-[640px] overflow-hidden`}>
-        <div
-          className={`flex ${transition}`}
-          style={{ transform: panel === "root" ? "translateX(0)" : "translateX(-100%)" }}
-        >
-          {/* ROOT PANEL */}
-          <ul className="flex items-center gap-3 min-w-[420px] sm:min-w-[520px] md:min-w-[640px]">
-            {ROOT_ITEMS.map(item => (
-              <li key={item.label}>
-                <Link
-                  href={item.href}
-                  className="px-2 py-1.5 text-sm rounded hover:bg-neutral-100 dark:hover:bg-neutral-800 focus:outline-none focus-visible:ring-2"
+    <nav aria-label="Sections" className="relative">
+      {/* Shaded rail */}
+      <div className="rounded-full px-2 py-1 bg-neutral-50/90 dark:bg-neutral-900/60 ring-1 ring-black/5 dark:ring-white/10">
+        {/* viewport */}
+        <div className="w-[420px] sm:w-[520px] md:w-[640px] overflow-hidden">
+          <div className={`flex ${transition}`} style={{ transform: panel === "root" ? "translateX(0)" : "translateX(-100%)" }}>
+            {/* ROOT */}
+            <ul className="flex items-center gap-2 min-w-[420px] sm:min-w-[520px] md:min-w-[640px]">
+              {ROOT_ITEMS.map(item => (
+                <li key={item.label}>
+                  <Link href={item.href} className={baseItem}>
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+              <li>
+                <button
+                  type="button"
+                  aria-label="More sections"
+                  onClick={() => setPanel("more")}
+                  className={baseItem + " inline-flex items-center gap-1"}
                 >
-                  {item.label}
-                </Link>
+                  {/* longer forward arrow */}
+                  <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M5 12h12M13 6l6 6-6 6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                  </svg>
+                </button>
               </li>
-            ))}
-            <li>
-              <button
-                type="button"
-                aria-label="More sections"
-                onClick={() => setPanel("more")}
-                className="px-2 py-1.5 text-sm rounded inline-flex items-center gap-1 hover:bg-neutral-100 dark:hover:bg-neutral-800 focus:outline-none focus-visible:ring-2"
-              >
-                {/* Forward arrow */}
-                <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M13 5l7 7-7 7M5 12h14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
-                </svg>
-              </button>
-            </li>
-          </ul>
+            </ul>
 
-          {/* MORE PANEL */}
-          <ul
-            aria-label="More sections"
-            className="flex items-center gap-3 min-w-[420px] sm:min-w-[520px] md:min-w-[640px]"
-          >
-            <li>
-              <button
-                type="button"
-                aria-label="Back to main sections"
-                onClick={() => setPanel("root")}
-                className="px-2 py-1.5 text-sm rounded inline-flex items-center gap-1 hover:bg-neutral-100 dark:hover:bg-neutral-800 focus:outline-none focus-visible:ring-2"
-              >
-                {/* Back arrow */}
-                <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M11 19l-7-7 7-7M19 12H5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
-                </svg>
-              </button>
-            </li>
-            {MORE_ITEMS.map(item => (
-              <li key={item.label}>
-                <Link
-                  href={item.href}
-                  className="px-2 py-1.5 text-sm rounded hover:bg-neutral-100 dark:hover:bg-neutral-800 focus:outline-none focus-visible:ring-2"
+            {/* MORE */}
+            <ul aria-label="More sections" className="flex items-center gap-2 min-w-[420px] sm:min-w-[520px] md:min-w-[640px]">
+              <li>
+                <button
+                  type="button"
+                  aria-label="Back to main sections"
+                  onClick={() => setPanel("root")}
+                  className={baseItem + " inline-flex items-center gap-1"}
                 >
-                  {item.label}
-                </Link>
+                  {/* longer back arrow */}
+                  <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M19 12H7M11 6l-6 6 6 6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                  </svg>
+                </button>
               </li>
-            ))}
-          </ul>
+              {more.map(item => (
+                <li key={item.label}>
+                  <Link href={item.href} className={baseItem}>
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
         </div>
       </div>
     </nav>

--- a/frontend/models/SessionEvent.ts
+++ b/frontend/models/SessionEvent.ts
@@ -1,0 +1,18 @@
+import mongoose from "mongoose";
+const { Schema } = mongoose as any;
+
+const SessionEventSchema = new Schema(
+  {
+    sessionId: { type: String, index: true, required: true },
+    type: { type: String, required: true }, // "view_category" | "open_post" | ...
+    value: { type: String },                // category/tag/slug
+    createdAt: { type: Date, default: Date.now, index: true },
+  },
+  { versionKey: false }
+);
+
+// TTL index: 14 days (1209600 seconds)
+SessionEventSchema.index({ createdAt: 1 }, { expireAfterSeconds: 1209600 });
+
+export default (mongoose as any).models.SessionEvent ||
+  (mongoose as any).model("SessionEvent", SessionEventSchema, "session_events");

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,7 +1,9 @@
-import type { AppProps } from 'next/app'
-import { SessionProvider } from 'next-auth/react'
-import '@/styles/globals.css'
-import Head from 'next/head'
+import type { AppProps } from 'next/app';
+import { SessionProvider } from 'next-auth/react';
+import '@/styles/globals.css';
+import Head from 'next/head';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
 
 export default function App({ Component, pageProps: { session, ...pageProps } }: AppProps) {
   return (
@@ -13,11 +15,18 @@ export default function App({ Component, pageProps: { session, ...pageProps } }:
         {/* <link rel="preconnect" href="https://cdn.example.com" crossOrigin="anonymous" /> */}
       </Head>
       <SessionProvider session={session}>
-        <a href="#main-content" className="skip-to-main">Skip to main content</a>
-        <div id="main-content">
+        <a
+          href="#main"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 bg-black text-white px-3 py-2 rounded"
+        >
+          Skip to main content
+        </a>
+        <Header />
+        <main id="main">
           <Component {...pageProps} />
-        </div>
+        </main>
+        <Footer />
       </SessionProvider>
     </>
-  )
+  );
 }

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -1,0 +1,27 @@
+import Document, { Html, Head, Main, NextScript } from "next/document";
+
+export default class MyDocument extends Document {
+  render() {
+    const inlineThemeInit = `
+(function() {
+  try {
+    var ls = localStorage.getItem('theme');
+    var m = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    var wantDark = (ls === 'dark') || (ls === null && m);
+    if (wantDark) document.documentElement.classList.add('dark');
+    else document.documentElement.classList.remove('dark');
+  } catch(e) {}
+})();`;
+    return (
+      <Html>
+        <Head>
+          <script dangerouslySetInnerHTML={{ __html: inlineThemeInit }} />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}

--- a/frontend/pages/api/categories.ts
+++ b/frontend/pages/api/categories.ts
@@ -1,0 +1,66 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { dbConnect } from "@/lib/server/db";
+import Post from "@/models/Post";
+import SessionEvent from "@/models/SessionEvent";
+
+const DEFAULTS = [
+  { label: "Sports", href: "/?cat=sports" },
+  { label: "Business", href: "/?cat=business" },
+  { label: "Politics", href: "/?cat=politics" },
+  { label: "Tech", href: "/?cat=tech" },
+  { label: "Weather", href: "/?cat=weather" },
+  { label: "Health", href: "/?cat=health" },
+];
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") { res.status(405).end(); return; }
+  try {
+    await dbConnect();
+
+    const sessionId = String((req.query as any).sessionId || (req as any).cookies?.sessionId || "");
+    const extras: { label: string; href: string }[] = [];
+
+    // Very light heuristic: popular tags from recent posts
+    const popular = await Post.find({}, { tags: 1 }).sort({ publishedAt: -1 }).limit(100).lean();
+    const counts = new Map<string, number>();
+    for (const p of popular) {
+      (p.tags || []).forEach((t: string) => {
+        const key = (t || "").toLowerCase();
+        if (!key) return;
+        counts.set(key, (counts.get(key) || 0) + 1);
+      });
+    }
+    const sortedTags = [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 8).map(([t]) => t);
+
+    // Personalization: session’s recent category views
+    if (sessionId) {
+      const recent = await SessionEvent.find({ sessionId, type: "view_category" })
+        .sort({ createdAt: -1 }).limit(20).lean();
+      for (const ev of recent) {
+        const t = String(ev.value || "").toLowerCase();
+        if (t && !sortedTags.includes(t)) sortedTags.unshift(t);
+      }
+    }
+
+    for (const t of sortedTags) {
+      const label = t.charAt(0).toUpperCase() + t.slice(1);
+      extras.push({ label, href: `/?cat=${encodeURIComponent(t)}` });
+      if (extras.length >= 10) break;
+    }
+
+    // Merge defaults (fixed order) + extras (dedup by label)
+    const seen = new Set(DEFAULTS.map(d => d.label.toLowerCase()));
+    const merged = [...DEFAULTS];
+    for (const e of extras) {
+      const k = e.label.toLowerCase();
+      if (!seen.has(k)) { seen.add(k); merged.push(e); }
+    }
+
+    res.setHeader("Cache-Control", "max-age=60, stale-while-revalidate=300");
+    res.status(200).json(merged);
+  } catch {
+    // Fallback: defaults only
+    res.setHeader("Cache-Control", "max-age=60, stale-while-revalidate=300");
+    res.status(200).json(DEFAULTS);
+  }
+}

--- a/frontend/pages/api/telemetry/events.ts
+++ b/frontend/pages/api/telemetry/events.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { dbConnect } from "@/lib/server/db";
+import SessionEvent from "@/models/SessionEvent";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") { res.status(405).end(); return; }
+  try {
+    await dbConnect();
+    const { sessionId, type, value } = (req.body || {}) as any;
+    if (!sessionId || !type) { res.status(400).json({ ok: false }); return; }
+    await SessionEvent.create({ sessionId, type, value, createdAt: new Date() });
+    res.setHeader("Cache-Control", "no-store");
+    res.json({ ok: true });
+  } catch (e) {
+    res.status(500).json({ ok: false });
+  }
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'class',
   content: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},

--- a/frontend/types/next/index.d.ts
+++ b/frontend/types/next/index.d.ts
@@ -19,6 +19,15 @@ declare module "next/router" {
 declare module "next/app" {
   export type AppProps = any;
 }
+declare module "next/document" {
+  export const Html: any;
+  export const Head: any;
+  export const Main: any;
+  export const NextScript: any;
+  export default class Document {
+    render(): any;
+  }
+}
 declare module "next" {
   export interface NextApiRequest {
     method?: string;


### PR DESCRIPTION
## Summary
- Add global Header and Footer with skip link
- Initialize theme on server and switch via class-based dark mode
- Polish navigation, search, and icons; add categories personalization and telemetry model

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a2c01ca8508329a04460e23a4f7950