### PR TITLE
Add global news ticker with unified API

### DIFF
--- a/frontend/components/BreakingTicker.tsx
+++ b/frontend/components/BreakingTicker.tsx
@@ -1,74 +1,140 @@
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
-type TickerItem = {
-  slug: string;
-  title: string;
-  tags?: string[];
-  isBreaking?: boolean;
-};
+type TickerItem = { slug: string; titleShort: string; summary: string };
 
-type Props = {
-  /** Optional pre-supplied items. If omitted, the ticker fetches /api/news/breaking. */
-  items?: TickerItem[];
-  /** Optional placeholder text when there are no items. */
-  emptyText?: string;
-};
+export default function BreakingTicker({ items: propItems = [] as TickerItem[] }) {
+  const [mode, setMode] = useState<"newswave" | "breaking">("newswave");
+  const [items, setItems] = useState<TickerItem[]>(propItems);
+  const [reduced, setReduced] = useState(false);
 
-export default function BreakingTicker({ items, emptyText = "No breaking updates" }: Props) {
-  const [autoItems, setAutoItems] = useState<TickerItem[] | null>(null);
-  const [loading, setLoading] = useState(false);
-
-  // Self-fetch from API if no items prop was passed
+  // Respect reduced-motion
   useEffect(() => {
-    if (items !== undefined) return; // respect provided props (even empty)
-    let alive = true;
+    if (typeof window !== "undefined" && "matchMedia" in window) {
+      setReduced(window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+    }
+  }, []);
+
+  // Auto-fetch if no items were provided
+  useEffect(() => {
+    if (propItems && propItems.length) return;
+    let aborted = false;
     (async () => {
-      setLoading(true);
       try {
-        const res = await fetch("/api/news/breaking");
-        const json = await res.json();
-        if (!alive) return;
-        setAutoItems(Array.isArray(json.items) ? json.items : []);
-      } catch {
-        if (!alive) return;
-        setAutoItems([]);
-      } finally {
-        if (alive) setLoading(false);
-      }
+        const r = await fetch("/api/news/ticker", { headers: { Accept: "application/json" } });
+        if (!r.ok) return;
+        const data = await r.json();
+        if (!aborted) {
+          setMode(data?.mode === "breaking" ? "breaking" : "newswave");
+          setItems(Array.isArray(data?.items) ? data.items : []);
+        }
+      } catch {}
     })();
-    return () => { alive = false; };
+    return () => {
+      aborted = true;
+    };
+  }, [propItems]);
+
+  // Visual theme
+  const theme = useMemo(() => {
+    if (mode === "breaking") {
+      // Breaking = strong red
+      return {
+        wrap: "bg-red-600 text-white border-b border-red-700",
+        label: "Breaking News",
+        pill: "bg-white/15 text-white ring-white/20",
+      };
+    }
+    // NewsWave = warm amber/orange
+    return {
+      wrap: "bg-amber-500 text-black border-b border-amber-600 dark:text-black",
+      label: "NewsWave",
+      pill: "bg-black/10 text-black ring-black/10",
+    };
+  }, [mode]);
+
+  // Duplicate items to form an infinite scroll loop
+  const loop = useMemo(() => {
+    const src = items.length ? items : [];
+    // Ensure minimum length for smooth loop
+    const base = src.length < 6 ? [...src, ...src, ...src] : src;
+    return [...base, ...base];
   }, [items]);
 
-  const list: TickerItem[] = items ?? autoItems ?? [];
-  const hasItems = list.length > 0;
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const [paused, setPaused] = useState(false);
+
+  if (!items.length) {
+    // Always visible bar with placeholder when empty
+    return (
+      <div
+        className={`${theme.wrap} text-sm`}
+        role="region"
+        aria-label="Live headlines"
+        aria-live="polite"
+      >
+        <div className="max-w-7xl mx-auto px-3 md:px-4 h-9 flex items-center gap-3">
+          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold ring-1 ${theme.pill}`}>
+            {theme.label}
+          </span>
+          <span className="opacity-80">No updates yet.</span>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div className="w-full border-b bg-neutral-50">
-      <div className="max-w-7xl mx-auto px-3 md:px-4 py-2 flex items-center gap-3 overflow-x-auto no-scrollbar">
-        <span className="text-[11px] font-semibold uppercase tracking-wide bg-red-50 text-red-800 px-2 py-0.5 rounded">
-          Breaking
+    <div
+      className={`${theme.wrap} text-sm`}
+      role="region"
+      aria-label="Live headlines"
+      aria-live="polite"
+    >
+      <div className="max-w-7xl mx-auto px-3 md:px-4 h-9 flex items-center gap-3 overflow-hidden">
+        <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold ring-1 ${theme.pill}`}>
+          {theme.label}
         </span>
 
-        {hasItems ? (
-          <ul className="flex items-center gap-4 text-sm">
-            {list.map((it) => (
-              <li key={it.slug} className="shrink-0">
-                <Link
-                  href={`/news/${it.slug}`}
-                  className="hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 rounded"
-                >
-                  {it.title}
-                </Link>
-              </li>
+        {/* Scrolling track */}
+        <div
+          ref={trackRef}
+          className="relative flex-1 overflow-hidden"
+          onMouseEnter={() => setPaused(true)}
+          onMouseLeave={() => setPaused(false)}
+        >
+          {/* We implement marquee-like scroll using CSS animation (no <marquee>) */}
+          <div
+            className={[
+              "whitespace-nowrap will-change-transform flex items-center gap-6",
+              reduced ? "" : "animate-[ticker_25s_linear_infinite]",
+              paused ? "paused" : "",
+            ].join(" ")}
+          >
+            {loop.map((it, idx) => (
+              <Link
+                key={`${it.slug}-${idx}`}
+                href={`/news/${it.slug}`}
+                className="inline-flex items-center gap-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-black/40 dark:focus-visible:ring-white/50"
+              >
+                <span className="font-semibold">{it.titleShort}</span>
+                {it.summary ? <span className="opacity-80">— {it.summary}</span> : null}
+              </Link>
             ))}
-          </ul>
-        ) : (
-          <span className="text-sm text-neutral-600">
-            {loading ? "Loading…" : emptyText}
-          </span>
-        )}
+          </div>
+        </div>
       </div>
+
+      {/* Inline styles for the marquee animation + pause */}
+      <style jsx>{`
+        @keyframes ticker {
+          0% { transform: translateX(0); }
+          100% { transform: translateX(-50%); }
+        }
+        .paused {
+          animation-play-state: paused !important;
+        }
+      `}</style>
     </div>
   );
 }
+

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -4,6 +4,7 @@ import '@/styles/globals.css';
 import Head from 'next/head';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import BreakingTicker from '@/components/BreakingTicker';
 
 export default function App({ Component, pageProps: { session, ...pageProps } }: AppProps) {
   return (
@@ -22,6 +23,8 @@ export default function App({ Component, pageProps: { session, ...pageProps } }:
           Skip to main content
         </a>
         <Header />
+        {/* Global ticker under header on all routes */}
+        <BreakingTicker />
         <main id="main">
           <Component {...pageProps} />
         </main>

--- a/frontend/pages/api/news/ticker.ts
+++ b/frontend/pages/api/news/ticker.ts
@@ -1,0 +1,110 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { dbConnect } from "@/lib/server/db";
+import Post from "@/models/Post";
+
+/**
+ * Returns a compact list of ticker items plus a banner mode:
+ * - mode: "newswave" | "breaking"
+ * - items: [{ slug, titleShort, summary }]
+ *
+ * Rules:
+ * - If any "breaking" post exists in the recent window, mode = "breaking" and items focus on breaking first.
+ * - Otherwise mode = "newswave" and items are latest/trending mix.
+ * - Headlines are shortened; summary uses excerpt or top tags.
+ * - HTTP caching with stale-while-revalidate for snappy global header renders.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") {
+    res.status(405).end();
+    return;
+  }
+
+  try {
+    await dbConnect();
+
+    // Look back a reasonable window (e.g., 48h) for breaking items
+    const since = new Date(Date.now() - 1000 * 60 * 60 * 48);
+
+    const breakingCandidates = await Post.find(
+      {
+        publishedAt: { $gte: since },
+        $or: [
+          { isBreaking: true },
+          { tags: { $in: ["breaking", "#breaking", "alert", "#alert"] } },
+        ],
+      },
+      { slug: 1, title: 1, excerpt: 1, tags: 1, publishedAt: 1 }
+    )
+      .sort({ publishedAt: -1 })
+      .limit(12)
+      .lean();
+
+    const hasBreaking = breakingCandidates.length > 0;
+
+    // Fill with non-breaking latest/trending if needed
+    let latest: any[] = [];
+    if (!hasBreaking) {
+      latest = await Post.find(
+        {},
+        { slug: 1, title: 1, excerpt: 1, tags: 1, engagementScore: 1, publishedAt: 1 }
+      )
+        .sort({ publishedAt: -1 })
+        .limit(30)
+        .lean();
+    } else {
+      // When in breaking mode, still include a few other items after the breaking block
+      latest = await Post.find(
+        {},
+        { slug: 1, title: 1, excerpt: 1, tags: 1, engagementScore: 1, publishedAt: 1 }
+      )
+        .sort({ engagementScore: -1, publishedAt: -1 })
+        .limit(30)
+        .lean();
+    }
+
+    const shorten = (s: string, n = 80) => {
+      if (!s) return "";
+      s = String(s).trim();
+      return s.length > n ? s.slice(0, n - 1).trimEnd() + "…" : s;
+    };
+
+    const asItem = (p: any) => {
+      const tags = (p.tags || [])
+        .map((t: string) => String(t).replace(/^#/, ""))
+        .slice(0, 3);
+      const titleShort = shorten(p.title || "", 72);
+      const summary = p.excerpt
+        ? shorten(p.excerpt, 110)
+        : tags.length
+        ? tags.join(" • ")
+        : "";
+      return { slug: p.slug, titleShort, summary };
+    };
+
+    const items: { slug: string; titleShort: string; summary: string }[] = [];
+
+    if (hasBreaking) {
+      items.push(...breakingCandidates.map(asItem));
+      // follow with a few latest/trending (dedupe by slug)
+      const seen = new Set(items.map((i) => i.slug));
+      for (const p of latest) {
+        if (seen.has(p.slug)) continue;
+        items.push(asItem(p));
+        if (items.length >= 30) break;
+      }
+    } else {
+      items.push(...latest.map(asItem).slice(0, 30));
+    }
+
+    res.setHeader("Cache-Control", "public, max-age=60, stale-while-revalidate=300");
+    res.status(200).json({
+      mode: hasBreaking ? "breaking" : "newswave",
+      items,
+    });
+  } catch (e) {
+    // Graceful fallback: empty list
+    res.setHeader("Cache-Control", "public, max-age=60, stale-while-revalidate=300");
+    res.status(200).json({ mode: "newswave", items: [] });
+  }
+}
+

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,9 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import axios from 'axios'
-import Header from '../components/Header'
-import Footer from '../components/Footer'
-import BreakingTicker from '../components/BreakingTicker'
 import Hero from '../components/Hero'
 import MasonryFeed from '../components/MasonryFeed'
 import { getFollowedAuthors, getFollowedTags, toggleFollowAuthor, toggleFollowTag, syncFollowsIfAuthed, pushServerFollows } from '../utils/follow'
@@ -148,10 +145,7 @@ export default function HomePage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
-
-      <BreakingTicker />
-      <main className="px-3 py-4 md:px-4 max-w-7xl mx-auto">
+      <div className="px-3 py-4 md:px-4 max-w-7xl mx-auto">
         {/* Contextual hero */}
         <Hero
           category={activeCategory}
@@ -177,9 +171,7 @@ export default function HomePage() {
               <MasonryFeed items={articles} />
             </div>
         }
-      </main>
-
-      <Footer />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Render BreakingTicker beneath the header in the global App layout so headlines appear on every route
- Add `/api/news/ticker` endpoint that merges breaking items with latest posts and signals ticker mode
- Rebuild BreakingTicker component with auto-fetching, CSS marquee animation, reduced-motion support and hover pause
- Remove page-level ticker/headers from the home page to avoid duplicates

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a2c71c19d483299b4ec45721fa7454