### PR TITLE
feat: add real-time notifications via WebSockets

### DIFF
--- a/frontend/components/NotificationsBellMenu.tsx
+++ b/frontend/components/NotificationsBellMenu.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
+import { useNotificationsSocket } from "@/lib/useNotificationsSocket";
 
 type FetchFn = (ts?: number) => Promise<any[]>;
 type FetchAllFn = () => Promise<any[]>;
@@ -11,7 +12,7 @@ export default function NotificationsBellMenu({
 }: { fetchSince?: FetchFn; fetchAll?: FetchAllFn; variant?: "solid" | "outline" }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
-  const [unread, setUnread] = useState(0);
+  const { connected, unread, setUnread } = useNotificationsSocket();
   const [sinceItems, setSinceItems] = useState<any[]>([]);
   const lastVisitKey = "wn:lastVisit";
 
@@ -73,8 +74,11 @@ export default function NotificationsBellMenu({
 
       {open && (
         <div role="menu" className="absolute right-0 mt-2 w-96 max-w-[92vw] rounded-2xl bg-white shadow-lg ring-1 ring-black/5 overflow-hidden">
-          <header className="px-4 py-2 text-xs font-semibold tracking-wide text-neutral-600 border-b">
-            Since last visit ({sinceItems.length})
+          <header className="flex justify-between px-4 py-2 text-xs font-semibold tracking-wide text-neutral-600 border-b">
+            <span>Since last visit ({sinceItems.length})</span>
+            <span className="font-normal text-[10px] text-neutral-500">
+              {connected ? "Live" : "Offline"}
+            </span>
           </header>
           <ul className="max-h-80 overflow-auto divide-y">
             {sinceItems.length === 0 ? (
@@ -89,13 +93,20 @@ export default function NotificationsBellMenu({
                 </li>
               ))
             )}
-            <li className="px-3 py-2 text-sm">
+            <li className="px-3 py-2 text-sm flex justify-between gap-2">
               <Link
                 href="/notifications"
                 className="text-blue-700 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 rounded"
               >
                 Open all
               </Link>
+              <button
+                onClick={() => setUnread(0)}
+                className="text-neutral-600 hover:underline"
+                aria-label="Mark all as read"
+              >
+                Mark all as read
+              </button>
             </li>
           </ul>
         </div>

--- a/frontend/lib/useNotificationsSocket.ts
+++ b/frontend/lib/useNotificationsSocket.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useState } from "react";
+
+type CountPayload = { count: number };
+type NewNotification = { id: string; title?: string; body?: string; createdAt?: string };
+
+export function useNotificationsSocket() {
+  const [connected, setConnected] = useState(false);
+  const [unread, setUnread] = useState<number | null>(null);
+  const seenRef = useRef<Set<string>>(new Set());
+  const ioRef = useRef<any>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function ensureServer() {
+      // Ensure the server route is initialized (no-op after first call)
+      try {
+        await fetch("/api/socket");
+      } catch {}
+      if (cancelled) return;
+      const { io } = await import("socket.io-client");
+      const client = io({
+        path: "/api/socket",
+        transports: ["websocket", "polling"],
+        reconnection: true,
+        reconnectionAttempts: Infinity,
+        reconnectionDelay: 500,
+        reconnectionDelayMax: 5000,
+      });
+      ioRef.current = client;
+      client.on("connect", () => setConnected(true));
+      client.on("disconnect", () => setConnected(false));
+
+      client.on("notification:count", (p: CountPayload) => {
+        if (typeof p?.count === "number") setUnread(p.count);
+      });
+      client.on("notification:new", (n: NewNotification) => {
+        if (n?.id && !seenRef.current.has(n.id)) {
+          seenRef.current.add(n.id);
+          setUnread((c) => (c == null ? 1 : c + 1));
+        }
+      });
+    }
+    ensureServer();
+    return () => {
+      cancelled = true;
+      ioRef.current?.close?.();
+    };
+  }, []);
+
+  return { connected, unread, setUnread };
+}
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,9 @@
     "next-auth": "^4.24.7",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "marked": "^12.0.2"
+    "marked": "^12.0.2",
+    "socket.io": "^4.7.5",
+    "socket.io-client": "^4.7.5"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.14",

--- a/frontend/pages/api/notifications.ts
+++ b/frontend/pages/api/notifications.ts
@@ -1,50 +1,66 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import type { Server as IOServer } from "socket.io";
 import { dbConnect } from "@/lib/server/db";
 import Event from "@/models/Event";
 import Post from "@/models/Post";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== "GET") return res.status(405).json({ error: "Method not allowed" });
+  if (req.method === "GET") {
+    await dbConnect();
+    // Pagination params
+    const limit = Math.min(
+      Math.max(parseInt(String(req.query.limit || "20"), 10) || 20, 5),
+      50
+    );
+    const cursor = String(req.query.cursor || "");
+    const before = cursor ? new Date(cursor) : undefined;
 
-  await dbConnect();
-  // Pagination params
-  const limit = Math.min(
-    Math.max(parseInt(String(req.query.limit || "20"), 10) || 20, 5),
-    50
-  );
-  const cursor = String(req.query.cursor || "");
-  const before = cursor ? new Date(cursor) : undefined;
+    const find: any = { visibility: { $in: ["public", "reader"] } };
+    if (!isNaN(before?.getTime?.() || NaN)) find.createdAt = { $lt: before };
 
-  const find: any = { visibility: { $in: ["public", "reader"] } };
-  if (!isNaN(before?.getTime?.() || NaN)) find.createdAt = { $lt: before };
+    const events = await Event.find(find)
+      .sort({ createdAt: -1 })
+      .limit(limit + 1) // fetch one extra to know if there's a next page
+      .lean();
 
-  const events = await Event.find(find)
-    .sort({ createdAt: -1 })
-    .limit(limit + 1) // fetch one extra to know if there's a next page
-    .lean();
+    // Resolve any post slugs referenced by events (lightweight join)
+    const postIds = events.map((e: any) => e.targetId).filter(Boolean);
+    const posts: any[] = await (Post as any)
+      .find({ _id: { $in: postIds } })
+      .select("_id slug title tags")
+      .lean();
+    const postMap = new Map(posts.map((p: any) => [String(p._id), p]));
 
-  // Resolve any post slugs referenced by events (lightweight join)
-  const postIds = events.map((e: any) => e.targetId).filter(Boolean);
-  const posts: any[] = await (Post as any)
-    .find({ _id: { $in: postIds } })
-    .select("_id slug title tags")
-    .lean();
-  const postMap = new Map(posts.map((p: any) => [String(p._id), p]));
+    const items = events.slice(0, limit).map((e: any) => {
+      const p = postMap.get(String(e.targetId));
+      return {
+        id: String(e._id),
+        type: e.type,
+        createdAt: e.createdAt,
+        title: p?.title || e.title || "Update",
+        slug: p?.slug || e.slug || "",
+        tags: p?.tags || e.tags || [],
+      };
+    });
 
-  const items = events.slice(0, limit).map((e: any) => {
-    const p = postMap.get(String(e.targetId));
-    return {
-      id: String(e._id),
-      type: e.type,
-      createdAt: e.createdAt,
-      title: p?.title || e.title || "Update",
-      slug: p?.slug || e.slug || "",
-      tags: p?.tags || e.tags || [],
-    };
-  });
+    const nextCursor = events.length > limit ? events[limit].createdAt.toISOString() : null;
 
-  const nextCursor = events.length > limit ? events[limit].createdAt.toISOString() : null;
+    res.setHeader("Cache-Control", "private, max-age=30"); // short client cache
+    return res.status(200).json({ items, nextCursor });
+  }
 
-  res.setHeader("Cache-Control", "private, max-age=30"); // short client cache
-  return res.status(200).json({ items, nextCursor });
+  if (req.method === "POST") {
+    const payload = { id: `${Date.now()}`, title: "New notification" };
+    try {
+      // Emit via Socket.IO if available
+      // @ts-ignore - Next.js augments the HTTP server
+      const io: IOServer | undefined = (res.socket as any)?.server?.io;
+      io?.emit?.("notification:new", payload);
+      // optionally emit count if you compute it server-side
+      // io?.emit?.("notification:count", { count: <newCount> });
+    } catch {}
+    return res.status(200).json({ ok: true, notification: payload });
+  }
+
+  return res.status(405).json({ error: "Method not allowed" });
 }

