### PR TITLE
Fix Markdown editor handler types

### DIFF
--- a/frontend/components/Newsroom/MarkdownEditor.tsx
+++ b/frontend/components/Newsroom/MarkdownEditor.tsx
@@ -1,5 +1,9 @@
-import { useEffect, useRef, useState } from "react";
-import type * as React from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEventHandler,
+} from "react";
 import { readingTime } from "@/lib/readingTime";
 
 export default function MarkdownEditor({ draft, onChange }: { draft: any; onChange: (val: string) => void }) {
@@ -52,7 +56,7 @@ export default function MarkdownEditor({ draft, onChange }: { draft: any; onChan
     });
   }
 
-  const onKeyDown: React.KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
+  const onKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
     const mod = e.metaKey || e.ctrlKey;
     if (!mod) return;
     if (e.key.toLowerCase() === "b") { e.preventDefault(); wrap("**"); }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -24,7 +24,8 @@
       "@/styles/*": ["styles/*"],
       "@/utils/*": ["utils/*"]
     },
-    "typeRoots": ["./types", "./node_modules/@types"]
+    "typeRoots": ["./types", "./node_modules/@types"],
+    "types": ["node", "react", "react-dom"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- use React's `KeyboardEventHandler` type for Markdown editor shortcuts
- restrict TypeScript type roots to node, React, and React DOM

## Testing
- `npm run typecheck`
- `npm test`
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f2d740ec8329b244d335f6e76d9a