### PR TITLE
Revamp header with inline search and global dark mode

### DIFF
--- a/frontend/components/BreakingTicker.tsx
+++ b/frontend/components/BreakingTicker.tsx
@@ -40,16 +40,16 @@ export default function BreakingTicker({ items: propItems = [] as TickerItem[] }
     if (mode === "breaking") {
       // Breaking = strong red
       return {
-        wrap: "bg-red-600 text-white border-b border-red-700",
+        wrap: "bg-red-600 text-white",
         label: "Breaking News",
         pill: "bg-white/15 text-white ring-white/20",
       };
     }
-    // NewsWave = warm amber/orange
+    // NewsWave = brand subtle
     return {
-      wrap: "bg-amber-500 text-black border-b border-amber-600 dark:text-black",
+      wrap: "bg-brand/5 text-slate-900 dark:bg-slate-700/40",
       label: "NewsWave",
-      pill: "bg-black/10 text-black ring-black/10",
+      pill: "bg-black/10 text-black ring-black/10 dark:bg-white/10 dark:text-white/90 dark:ring-white/20",
     };
   }, [mode]);
 
@@ -70,7 +70,7 @@ export default function BreakingTicker({ items: propItems = [] as TickerItem[] }
       <div
         className={`${theme.wrap} text-sm`}
         role="region"
-        aria-label="Live headlines"
+        aria-label={mode === "breaking" ? "Breaking News" : "NewsWave headlines"}
         aria-live="polite"
       >
         <div className="max-w-7xl mx-auto px-3 md:px-4 h-9 flex items-center gap-3">
@@ -87,7 +87,7 @@ export default function BreakingTicker({ items: propItems = [] as TickerItem[] }
     <div
       className={`${theme.wrap} text-sm`}
       role="region"
-      aria-label="Live headlines"
+      aria-label={mode === "breaking" ? "Breaking News" : "NewsWave headlines"}
       aria-live="polite"
     >
       <div className="max-w-7xl mx-auto px-3 md:px-4 h-9 flex items-center gap-3 overflow-hidden">

--- a/frontend/components/DarkModeToggle.tsx
+++ b/frontend/components/DarkModeToggle.tsx
@@ -2,17 +2,17 @@ import { useEffect, useState } from "react";
 
 /**
  * Minimal dark-mode toggle.
- * - Persists to localStorage("theme") = "dark" | "light"
+ * - Persists to localStorage("wn-theme") = "dark" | "light"
  * - Applies/removes the "dark" class on <html>
  */
-export default function DarkModeToggle({ variant = "icon" }: { variant?: "icon" | "button" }) {
+export default function DarkModeToggle() {
   const [ready, setReady] = useState(false);
   const [dark, setDark] = useState(false);
 
   useEffect(() => {
     // SSR guard
     if (typeof window === "undefined" || typeof document === "undefined") return;
-    const saved = (localStorage.getItem("theme") || "").toLowerCase();
+    const saved = (localStorage.getItem("wn-theme") || "").toLowerCase();
     const prefersDark = window.matchMedia?.("(prefers-color-scheme: dark)").matches;
     const next = saved ? saved === "dark" : prefersDark;
     setDark(next);
@@ -27,7 +27,7 @@ export default function DarkModeToggle({ variant = "icon" }: { variant?: "icon" 
       document.documentElement.classList.toggle("dark", next);
     }
     if (typeof localStorage !== "undefined") {
-      localStorage.setItem("theme", next ? "dark" : "light");
+      localStorage.setItem("wn-theme", next ? "dark" : "light");
     }
   };
 
@@ -41,7 +41,7 @@ export default function DarkModeToggle({ variant = "icon" }: { variant?: "icon" 
       type="button"
       aria-label={dark ? "Switch to light theme" : "Switch to dark theme"}
       onClick={toggle}
-      className="w-9 h-9 inline-flex items-center justify-center hover:bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50"
+      className="inline-flex h-9 w-9 items-center justify-center rounded-full hover:bg-slate-100 dark:hover:bg-slate-800"
     >
       {dark ? (
         <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0V5a1 1 0 0 1 1-1Zm7 7a1 1 0 0 1 1 1 8 8 0 1 1-8-8 1 1 0 1 1 0 2 6 6 0 1 0 6 6 1 1 0 0 1 1-1Z" fill="currentColor"/></svg>

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -2,31 +2,32 @@ import DarkModeToggle from "@/components/DarkModeToggle";
 import SmartMenu from "@/components/SmartMenu";
 import SearchBox from "@/components/SearchBox";
 import NotificationsBellMenu from "@/components/NotificationsBellMenu";
+import BreakingTicker from "@/components/BreakingTicker";
 import Link from "next/link";
 
 export default function Header() {
   return (
-    <header className="sticky top-0 z-40 bg-white/90 dark:bg-neutral-950/90 backdrop-blur supports-[backdrop-filter]:bg-white/60 supports-[backdrop-filter]:dark:bg-neutral-950/60 border-b border-black/5 dark:border-white/10">
-      <div className="max-w-7xl mx-auto px-3 md:px-4 h-14 flex items-center justify-between gap-3">
-        {/* Logo bigger */}
-        <div className="flex items-center gap-3 shrink-0">
-          <Link href="/" className="flex items-center gap-2">
-            <img src="/logo-waternews.svg" alt="WaterNews" className="h-8 md:h-9 w-auto" />
-            <span className="sr-only">WaterNews home</span>
-          </Link>
-        </div>
+    <header className="sticky top-0 z-[60] border-b bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/70 dark:border-slate-800 dark:bg-slate-900/80">
+      {/* Top row: logo • SmartMenu • actions */}
+      <div className="mx-auto flex h-14 max-w-7xl items-center gap-3 px-3 md:h-16 md:px-4">
+        <Link href="/" aria-label="Home" className="inline-flex items-center">
+          <img src="/logo-waternews.svg" alt="WaterNews logo" className="h-8 w-auto md:h-10 lg:h-12" />
+        </Link>
 
-        {/* Center SmartMenu */}
-        <div className="hidden md:flex flex-1 justify-center">
-          <SmartMenu />
-        </div>
+        {/* center: SmartMenu */}
+        <div className="mx-auto hidden flex-1 md:block"><SmartMenu /></div>
 
-        {/* Right controls: Search (icon expands left), Bell, Dark mode (no circles) */}
-        <div className="flex items-center gap-2">
-          <SearchBox iconOnly align="right-expand-left" />
+        {/* right actions: inline expanding search + bell + theme */}
+        <div className="ml-auto flex items-center gap-2">
+          <SearchBox mode="inline" />
           <NotificationsBellMenu variant="outline" />
-          <DarkModeToggle variant="icon" />
+          <DarkModeToggle />
         </div>
+      </div>
+
+      {/* Bottom row: ticker inside header so it always sticks */}
+      <div className="border-t border-slate-200 bg-[#fffefc] dark:border-slate-800 dark:bg-slate-800">
+        <BreakingTicker />
       </div>
     </header>
   );

--- a/frontend/components/NotificationsBellMenu.tsx
+++ b/frontend/components/NotificationsBellMenu.tsx
@@ -7,8 +7,8 @@ type FetchAllFn = () => Promise<any[]>;
 export default function NotificationsBellMenu({
   fetchSince = async () => [],
   fetchAll = async () => [],
-  variant = "outline",
-}: { fetchSince?: FetchFn; fetchAll?: FetchAllFn; variant?: string }) {
+  variant = "outline" as any,
+}: { fetchSince?: FetchFn; fetchAll?: FetchAllFn; variant?: "solid" | "outline" }) {
   const [open, setOpen] = useState(false);
   const [unread, setUnread] = useState(0);
   const [sinceItems, setSinceItems] = useState<any[]>([]);
@@ -17,12 +17,19 @@ export default function NotificationsBellMenu({
   useEffect(() => {
     const last = Number((typeof window !== "undefined" && localStorage.getItem(lastVisitKey)) || 0);
     fetchSince(last || undefined)
-      .then(rows => { setSinceItems(rows || []); setUnread((rows || []).length); })
-      .catch(() => { setSinceItems([]); setUnread(0); });
+      .then((rows) => {
+        setSinceItems(rows || []);
+        setUnread((rows || []).length);
+      })
+      .catch(() => {
+        setSinceItems([]);
+        setUnread(0);
+      });
   }, []);
 
   const onToggle = () => {
-    const next = !open; setOpen(next);
+    const next = !open;
+    setOpen(next);
     if (next && typeof window !== "undefined") localStorage.setItem(lastVisitKey, String(Date.now()));
   };
 
@@ -33,10 +40,18 @@ export default function NotificationsBellMenu({
         aria-label="Open notifications"
         aria-expanded={open}
         onClick={onToggle}
-        className="w-9 h-9 inline-flex items-center justify-center hover:bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50"
+        className="relative inline-flex h-9 w-9 items-center justify-center rounded-full hover:bg-slate-100 dark:hover:bg-slate-800"
       >
-        <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M14 20a2 2 0 1 1-4 0m8-8a6 6 0 1 0-12 0c0 1.886-.664 3.056-1.414 3.707-.44.377-.66.565-.651.827.009.262.244.466.715.873.902.784 2.214 1.593 4.35 1.593h6c2.136 0 3.448-.809 4.35-1.593.471-.407.706-.611.715-.873.009-.262-.211-.45-.651-.827C16.664 15.056 16 13.886 16 12Z" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
+        {/* Modern outline bell */}
+        <svg width="22" height="22" viewBox="0 0 24 24" className="text-slate-700 dark:text-slate-200" aria-hidden="true">
+          <path
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15 17H9m8-1V11a5 5 0 10-10 0v5l-2 2h14l-2-2zm-6 4a2 2 0 004 0"
+          />
         </svg>
         {unread > 0 && (
           <span className="absolute -top-0.5 -right-0.5 inline-flex items-center justify-center text-[10px] min-w-[18px] h-[18px] px-1 rounded-full bg-blue-600 text-white">
@@ -53,14 +68,16 @@ export default function NotificationsBellMenu({
           <ul className="max-h-80 overflow-auto divide-y">
             {sinceItems.length === 0 ? (
               <li className="p-4 text-sm text-neutral-600">You’re all caught up.</li>
-            ) : sinceItems.map((n, i) => (
-              <li key={i} className="p-4 hover:bg-neutral-50 focus-within:bg-neutral-50">
-                <a href={n.href} className="block outline-none focus:ring-2 focus:ring-blue-500 rounded">
-                  <div className="text-sm font-medium">{n.title}</div>
-                  <div className="text-xs text-neutral-600">{n.summary}</div>
-                </a>
-              </li>
-            ))}
+            ) : (
+              sinceItems.map((n, i) => (
+                <li key={i} className="p-4 hover:bg-neutral-50 focus-within:bg-neutral-50">
+                  <a href={n.href} className="block outline-none focus:ring-2 focus:ring-blue-500 rounded">
+                    <div className="text-sm font-medium">{n.title}</div>
+                    <div className="text-xs text-neutral-600">{n.summary}</div>
+                  </a>
+                </li>
+              ))
+            )}
             <li className="px-3 py-2 text-sm">
               <Link
                 href="/notifications"
@@ -75,3 +92,4 @@ export default function NotificationsBellMenu({
     </div>
   );
 }
+

--- a/frontend/components/SmartMenu.tsx
+++ b/frontend/components/SmartMenu.tsx
@@ -59,7 +59,7 @@ export default function SmartMenu() {
 
   const transition = reduced ? "" : "transition-transform duration-300 ease-out";
   const baseItem =
-    "px-2 py-1.5 text-sm rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50";
+    "rounded-full px-3 py-1 bg-white/40 ring-1 ring-slate-200 hover:bg-brand/10 hover:text-brand dark:bg-slate-900/40 dark:ring-slate-700 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50";
 
   return (
     <nav aria-label="Sections" className="relative">

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -4,7 +4,6 @@ import '@/styles/globals.css';
 import Head from 'next/head';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
-import BreakingTicker from '@/components/BreakingTicker';
 
 export default function App({ Component, pageProps: { session, ...pageProps } }: AppProps) {
   return (
@@ -17,15 +16,13 @@ export default function App({ Component, pageProps: { session, ...pageProps } }:
       </Head>
       <SessionProvider session={session}>
         <a
-          href="#main"
+          href="#main-content"
           className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 bg-black text-white px-3 py-2 rounded"
         >
           Skip to main content
         </a>
         <Header />
-        {/* Global ticker under header on all routes */}
-        <BreakingTicker />
-        <main id="main">
+        <main id="main-content" className="min-h-screen bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-100">
           <Component {...pageProps} />
         </main>
         <Footer />

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -2,22 +2,29 @@ import Document, { Html, Head, Main, NextScript } from "next/document";
 
 export default class MyDocument extends Document {
   render() {
-    const inlineThemeInit = `
-(function() {
-  try {
-    var ls = localStorage.getItem('theme');
-    var m = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-    var wantDark = (ls === 'dark') || (ls === null && m);
-    if (wantDark) document.documentElement.classList.add('dark');
-    else document.documentElement.classList.remove('dark');
-  } catch(e) {}
-})();`;
     return (
-      <Html>
+      <Html lang="en">
         <Head>
-          <script dangerouslySetInnerHTML={{ __html: inlineThemeInit }} />
+          {/* Brand color meta & preconnects */}
+          <meta name="theme-color" content="#0F6CAD" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
         </Head>
         <body>
+          {/* No-flash theme initializer: reads localStorage + system and applies .dark on <html> before paint */}
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+(function(){
+  try {
+    var ls = localStorage.getItem('wn-theme');
+    var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    var shouldDark = ls ? (ls === 'dark') : prefersDark;
+    var html = document.documentElement;
+    if (shouldDark) html.classList.add('dark'); else html.classList.remove('dark');
+  } catch(e){}
+})();`,
+            }}
+          />
           <Main />
           <NextScript />
         </body>

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -11,12 +11,27 @@ mark {
   text-underline-offset: 2px;
 }
 
-:root { --leading-tight: 1.25; --leading-normal: 1.5; }
+:root {
+  --leading-tight: 1.25; --leading-normal: 1.5;
+  /* WaterNews brand (from new logo) */
+  --brand-blue: #0F6CAD;
+  --brand-blue-2: #0B5D95;
+  --brand-gold: #F2A300;
+  --brand-wave-1: #1179C0;
+  --brand-wave-2: #2DA6D9;
+}
 h1,h2,h3 { line-height: var(--leading-tight); letter-spacing: -0.01em; }
 p { line-height: var(--leading-normal); }
 .line-clamp-2 { display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
 .line-clamp-3 { display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical; overflow:hidden; }
 .line-clamp-4 { display:-webkit-box; -webkit-line-clamp:4; -webkit-box-orient:vertical; overflow:hidden; }
+
+/* Brand utility helpers */
+.text-brand { color: var(--brand-blue); }
+.text-brand-gold { color: var(--brand-gold); }
+.bg-brand { background-color: var(--brand-blue); }
+.bg-brand-gold { background-color: var(--brand-gold); }
+.ring-brand { --tw-ring-color: var(--brand-blue); }
 
 /* --- Global focus visibility (WCAG 2.4.7 / 2.4.13) --- */
 :focus-visible {


### PR DESCRIPTION
## Summary
- Move BreakingTicker into sticky Header and bump logo size
- Add brand color variables and utility classes
- Introduce inline expanding SearchBox, outline bell icon, and global dark-mode initialization

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a3c1092a408329884e83b445325b3c