### PR TITLE
feat: lock in header and footer branding

### DIFF
--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -1,22 +1,35 @@
-import Link from 'next/link'
+import Link from "next/link";
+import Image from "next/image";
 
 export default function Footer() {
   return (
-    <footer className="mt-8 border-t bg-black text-neutral-200">
-      <div className="max-w-7xl mx-auto px-3 md:px-4 py-6 text-sm">
-        <nav className="flex flex-wrap gap-4 mb-2">
-          <Link href="/about" className="hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 rounded">About</Link>
-          <Link href="/contact" className="hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 rounded">Contact</Link>
-          <Link href="/suggest" className="hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 rounded">Suggest a Story</Link>
-          <Link href="/privacy" className="hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 rounded">Privacy Policy</Link>
-          <Link href="/prefs" className="hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 rounded">Preferences</Link>
-          <Link href="/login" className="hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 rounded">Login</Link>
-        </nav>
-        <div className="text-neutral-400">
+    <footer className="border-t bg-neutral-50 text-sm text-neutral-600 dark:bg-neutral-950 dark:text-neutral-300">
+      <div className="mx-auto max-w-7xl px-4 py-10">
+        <div className="flex items-center justify-between gap-6">
+          <Link href="/" aria-label="WaterNews — Home" className="inline-flex items-center gap-2">
+            <Image
+              src="/logo-mini.svg"
+              alt="WaterNews mini logo"
+              width={28}
+              height={28}
+              className="h-7 w-7"
+            />
+            <span className="sr-only">WaterNews</span>
+          </Link>
+          <nav className="flex flex-wrap items-center gap-4">
+            <Link href="/about">About</Link>
+            <Link href="/contact">Contact</Link>
+            <Link href="/suggest">Suggest a Story</Link>
+            <Link href="/privacy">Privacy Policy</Link>
+            <Link href="/prefs">Preferences</Link>
+            <Link href="/login">Login</Link>
+          </nav>
+        </div>
+        <div className="mt-8 text-xs text-neutral-500 dark:text-neutral-400">
           © {new Date().getFullYear()} WaterNewsGY
         </div>
       </div>
     </footer>
-  )
+  );
 }
 

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -4,29 +4,43 @@ import SearchBox from "@/components/SearchBox";
 import NotificationsBellMenu from "@/components/NotificationsBellMenu";
 import BreakingTicker from "@/components/BreakingTicker";
 import Link from "next/link";
+import Image from "next/image";
 
 export default function Header() {
   return (
-    <header className="sticky top-0 z-[60] border-b bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/70 dark:border-slate-800 dark:bg-slate-900/80">
+    <header className="sticky top-0 z-50 border-b bg-white/80 backdrop-blur dark:bg-neutral-950/80">
       {/* Top row: logo • SmartMenu • actions */}
-      <div className="mx-auto flex h-14 max-w-7xl items-center gap-3 px-3 md:h-16 md:px-4">
-        <Link href="/" aria-label="Home" className="inline-flex items-center">
-          <img src="/logo-waternews.svg" alt="WaterNews logo" className="h-8 w-auto md:h-10 lg:h-12" />
+      <div className="mx-auto flex h-16 max-w-7xl items-center gap-4 px-4">
+        <Link
+          href="/"
+          aria-label="WaterNews — Home"
+          className="shrink-0 inline-flex items-center"
+        >
+          <Image
+            src="/logo-waternews.svg"
+            alt="WaterNews"
+            width={156}
+            height={28}
+            priority
+            className="h-7 w-auto"
+          />
         </Link>
 
         {/* center: SmartMenu */}
-        <div className="mx-auto hidden flex-1 md:block"><SmartMenu /></div>
+        <div className="flex-1 min-w-0">
+          <SmartMenu />
+        </div>
 
         {/* right actions: inline expanding search + bell + theme */}
-        <div className="ml-auto flex items-center gap-2">
-          <SearchBox mode="inline" />
-          <NotificationsBellMenu variant="outline" />
+        <div className="flex items-center gap-2">
+          <SearchBox />
+          <NotificationsBellMenu />
           <DarkModeToggle />
         </div>
       </div>
 
       {/* Bottom row: ticker inside header so it always sticks */}
-      <div className="border-t border-slate-200 bg-[#fffefc] dark:border-slate-800 dark:bg-slate-800">
+      <div className="border-t">
         <BreakingTicker />
       </div>
     </header>

--- a/frontend/types/next/index.d.ts
+++ b/frontend/types/next/index.d.ts
@@ -19,6 +19,10 @@ declare module "next/router" {
 declare module "next/app" {
   export type AppProps = any;
 }
+declare module "next/image" {
+  const Image: any;
+  export default Image;
+}
 declare module "next/document" {
   export const Html: any;
   export const Head: any;


### PR DESCRIPTION
## Summary
- hard-wire site logo in header
- show mini logo in footer
- stub next/image types for TS

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a3e9d102008329acc2f337f4ad5202