### PR TITLE
Add author application and corrections flows with image placeholders

### DIFF
--- a/frontend/lib/db.js
+++ b/frontend/lib/db.js
@@ -1,0 +1,7 @@
+import { dbConnect } from "./mongodb";
+import mongoose from "mongoose";
+
+export async function getDb() {
+  await dbConnect();
+  return mongoose.connection.db;
+}

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false,
+  images: { domains: ["images.unsplash.com"] },
   // ⚠️ Emergency-only: let builds pass even with TS errors
   // typescript: {
   //   ignoreBuildErrors: true,

--- a/frontend/pages/about/index.jsx
+++ b/frontend/pages/about/index.jsx
@@ -14,7 +14,19 @@ export default function AboutPage() {
       </Head>
 
       {/* HERO */}
-      <header className="relative grid min-h-[58vh] place-items-center overflow-hidden bg-gradient-to-b from-[#0f6cad] via-[#0b5d95] to-[#0a4f7f] px-4 text-center text-white">
+      <header
+        className="relative grid min-h-[58vh] place-items-center overflow-hidden px-4 text-center text-white"
+        style={{
+          backgroundImage: `
+            radial-gradient(1200px 60% at 10% 10%, rgba(21,131,194,0.20), transparent 60%),
+            radial-gradient(1000px 70% at 80% 30%, rgba(15,108,173,0.18), transparent 60%),
+            linear-gradient(180deg, #0f6cad 0%, #0b5d95 40%, #0a4f7f 100%),
+            url(https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?q=80&w=1600&auto=format&fit=crop)
+          `,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      >
         <div className="mb-4 flex items-center justify-center gap-4">
           <Image
             src="/logo-mini.svg"
@@ -89,10 +101,14 @@ export default function AboutPage() {
               </a>
             </div>
           </div>
-          <div className="grid min-h-[220px] place-items-center rounded-xl border border-slate-200 bg-gradient-to-br from-[#e8f4fd] to-[#f7fbff] p-4 text-slate-600">
-            <p className="text-sm">
-              [Placeholder: replace with a newsroom / Caribbean community image]
-            </p>
+          <div className="relative h-[220px] w-full overflow-hidden rounded-xl">
+            <Image
+              src="https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?q=80&w=1200&auto=format&fit=crop"
+              alt="Newsroom"
+              fill
+              className="object-cover"
+              priority
+            />
           </div>
         </section>
 
@@ -212,8 +228,13 @@ export default function AboutPage() {
                 bridging local narratives with global relevance.
               </p>
             </div>
-            <div className="grid min-h-[220px] place-items-center rounded-xl border border-slate-200 bg-gradient-to-br from-[#e8f4fd] to-[#f7fbff] p-4 text-slate-600">
-              <p className="text-sm">[Placeholder: Tatiana’s headshot]</p>
+            <div className="relative h-[220px] w-full overflow-hidden rounded-xl">
+              <Image
+                src="https://images.unsplash.com/photo-1544005313-94ddf0286df2?q=80&w=900&auto=format&fit=crop"
+                alt="Headshot placeholder"
+                fill
+                className="object-cover"
+              />
             </div>
           </div>
         </section>

--- a/frontend/pages/about/masthead.jsx
+++ b/frontend/pages/about/masthead.jsx
@@ -107,12 +107,16 @@ export default function MastheadPage() {
           <div className="grid gap-4 md:grid-cols-3">
             {people.map((p) => (
               <article key={p.name} className="rounded-2xl bg-white p-5 shadow">
-                <div className="grid min-h-[120px] place-items-center rounded-md border border-slate-200 bg-gradient-to-br from-[#e8f4fd] to-[#f7fbff]">
-                  {p.headshot ? (
-                    <Image src={p.headshot} alt={p.name} width={160} height={160} className="rounded-md object-cover" />
-                  ) : (
-                    <p className="text-xs text-slate-600">[Headshot placeholder]</p>
-                  )}
+                <div className="relative h-[220px] w-full overflow-hidden rounded-xl">
+                  <Image
+                    src={
+                      p.headshot ||
+                      "https://images.unsplash.com/photo-1544005313-94ddf0286df2?q=80&w=900&auto=format&fit=crop"
+                    }
+                    alt={p.headshot ? p.name : "Headshot placeholder"}
+                    fill
+                    className="object-cover"
+                  />
                 </div>
                 <h3 className="mt-3 text-base font-semibold">{p.name}</h3>
                 <p className="m-0 text-[13px] text-slate-600">{p.role}</p>

--- a/frontend/pages/api/apply.js
+++ b/frontend/pages/api/apply.js
@@ -1,0 +1,33 @@
+import { getDb } from "@/lib/db";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+
+  const { name, email, role, beats, samples = [], bio, portfolio } = req.body || {};
+  if (!name || !email) return res.status(400).json({ error: "Name and email are required" });
+
+  const record = {
+    name,
+    email,
+    role: role || null,
+    beats: (beats || "")
+      .split(",")
+      .map((x) => x.trim())
+      .filter(Boolean),
+    samples: Array.isArray(samples) ? samples : [],
+    bio: bio || "",
+    portfolio: portfolio || "",
+    createdAt: new Date(),
+    ref: "APL-" + Date.now().toString(36).toUpperCase(),
+  };
+
+  try {
+    const db = await getDb();
+    if (db) await db.collection("applications").insertOne(record);
+    // (Optional) Add email dispatch here later
+    return res.status(200).json({ ok: true, ref: record.ref });
+  } catch (err) {
+    console.error("apply-error", err);
+    return res.status(500).json({ error: "Server error" });
+  }
+}

--- a/frontend/pages/api/corrections.js
+++ b/frontend/pages/api/corrections.js
@@ -1,0 +1,31 @@
+import { getDb } from "@/lib/db";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+
+  const { url, name, email, issue, correction } = req.body || {};
+  if (!url || !email || !issue || !correction) {
+    return res.status(400).json({ error: "Missing required fields" });
+  }
+
+  const record = {
+    url,
+    name: name || "",
+    email,
+    issue,
+    correction,
+    createdAt: new Date(),
+    status: "new",
+    ref: "COR-" + Date.now().toString(36).toUpperCase(),
+  };
+
+  try {
+    const db = await getDb();
+    if (db) await db.collection("corrections").insertOne(record);
+    // (Optional) Add email dispatch to corrections@waternewsgy.com here later
+    return res.status(200).json({ ok: true, ref: record.ref });
+  } catch (err) {
+    console.error("corrections-error", err);
+    return res.status(500).json({ error: "Server error" });
+  }
+}

--- a/frontend/pages/apply.jsx
+++ b/frontend/pages/apply.jsx
@@ -1,0 +1,115 @@
+import Head from "next/head";
+import { useState } from "react";
+
+export default function ApplyPage() {
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(null);
+  const [error, setError] = useState(null);
+
+  async function onSubmit(e) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    setDone(null);
+
+    const form = new FormData(e.currentTarget);
+    const payload = Object.fromEntries(form.entries());
+    payload.samples = (payload.samples || "")
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    try {
+      const res = await fetch("/api/apply", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error || "Failed to submit");
+      setDone(json);
+      e.currentTarget.reset();
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Apply — WaterNews</title>
+        <meta name="description" content="Apply to write for WaterNews." />
+      </Head>
+
+      <header className="bg-gradient-to-b from-[#0f6cad] via-[#0b5d95] to-[#0a4f7f] px-4 py-14 text-white">
+        <div className="mx-auto max-w-3xl">
+          <h1 className="m-0 text-3xl font-extrabold md:text-5xl">Become an Author</h1>
+          <p className="mt-2 max-w-2xl text-sm opacity-95 md:text-base">
+            Pitch your voice. We’re looking for clear, credible reporting and compelling lifestyle features.
+          </p>
+        </div>
+      </header>
+
+      <main className="mx-auto my-10 max-w-3xl px-4">
+        <form onSubmit={onSubmit} className="space-y-4 rounded-2xl bg-white p-6 shadow">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="block text-sm font-semibold">Full Name</label>
+              <input name="name" required className="mt-1 w-full rounded-lg border p-2" />
+            </div>
+            <div>
+              <label className="block text-sm font-semibold">Email</label>
+              <input type="email" name="email" required className="mt-1 w-full rounded-lg border p-2" />
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="block text-sm font-semibold">Role</label>
+              <select name="role" className="mt-1 w-full rounded-lg border p-2">
+                <option>News Reporter</option>
+                <option>Opinion/Letters</option>
+                <option>Lifestyle</option>
+                <option>Photo/Video</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-semibold">Beats (comma-separated)</label>
+              <input name="beats" placeholder="politics, economy, culture" className="mt-1 w-full rounded-lg border p-2" />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-semibold">Links to recent samples (one per line)</label>
+            <textarea name="samples" rows={4} className="mt-1 w-full rounded-lg border p-2" placeholder="https://example.com/story-1&#10;https://example.com/story-2" />
+          </div>
+
+          <div>
+            <label className="block text-sm font-semibold">Short Bio</label>
+            <textarea name="bio" rows={3} className="mt-1 w-full rounded-lg border p-2" placeholder="Tell us about your experience and interests." />
+          </div>
+
+          <div>
+            <label className="block text-sm font-semibold">Portfolio URL (optional)</label>
+            <input name="portfolio" placeholder="https://your-site.com" className="mt-1 w-full rounded-lg border p-2" />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button disabled={submitting} className="rounded-xl bg-[#1583c2] px-5 py-2 font-semibold text-white disabled:opacity-60">
+              {submitting ? "Submitting..." : "Submit Application"}
+            </button>
+            {done && <span className="text-sm text-green-700">Received — reference <strong>{done.ref}</strong></span>}
+            {error && <span className="text-sm text-red-600">Error: {error}</span>}
+          </div>
+        </form>
+
+        <p className="mt-4 text-center text-sm text-slate-600">
+          Prefer email? Send your pitch to <a className="text-[#1583c2]" href="mailto:careers@waternewsgy.com">careers@waternewsgy.com</a>.
+        </p>
+      </main>
+    </>
+  );
+}
+

--- a/frontend/pages/corrections.jsx
+++ b/frontend/pages/corrections.jsx
@@ -1,0 +1,99 @@
+import Head from "next/head";
+import { useState } from "react";
+
+export default function CorrectionsPage() {
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(null);
+  const [error, setError] = useState(null);
+
+  async function onSubmit(e) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    setDone(null);
+
+    const form = new FormData(e.currentTarget);
+    const payload = Object.fromEntries(form.entries());
+
+    try {
+      const res = await fetch("/api/corrections", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error || "Failed to submit");
+      setDone(json);
+      e.currentTarget.reset();
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Corrections — WaterNews</title>
+        <meta name="description" content="Request a correction on WaterNews content." />
+      </Head>
+
+      <header className="bg-gradient-to-b from-[#0f6cad] via-[#0b5d95] to-[#0a4f7f] px-4 py-14 text-white">
+        <div className="mx-auto max-w-3xl">
+          <h1 className="m-0 text-3xl font-extrabold md:text-5xl">Request a Correction</h1>
+          <p className="mt-2 max-w-2xl text-sm opacity-95 md:text-base">
+            If we got something wrong, tell us exactly what to fix and where.
+          </p>
+        </div>
+      </header>
+
+      <main className="mx-auto my-10 max-w-3xl px-4">
+        <form onSubmit={onSubmit} className="space-y-4 rounded-2xl bg-white p-6 shadow">
+          <div>
+            <label className="block text-sm font-semibold">Article URL</label>
+            <input name="url" type="url" required className="mt-1 w-full rounded-lg border p-2" placeholder="https://www.waternewsgy.com/article/..." />
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="block text-sm font-semibold">Your Name</label>
+              <input name="name" className="mt-1 w-full rounded-lg border p-2" />
+            </div>
+            <div>
+              <label className="block text-sm font-semibold">Email</label>
+              <input type="email" name="email" required className="mt-1 w-full rounded-lg border p-2" />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-semibold">What’s incorrect?</label>
+            <textarea name="issue" rows={4} required className="mt-1 w-full rounded-lg border p-2" placeholder="Quote the exact line, figure, or claim." />
+          </div>
+
+          <div>
+            <label className="block text-sm font-semibold">What’s the correct information?</label>
+            <textarea name="correction" rows={3} required className="mt-1 w-full rounded-lg border p-2" placeholder="Provide the correction and supporting link(s), if any." />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button disabled={submitting} className="rounded-xl bg-[#1583c2] px-5 py-2 font-semibold text-white disabled:opacity-60">
+              {submitting ? "Sending..." : "Send Correction"}
+            </button>
+            {done && <span className="text-sm text-green-700">Received — reference <strong>{done.ref}</strong></span>}
+            {error && <span className="text-sm text-red-600">Error: {error}</span>}
+          </div>
+        </form>
+
+        <p className="mt-4 text-center text-sm text-slate-600">
+          Or email us directly at{" "}
+          <a className="text-[#1583c2]" href="mailto:corrections@waternewsgy.com">
+            corrections@waternewsgy.com
+          </a>
+          .
+        </p>
+      </main>
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable Mongo helper
- provide /apply and /corrections forms with persistence APIs
- refresh About and Masthead pages with Unsplash placeholder images

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a33e7f396083299afcd71cb759b4b3