### PR TITLE
feat: add suggest-story page and API

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "axios": "^1.6.8",
     "bcryptjs": "^2.4.3",
+    "formidable": "^3.5.1",
     "mongoose": "^8.6.0",
     "next": "14.2.31",
     "next-auth": "^4.24.7",

--- a/frontend/pages/api/suggest-story.js
+++ b/frontend/pages/api/suggest-story.js
@@ -1,0 +1,60 @@
+import formidable from "formidable";
+import { MongoClient } from "mongodb";
+
+// Tell Next.js we’re handling multipart ourselves
+export const config = { api: { bodyParser: false } };
+
+async function parseForm(req) {
+  return new Promise((resolve, reject) => {
+    const form = new formidable.IncomingForm({ multiples: true, keepExtensions: true });
+    form.parse(req, (err, fields, files) => {
+      if (err) reject(err);
+      else resolve({ fields, files });
+    });
+  });
+}
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") return res.status(405).json({ ok: false, error: "Method not allowed" });
+  try {
+    const { fields, files } = await parseForm(req);
+    const tip = {
+      name: String(fields.name || "").trim(),
+      email: String(fields.email || "").trim(),
+      phone: String(fields.phone || "").trim(),
+      anonymous: String(fields.anonymous || "") === "on" || fields.anonymous === true,
+      story: String(fields.story || "").trim(),
+      attachments: files?.media
+        ? []
+            .concat(files.media)
+            .map((f) => ({
+              filepath: f.filepath,
+              mimetype: f.mimetype,
+              size: f.size,
+              originalFilename: f.originalFilename,
+            }))
+        : [],
+      createdAt: new Date(),
+    };
+
+    // Frontend also enforces these; double‑check on server
+    if (!tip.name) return res.status(400).json({ ok: false, error: "Name is required for verification." });
+    if (!tip.email) return res.status(400).json({ ok: false, error: "Email is required." });
+    if (!tip.story) return res.status(400).json({ ok: false, error: "Story is required." });
+
+    // Write to Mongo if configured; otherwise stub success
+    const uri = process.env.MONGO_URI || process.env.MONGODB_URI;
+    if (uri) {
+      const client = await MongoClient.connect(uri);
+      const db = client.db(process.env.MONGO_DB || "waternews");
+      await db.collection("tips").insertOne(tip);
+      await client.close();
+    }
+
+    // Email alerts intentionally deferred (Rev.3.X).
+    return res.status(200).json({ ok: true });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ ok: false, error: "Server error" });
+  }
+}

