### PR TITLE
feat: support device and user-specific notification sockets

### DIFF
--- a/frontend/pages/api/socket.ts
+++ b/frontend/pages/api/socket.ts
@@ -1,7 +1,19 @@
 import type { NextApiRequest } from "next";
 import type { Server as HTTPServer } from "http";
 import type { Socket as NetSocket } from "net";
-import type { Server as IOServer } from "socket.io";
+import type { Server as IOServer, Socket } from "socket.io";
+
+// tiny cookie parser (no dep)
+function parseCookie(header: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!header) return out;
+  header.split(";").forEach((p) => {
+    const [k, ...rest] = p.split("=");
+    if (!k) return;
+    out[k.trim()] = decodeURIComponent(rest.join("=").trim() || "");
+  });
+  return out;
+}
 
 type NextApiResponseWithSocket = {
   socket: NetSocket & { server: HTTPServer & { io?: IOServer } };
@@ -20,9 +32,36 @@ export default function handler(_req: NextApiRequest, res: NextApiResponseWithSo
     });
     res.socket.server.io = io;
 
-    io.on("connection", (socket) => {
-      // Optionally join per-user rooms later: socket.join(`user:${userId}`)
+    io.on("connection", async (socket: Socket) => {
+      // 1) Join per-device room (anonymous readers)
+      const cookieStr = socket.request?.headers?.cookie as string | undefined;
+      const cookies = parseCookie(cookieStr);
+      const did = (socket.handshake.query?.did as string) || cookies["wn_did"];
+      if (did) {
+        socket.join(`device:${did}`);
+      }
+
+      // 2) If authenticated, also join per-user room (newsroom staff)
+      try {
+        // next-auth JWT verification (no page req context here)
+        const { getToken } = require("next-auth/jwt");
+        const fakeReq = { headers: { cookie: cookieStr || "" } };
+        const token = await getToken({ req: fakeReq, secret: process.env.NEXTAUTH_SECRET });
+        const userId = token?.sub || token?.id;
+        if (userId) {
+          socket.join(`user:${userId}`);
+        }
+      } catch {
+        // ignore auth errors; device room still works
+      }
+
       socket.emit("hello", { ok: true });
+
+      // Optional: client may explicitly request joining rooms again
+      socket.on("join", (payload: any) => {
+        if (payload?.deviceId) socket.join(`device:${payload.deviceId}`);
+        // never trust client userId here; we only join user rooms after server-side validation above
+      });
     });
   }
   res.end();


### PR DESCRIPTION
## Summary
- track device IDs via wn_did cookie for notification sockets
- join device and user-specific rooms based on cookie and NextAuth token

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find module types and React namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68a5235a449483299d3387cd55bc1766