### PR TITLE
feat: add unified intake and admin inbox

### DIFF
--- a/frontend/components/Toast.jsx
+++ b/frontend/components/Toast.jsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+export default function Toast({ message, type = "success", onDone }) {
+  const [open, setOpen] = useState(true);
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setOpen(false);
+      onDone?.();
+    }, 3000);
+    return () => clearTimeout(t);
+  }, []);
+  if (!open) return null;
+  return (
+    <div className="fixed bottom-4 right-4 z-50">
+      <div className={`px-4 py-3 rounded-lg shadow text-white ${type === "error" ? "bg-red-600" : "bg-green-600"}`}>
+        {message}
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/admin-auth.js
+++ b/frontend/lib/admin-auth.js
@@ -1,0 +1,16 @@
+export async function isAdminEmail(email) {
+  if (!email) return false;
+  const env = process.env.ADMIN_EMAILS || "";
+  const list = env.split(",").map((s) => s.trim().toLowerCase()).filter(Boolean);
+  return list.includes(email.toLowerCase());
+}
+
+// Optional DB role check (call this server-side in getServerSideProps / API)
+import { getDb } from "./db";
+export async function isAdminUser(email) {
+  if (!email) return false;
+  const db = await getDb();
+  if (!db) return false;
+  const user = await db.collection("users").findOne({ email: email.toLowerCase() }, { projection: { role: 1 } });
+  return !!user && (user.role === "admin" || user.role === "editor" || user.role === "moderator");
+}

--- a/frontend/lib/cloudinary.js
+++ b/frontend/lib/cloudinary.js
@@ -1,0 +1,31 @@
+import { v2 as cloudinary } from "cloudinary";
+
+const url = process.env.CLOUDINARY_URL; // preferred single var
+if (url) {
+  cloudinary.config({ secure: true }); // CLOUDINARY_URL auto-parsed
+} else {
+  // fallback if you use separate vars (optional)
+  cloudinary.config({
+    cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+    api_key: process.env.CLOUDINARY_API_KEY,
+    api_secret: process.env.CLOUDINARY_API_SECRET,
+    secure: true,
+  });
+}
+
+export async function uploadLocalFile(filepath, folder = "waternews/uploads") {
+  const res = await cloudinary.uploader.upload(filepath, {
+    folder,
+    resource_type: "auto",
+    // eager transforms later if needed
+  });
+  return {
+    url: res.secure_url,
+    public_id: res.public_id,
+    resource_type: res.resource_type,
+    bytes: res.bytes,
+    width: res.width,
+    height: res.height,
+    format: res.format,
+  };
+}

--- a/frontend/lib/cms-routing.js
+++ b/frontend/lib/cms-routing.js
@@ -1,0 +1,17 @@
+export const SUBJECTS = [
+  { value: "tip",         label: "News Tip" },
+  { value: "correction",  label: "Correction Request" },
+  { value: "apply",       label: "Apply to Contribute" },
+  { value: "advertising", label: "Advertising / Partnerships" },
+  { value: "general",     label: "General Contact" },
+];
+
+export function routeSubject(subject) {
+  switch (subject) {
+    case "tip":         return { queue: "tips",         role: "Moderator", status: "new", priority: "high" };
+    case "correction":  return { queue: "corrections",  role: "Editor",    status: "new", priority: "high" };
+    case "apply":       return { queue: "applications", role: "Editor",    status: "new", priority: "normal" };
+    case "advertising": return { queue: "ads",          role: "Admin",     status: "new", priority: "normal" };
+    default:            return { queue: "general",      role: "Editor",    status: "new", priority: "normal" };
+  }
+}

--- a/frontend/lib/db.js
+++ b/frontend/lib/db.js
@@ -1,23 +1,8 @@
 import { MongoClient } from "mongodb";
-
-/**
- * Tiny Mongo helper used by the contact/apply/corrections APIs.
- *
- * Gracefully returns null if no URI is present so routes can still 200.
- */
 let client;
-let db;
-
 export async function getDb() {
-  const uri = process.env.MONGODB_URI;
+  const uri = process.env.MONGO_URI || process.env.MONGODB_URI;
   if (!uri) return null;
-  if (!client) {
-    client = new MongoClient(uri, { ignoreUndefined: true });
-    await client.connect();
-  }
-  if (!db) {
-    db = client.db(process.env.MONGODB_DB || "waternews");
-  }
-  return db;
+  if (!client) client = await MongoClient.connect(uri);
+  return client.db(process.env.MONGO_DB || "waternews");
 }
-

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,8 +13,10 @@
   "dependencies": {
     "axios": "^1.6.8",
     "bcryptjs": "^2.4.3",
+    "cloudinary": "^1.41.2",
     "formidable": "^3.5.1",
     "mongoose": "^8.6.0",
+    "mongodb": "^6.6.0",
     "next": "14.2.31",
     "next-auth": "^4.24.7",
     "react": "18.3.1",

--- a/frontend/pages/admin/inbox.jsx
+++ b/frontend/pages/admin/inbox.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { isAdminEmail, isAdminUser } from "@/lib/admin-auth";
+
+export default function AdminInbox() {
+  const [tickets, setTickets] = useState([]);
+  useEffect(() => {
+    fetch("/api/inbox/list").then((r) => r.json()).then((d) => {
+      if (d.ok) setTickets(d.items);
+    });
+  }, []);
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Inbox</h1>
+      <ul className="space-y-2">
+        {tickets.map((t) => (
+          <li key={t._id} className="p-3 rounded border">
+            <Link href={`/admin/inbox/${t._id}`}>{t.subject || "(no subject)"}</Link>
+            <span className="ml-2 text-sm text-gray-500">{t.status}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export async function getServerSideProps(ctx) {
+  const email = ctx.req?.headers["x-user-email"] || null;
+  const ok = (await isAdminEmail(email)) || (await isAdminUser(email));
+  if (!ok) {
+    return { redirect: { destination: "/profile", permanent: false } };
+  }
+  return { props: {} };
+}

--- a/frontend/pages/admin/inbox/[id].jsx
+++ b/frontend/pages/admin/inbox/[id].jsx
@@ -1,0 +1,34 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { isAdminEmail, isAdminUser } from "@/lib/admin-auth";
+
+export default function TicketDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [ticket, setTicket] = useState(null);
+  useEffect(() => {
+    if (id) {
+      fetch(`/api/inbox/get?id=${id}`).then((r) => r.json()).then((d) => {
+        if (d.ok) setTicket(d.ticket);
+      });
+    }
+  }, [id]);
+  if (!ticket) return <div className="p-6">Loading...</div>;
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">{ticket.subject}</h1>
+      <p><strong>Name:</strong> {ticket.name}</p>
+      <p><strong>Email:</strong> {ticket.email}</p>
+      <p className="mt-4 whitespace-pre-line">{ticket.body}</p>
+    </div>
+  );
+}
+
+export async function getServerSideProps(ctx) {
+  const email = ctx.req?.headers["x-user-email"] || null;
+  const ok = (await isAdminEmail(email)) || (await isAdminUser(email));
+  if (!ok) {
+    return { redirect: { destination: "/profile", permanent: false } };
+  }
+  return { props: {} };
+}

--- a/frontend/pages/api/inbox/[id].js
+++ b/frontend/pages/api/inbox/[id].js
@@ -1,0 +1,23 @@
+import { getDb } from "@/lib/db";
+import { ObjectId } from "mongodb";
+
+export default async function handler(req, res) {
+  const { id } = req.query;
+  if (!id) return res.status(400).json({ ok: false, error: "Missing id" });
+  const db = await getDb();
+  if (!db) return res.status(404).json({ ok: false, error: "Not found" });
+
+  if (req.method === "PATCH") {
+    const { status, queue, roleTarget, assignedTo } = req.body || {};
+    const set = {};
+    if (status) set.status = status;
+    if (queue) set.queue = queue;
+    if (roleTarget) set.roleTarget = roleTarget;
+    if (assignedTo) set.assignedTo = assignedTo;
+    set.updatedAt = new Date();
+    await db.collection("tickets").updateOne({ _id: new ObjectId(String(id)) }, { $set: set });
+    return res.status(200).json({ ok: true });
+  }
+
+  return res.status(405).json({ ok: false, error: "Method not allowed" });
+}

--- a/frontend/pages/api/inbox/[id]/notes.js
+++ b/frontend/pages/api/inbox/[id]/notes.js
@@ -1,0 +1,15 @@
+import { getDb } from "@/lib/db";
+import { ObjectId } from "mongodb";
+
+export default async function handler(req, res) {
+  const { id } = req.query;
+  if (!id) return res.status(400).json({ ok: false, error: "Missing id" });
+  if (req.method !== "POST") return res.status(405).json({ ok: false, error: "Method not allowed" });
+  const { note, by = null } = req.body || {};
+  if (!note) return res.status(400).json({ ok: false, error: "Note required" });
+  const db = await getDb();
+  if (!db) return res.status(404).json({ ok: false, error: "Not found" });
+  const entry = { note: String(note), by, at: new Date() };
+  await db.collection("tickets").updateOne({ _id: new ObjectId(String(id)) }, { $push: { notes: entry } });
+  return res.status(200).json({ ok: true });
+}

--- a/frontend/pages/api/inbox/create.js
+++ b/frontend/pages/api/inbox/create.js
@@ -1,0 +1,74 @@
+import formidable from "formidable";
+import fs from "fs";
+import { getDb } from "@/lib/db";
+import { routeSubject } from "@/lib/cms-routing";
+import { uploadLocalFile } from "@/lib/cloudinary";
+
+export const config = { api: { bodyParser: false } };
+
+function parseForm(req) {
+  return new Promise((resolve, reject) => {
+    const form = new formidable.IncomingForm({ multiples: true, keepExtensions: true });
+    form.parse(req, (err, fields, files) => (err ? reject(err) : resolve({ fields, files })));
+  });
+}
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") return res.status(405).json({ ok: false, error: "Method not allowed" });
+  try {
+    const { fields, files } = await parseForm(req);
+    const subject = String(fields.subject || "general");
+    const route = routeSubject(subject);
+
+    const base = {
+      subject,
+      name: String(fields.name || "").trim(),
+      email: String(fields.email || "").trim(),
+      phone: String(fields.phone || "").trim(),
+      anonymous: String(fields.anonymous || "") === "on" || fields.anonymous === true,
+      body: String(fields.story || fields.message || "").trim(),
+      queue: route.queue,
+      status: route.status,
+      priority: route.priority,
+      roleTarget: route.role,
+      createdAt: new Date(),
+      notes: [],
+      history: [{ at: new Date(), by: null, action: "created", meta: { queue: route.queue } }],
+    };
+
+    if (!base.name) return res.status(400).json({ ok: false, error: "Name is required for verification." });
+    if (!base.email) return res.status(400).json({ ok: false, error: "Email is required." });
+    if (!base.body) return res.status(400).json({ ok: false, error: "Message is required." });
+
+    // Upload media (if any) to Cloudinary
+    let attachments = [];
+    const media = files?.media ? [].concat(files.media) : [];
+    for (const f of media) {
+      try {
+        const uploaded = await uploadLocalFile(f.filepath, `waternews/${subject}`);
+        attachments.push({
+          ...uploaded,
+          originalFilename: f.originalFilename,
+          mimetype: f.mimetype,
+        });
+      } catch (e) {
+        // Skip failed file; continue others
+      } finally {
+        try { fs.unlinkSync(f.filepath); } catch {}
+      }
+    }
+
+    const ticket = { ...base, attachments };
+
+    const db = await getDb();
+    if (db) {
+      await db.collection("tickets").createIndex({ createdAt: -1 });
+      const r = await db.collection("tickets").insertOne(ticket);
+      return res.status(200).json({ ok: true, id: r.insertedId });
+    }
+    return res.status(200).json({ ok: true });
+  } catch (e) {
+    console.error(e);
+    return res.status(500).json({ ok: false, error: "Server error" });
+  }
+}

--- a/frontend/pages/api/inbox/get.js
+++ b/frontend/pages/api/inbox/get.js
@@ -1,0 +1,13 @@
+import { getDb } from "@/lib/db";
+import { ObjectId } from "mongodb";
+
+export default async function handler(req, res) {
+  if (req.method !== "GET") return res.status(405).json({ ok: false, error: "Method not allowed" });
+  const { id } = req.query;
+  if (!id) return res.status(400).json({ ok: false, error: "Missing id" });
+  const db = await getDb();
+  if (!db) return res.status(404).json({ ok: false, error: "Not found" });
+  const ticket = await db.collection("tickets").findOne({ _id: new ObjectId(String(id)) });
+  if (!ticket) return res.status(404).json({ ok: false, error: "Not found" });
+  return res.status(200).json({ ok: true, ticket });
+}

--- a/frontend/pages/api/inbox/list.js
+++ b/frontend/pages/api/inbox/list.js
@@ -1,0 +1,9 @@
+import { getDb } from "@/lib/db";
+
+export default async function handler(req, res) {
+  if (req.method !== "GET") return res.status(405).json({ ok: false, error: "Method not allowed" });
+  const db = await getDb();
+  if (!db) return res.status(200).json({ ok: true, items: [] });
+  const items = await db.collection("tickets").find().sort({ createdAt: -1 }).limit(100).toArray();
+  return res.status(200).json({ ok: true, items });
+}

--- a/frontend/pages/apply.jsx
+++ b/frontend/pages/apply.jsx
@@ -1,26 +1,34 @@
 import Head from "next/head";
 import Image from "next/image";
 import { useState } from "react";
+import { SUBJECTS } from "@/lib/cms-routing";
+import Toast from "@/components/Toast";
 
 export default function ApplyPage() {
-  const [state, setState] = useState({ name: "", email: "", role: "", links: "", note: "" });
+  const [state, setState] = useState({ name: "", email: "", role: "", links: "", note: "", subject: "apply" });
   const [submitting, setSubmitting] = useState(false);
-  const [done, setDone] = useState(null);
+  const [toast, setToast] = useState(null);
 
   async function onSubmit(e) {
     e.preventDefault();
     if (submitting) return;
     setSubmitting(true);
     try {
-      const r = await fetch("/api/apply", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(state),
-      });
+      const fd = new FormData();
+      fd.append("subject", state.subject);
+      fd.append("name", state.name);
+      fd.append("email", state.email);
+      fd.append(
+        "message",
+        `${state.note}${state.role ? `\nRole: ${state.role}` : ""}${state.links ? `\nLinks: ${state.links}` : ""}`
+      );
+      const r = await fetch("/api/inbox/create", { method: "POST", body: fd });
       const json = await r.json();
-      setDone(json);
-    } catch {
-      setDone({ ok: true, ref: "OFFLINE" });
+      if (!json.ok) throw new Error(json.error || "Failed");
+      setToast({ type: "success", message: "Thank you — submitted." });
+      setState({ name: "", email: "", role: "", links: "", note: "", subject: "apply" });
+    } catch (e) {
+      setToast({ type: "error", message: e.message || "Something went wrong." });
     } finally {
       setSubmitting(false);
     }
@@ -61,6 +69,21 @@ export default function ApplyPage() {
           <form onSubmit={onSubmit}>
             <h2 className="text-xl font-bold">Tell us about you</h2>
             <div className="mt-3 grid gap-3">
+              <label className="block">
+                <span className="text-sm font-medium">Subject</span>
+                <select
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  value={state.subject}
+                  onChange={(e) => setState((s) => ({ ...s, subject: e.target.value }))}
+                  name="subject"
+                >
+                  {SUBJECTS.map((s) => (
+                    <option key={s.value} value={s.value}>
+                      {s.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
               <label className="block">
                 <span className="text-sm font-medium">Name</span>
                 <input
@@ -114,11 +137,6 @@ export default function ApplyPage() {
               >
                 {submitting ? "Submitting…" : "Submit application"}
               </button>
-              {done && (
-                <p className="text-sm text-green-700">
-                  Thanks! We received your application. Reference: <strong>{done.ref}</strong>
-                </p>
-              )}
             </div>
           </form>
 
@@ -132,6 +150,8 @@ export default function ApplyPage() {
           </aside>
         </section>
       </main>
+
+      {toast && <Toast {...toast} onDone={() => setToast(null)} />}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- integrate Cloudinary and Mongo helpers
- add intake API with subject routing and admin inbox UI
- update public forms to route to unified intake with toast feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a53c8ea2f0832980bebaacca6319f1