--- a/frontend/pages/suggest-story.jsx
+++ b/frontend/pages/suggest-story.jsx
@@ -1,0 +1,226 @@
+import { useState } from "react";
+import Head from "next/head";
+
+export default function SuggestStory() {
+  const [anonymous, setAnonymous] = useState(false);
+  const [showWhy, setShowWhy] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState("");
+  const [errors, setErrors] = useState({ name: "", email: "", story: "" });
+
+  function validate(form) {
+    const next = { name: "", email: "", story: "" };
+    if (!form.name?.trim()) next.name = "Name is required (for newsroom verification only).";
+    if (!form.email?.trim()) next.email = "Email is required.";
+    if (!form.story?.trim()) next.story = "Please describe the story.";
+    setErrors(next);
+    return !next.name && !next.email && !next.story;
+  }
+
+  async function onSubmit(e) {
+    e.preventDefault();
+    setError("");
+    setSuccess(false);
+    const formEl = e.currentTarget;
+    const fd = new FormData(formEl);
+
+    const ok = validate(Object.fromEntries(fd.entries()));
+    if (!ok) {
+      // If name missing, also surface the WHY modal to educate.
+      if (!fd.get("name")) setShowWhy(true);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/suggest-story", { method: "POST", body: fd });
+      const data = await res.json();
+      if (!data.ok) throw new Error(data.error || "Failed to submit.");
+      setSuccess(true);
+      formEl.reset();
+      setAnonymous(false);
+    } catch (err) {
+      setError(err.message || "Something went wrong.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Head>
+        <title>Suggest a Story • WaterNews</title>
+      </Head>
+
+      {/* Hero (align with About/Contact aesthetic) */}
+      <header className="bg-gradient-to-r from-blue-600 to-blue-400 text-white py-16 text-center">
+        <h1 className="text-4xl font-bold">Suggest a Story</h1>
+        <p className="mt-2 text-lg text-blue-100">
+          Share your tip with confidence — your privacy is our priority.
+        </p>
+      </header>
+
+      <main className="max-w-6xl mx-auto px-4 py-12 grid gap-8 lg:grid-cols-3">
+        {/* Left Info Cards (trust/privacy cues) */}
+        <div className="space-y-6 hidden lg:block">
+          <InfoCard
+            title="Your Privacy"
+            text="Anonymous tips are welcome. If Anonymous is on, we won’t publish or share your name as the source."
+          />
+          <InfoCard
+            title="Secure Handling"
+            text="Only our editors see your private details for verification and legal review."
+          />
+        </div>
+
+        {/* Form Card */}
+        <div className="bg-white rounded-2xl shadow-lg p-8 lg:col-span-2">
+          <form onSubmit={onSubmit} className="space-y-6">
+            {/* Name + Anonymous toggle */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Name</label>
+              <input
+                name="name"
+                type="text"
+                placeholder="Your full name (kept private if Anonymous)"
+                className={`mt-1 w-full rounded-md border ${errors.name ? "border-red-400" : "border-gray-300"} shadow-sm focus:border-blue-500 focus:ring-blue-500`}
+                required
+              />
+              {errors.name && <p className="mt-1 text-sm text-red-600">{errors.name}</p>}
+              <div className="mt-2 text-xs text-gray-600">
+                We require a real name for newsroom verification.
+                If Anonymous is on, your name will <span className="font-semibold">not be published</span>.
+                <button type="button" className="text-blue-600 ml-2 underline" onClick={() => setShowWhy(true)}>
+                  Why?
+                </button>
+              </div>
+              <div className="mt-3 flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  name="anonymous"
+                  checked={anonymous}
+                  onChange={(e) => setAnonymous(e.target.checked)}
+                  className="h-4 w-4 text-blue-600 border-gray-300 rounded"
+                />
+                <span className="text-sm text-gray-700">
+                  Submit <span className="font-medium">Anonymous</span> (we won’t publish your name)
+                </span>
+              </div>
+            </div>
+
+            {/* Email + Phone inline */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700">Email</label>
+                <input
+                  name="email"
+                  type="email"
+                  placeholder="you@example.com"
+                  className={`mt-1 w-full rounded-md border ${errors.email ? "border-red-400" : "border-gray-300"} shadow-sm focus:border-blue-500 focus:ring-blue-500`}
+                  required
+                />
+                {errors.email && <p className="mt-1 text-sm text-red-600">{errors.email}</p>}
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700">Phone (optional)</label>
+                <input
+                  name="phone"
+                  type="tel"
+                  placeholder="+592 600 0000"
+                  className="mt-1 w-full rounded-md border border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                />
+              </div>
+            </div>
+
+            {/* Story details */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Story Details</label>
+              <textarea
+                name="story"
+                rows={6}
+                placeholder="Describe the story you want to suggest..."
+                className={`mt-1 w-full rounded-md border ${errors.story ? "border-red-400" : "border-gray-300"} shadow-sm focus:border-blue-500 focus:ring-blue-500`}
+                required
+              />
+              {errors.story && <p className="mt-1 text-sm text-red-600">{errors.story}</p>}
+            </div>
+
+            {/* Media upload */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Upload Media (optional)</label>
+              <input
+                name="media"
+                type="file"
+                className="mt-1 block w-full text-sm text-gray-600 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
+                accept="image/*,video/*,.pdf,.doc,.docx,.zip"
+                multiple
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                Accepted: images, videos, PDF/Docs, ZIP. Large files may take longer to upload.
+              </p>
+            </div>
+
+            {/* Submit */}
+            <div className="flex items-center gap-4">
+              <button
+                type="submit"
+                disabled={submitting}
+                className="inline-flex items-center justify-center px-5 py-3 bg-blue-600 text-white rounded-lg shadow hover:bg-blue-700 transition disabled:opacity-70"
+              >
+                {submitting ? "Submitting…" : "Submit Story"}
+              </button>
+              {success && <span className="text-sm text-green-600">Thank you — your tip was submitted.</span>}
+              {error && <span className="text-sm text-red-600">{error}</span>}
+            </div>
+          </form>
+        </div>
+
+        {/* Right Info Cards */}
+        <div className="space-y-6 hidden lg:block">
+          <InfoCard
+            title="Why Share?"
+            text="Your tips help us uncover important stories that matter to the community."
+          />
+          <InfoCard
+            title="Editorial Standards"
+            text="We verify submissions and protect sources under industry best practices."
+          />
+        </div>
+      </main>
+
+      {/* WHY modal */}
+      {showWhy && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl shadow-xl p-6 max-w-md w-full">
+            <h3 className="text-lg font-semibold">Why we need your name</h3>
+            <p className="mt-2 text-sm text-gray-600">
+              Responsible newsrooms verify tips to protect the public interest and reduce misinformation.
+              A real name helps editors authenticate submissions and follow up for clarity.
+              If you choose Anonymous, we will not publish or share your name as the source.
+            </p>
+            <ul className="mt-3 list-disc pl-5 text-sm text-gray-600">
+              <li>Industry best practice in responsible journalism</li>
+              <li>Supports fact‑checking and legal review</li>
+              <li>Protects you while preserving story integrity</li>
+            </ul>
+            <div className="mt-4 flex justify-end">
+              <button className="px-4 py-2 rounded-md bg-blue-600 text-white" onClick={() => setShowWhy(false)}>
+                Got it
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function InfoCard({ title, text }) {
+  return (
+    <div className="bg-white rounded-xl shadow-md p-6">
+      <h3 className="text-lg font-semibold text-blue-700">{title}</h3>
+      <p className="mt-2 text-sm text-gray-600">{text}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add formidable dependency for multipart form handling
- create Suggest a Story page with anonymous option, file uploads, and trust cards
- add API route that parses submissions and writes to Mongo when configured

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a5258a9f08832984e88a4a40a9165e