### PR TITLE
fix: align markdown editor keyboard event type

### DIFF
--- a/frontend/components/Newsroom/MarkdownEditor.tsx
+++ b/frontend/components/Newsroom/MarkdownEditor.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import type { KeyboardEventHandler } from "react";
+import type * as React from "react";
 import { readingTime } from "@/lib/readingTime";
 
 export default function MarkdownEditor({ draft, onChange }: { draft: any; onChange: (val: string) => void }) {
@@ -52,7 +52,7 @@ export default function MarkdownEditor({ draft, onChange }: { draft: any; onChan
     });
   }
 
-  const onKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
+  const onKeyDown: React.KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
     const mod = e.metaKey || e.ctrlKey;
     if (!mod) return;
     if (e.key.toLowerCase() === "b") { e.preventDefault(); wrap("**"); }


### PR DESCRIPTION
## Summary
- import React types for keyboard handler
- ensure onKeyDown uses React.KeyboardEventHandler

## Testing
- `npm test`
- `npm install` *(failed: 403 Forbidden - GET https://registry.npmjs.org/marked)*

------
https://chatgpt.com/codex/tasks/task_e_68a4eed872bc8329bbc1eb9b742ad44a