--- a/frontend/pages/api/socket.ts
+++ b/frontend/pages/api/socket.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest } from "next";
+import type { Server as HTTPServer } from "http";
+import type { Socket as NetSocket } from "net";
+import type { Server as IOServer } from "socket.io";
+
+type NextApiResponseWithSocket = {
+  socket: NetSocket & { server: HTTPServer & { io?: IOServer } };
+} & any;
+
+export const config = { api: { bodyParser: false } };
+
+export default function handler(_req: NextApiRequest, res: NextApiResponseWithSocket) {
+  if (!res.socket.server.io) {
+    // Lazy-init a single Socket.IO server per instance
+    const { Server } = require("socket.io");
+    const io: IOServer = new Server(res.socket.server, {
+      path: "/api/socket",
+      addTrailingSlash: false,
+      transports: ["websocket", "polling"],
+    });
+    res.socket.server.io = io;
+
+    io.on("connection", (socket) => {
+      // Optionally join per-user rooms later: socket.join(`user:${userId}`)
+      socket.emit("hello", { ok: true });
+    });
+  }
+  res.end();
+}
+


### PR DESCRIPTION
## Summary
- build a singleton Socket.IO server at `/api/socket`
- create `useNotificationsSocket` hook for live notification counts
- update notifications API and bell menu to broadcast and receive updates

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find module 'socket.io-client' and other missing types)*

------
https://chatgpt.com/codex/tasks/task_e_68a50503b4308329ac0857006d2028c3