### PR TITLE
fix: remove styled-jsx prop

### DIFF
--- a/frontend/components/BreakingTicker.tsx
+++ b/frontend/components/BreakingTicker.tsx
@@ -124,8 +124,8 @@ export default function BreakingTicker({ items: propItems = [] as TickerItem[] }
         </div>
       </div>
 
-      {/* Inline styles for the marquee animation + pause */}
-      <style jsx>{`
+      {/* Inline styles for the marquee animation + pause (global <style> to avoid styled-jsx typings) */}
+      <style>{`
         @keyframes ticker {
           0% { transform: translateX(0); }
           100% { transform: translateX(-50%); }


### PR DESCRIPTION
## Summary
- replace `<style jsx>` with global `<style>` in `BreakingTicker` to avoid styled-jsx typing issue

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find type definition file for 'prop-types', 'webidl-conversions', 'whatwg-url')*
- `npm run build` *(fails: Cannot find type definition file for 'prop-types', 'webidl-conversions', 'whatwg-url')*

------
https://chatgpt.com/codex/tasks/task_e_68a2cb7e3bd48329ac1f4d87eaaeade9