### PR TITLE
revert: restore original apply, contact, and corrections pages

### DIFF
--- a/frontend/pages/apply.jsx
+++ b/frontend/pages/apply.jsx
@@ -1,45 +1,158 @@
-export default function Apply() {
+import Head from "next/head";
+import Image from "next/image";
+import { useState } from "react";
+import { SUBJECTS } from "@/lib/cms-routing";
+import Toast from "@/components/Toast";
+
+export default function ApplyPage() {
+  const [state, setState] = useState({ name: "", email: "", role: "", links: "", note: "", subject: "apply" });
+  const [submitting, setSubmitting] = useState(false);
+  const [toast, setToast] = useState(null);
+
+  async function onSubmit(e) {
+    e.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      const fd = new FormData();
+      fd.append("subject", state.subject);
+      fd.append("name", state.name);
+      fd.append("email", state.email);
+      fd.append(
+        "message",
+        `${state.note}${state.role ? `\nRole: ${state.role}` : ""}${state.links ? `\nLinks: ${state.links}` : ""}`
+      );
+      const r = await fetch("/api/inbox/create", { method: "POST", body: fd });
+      const json = await r.json();
+      if (!json.ok) throw new Error(json.error || "Failed");
+      setToast({ type: "success", message: "Thank you — submitted." });
+      setState({ name: "", email: "", role: "", links: "", note: "", subject: "apply" });
+    } catch (e) {
+      setToast({ type: "error", message: e.message || "Something went wrong." });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   return (
-    <main className="mx-auto max-w-3xl px-4 pb-16">
-      <div className="sticky top-0 -mx-4 mb-6 h-28 bg-[image:var(--wn-grad-hero)] bg-[length:100%_100%] bg-no-repeat" />
-      <section className="wn-card p-6">
-        <h1 className="mb-2 text-2xl font-semibold">Apply to Contribute</h1>
-        <p className="mb-6 text-sm text-neutral-600">Tell us about your beat and clips.</p>
-        <form
-          className="space-y-4"
-          onSubmit={(e) => {
-            const el = e.currentTarget.querySelector(":invalid");
-            if (el) { e.preventDefault(); el.scrollIntoView({ behavior: "smooth", block: "center" }); el.focus(); }
-          }}
-        >
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="wn-field">
-              <label htmlFor="a-name">Full name</label>
-              <input id="a-name" name="name" required placeholder=" " className="wn-input w-full rounded-xl border p-3" />
+    <>
+      <Head>
+        <title>Apply — WaterNews</title>
+        <meta
+          name="description"
+          content="Pitch your voice — apply to contribute to WaterNews."
+        />
+      </Head>
+
+      <header className="bg-gradient-to-b from-[#0f6cad] via-[#0b5d95] to-[#0a4f7f] px-4 py-14 text-white">
+        <div className="mx-auto max-w-5xl">
+          <div className="mb-5 flex items-center gap-3">
+            <Image
+              src="/logo-waternews.svg"
+              alt="WaterNews"
+              width={220}
+              height={60}
+              priority
+            />
+            <h1 className="m-0 text-3xl font-extrabold leading-tight md:text-5xl">
+              Apply to Contribute
+            </h1>
+          </div>
+          <p className="max-w-3xl text-sm opacity-95 md:text-base">
+            Writers, photographers, and editors — we’d love to see your work.
+          </p>
+        </div>
+      </header>
+
+      <main className="mx-auto my-10 max-w-5xl px-4">
+        <section className="grid gap-6 rounded-2xl bg-white p-6 shadow md:grid-cols-[1.1fr,0.9fr]">
+          <form onSubmit={onSubmit}>
+            <h2 className="text-xl font-bold">Tell us about you</h2>
+            <div className="mt-3 grid gap-3">
+              <label className="block">
+                <span className="text-sm font-medium">Subject</span>
+                <select
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  value={state.subject}
+                  onChange={(e) => setState((s) => ({ ...s, subject: e.target.value }))}
+                  name="subject"
+                >
+                  {SUBJECTS.map((s) => (
+                    <option key={s.value} value={s.value}>
+                      {s.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium">Name</span>
+                <input
+                  required
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  value={state.name}
+                  onChange={(e) => setState((s) => ({ ...s, name: e.target.value }))}
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium">Email</span>
+                <input
+                  required
+                  type="email"
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  value={state.email}
+                  onChange={(e) => setState((s) => ({ ...s, email: e.target.value }))}
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium">Role (Reporter, Opinion, Photo…)</span>
+                <input
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  value={state.role}
+                  onChange={(e) => setState((s) => ({ ...s, role: e.target.value }))}
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium">Portfolio / Links</span>
+                <textarea
+                  rows={3}
+                  placeholder="URLs, clips, social"
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  value={state.links}
+                  onChange={(e) => setState((s) => ({ ...s, links: e.target.value }))}
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium">Note</span>
+                <textarea
+                  rows={6}
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  value={state.note}
+                  onChange={(e) => setState((s) => ({ ...s, note: e.target.value }))}
+                />
+              </label>
+              <button
+                type="submit"
+                disabled={submitting}
+                className="mt-1 inline-flex items-center justify-center rounded-xl bg-[#1583c2] px-4 py-2 font-semibold text-white hover:brightness-110 disabled:opacity-60"
+              >
+                {submitting ? "Submitting…" : "Submit application"}
+              </button>
             </div>
-            <div className="wn-field">
-              <label htmlFor="a-email">Email</label>
-              <input id="a-email" name="email" type="email" required placeholder=" " className="wn-input w-full rounded-xl border p-3" />
+          </form>
+
+          <aside className="grid place-items-center rounded-xl border border-slate-200 bg-gradient-to-br from-[#e8f4fd] to-[#f7fbff] p-4 text-slate-600">
+            <div className="text-center">
+              <Image src="/placeholders/community-2.svg" alt="" width={320} height={180} />
+              <p className="mt-3 text-sm">
+                We welcome voices across Guyana, the Caribbean, and the diaspora.
+              </p>
             </div>
-          </div>
-          <div className="wn-field">
-            <label htmlFor="a-beat">Primary beat</label>
-            <input id="a-beat" name="beat" required placeholder=" " className="wn-input w-full rounded-xl border p-3" />
-          </div>
-          <div className="wn-field">
-            <label htmlFor="a-links">Links to clips (comma‑separated)</label>
-            <input id="a-links" name="links" placeholder="https://example.com/clip‑1, https://…" className="wn-input w-full rounded-xl border p-3" />
-          </div>
-          <div className="wn-field">
-            <label htmlFor="a-notes">Notes</label>
-            <textarea id="a-notes" name="notes" rows={6} placeholder=" " className="wn-input w-full rounded-xl border p-3" />
-          </div>
-          <div className="flex items-center justify-end">
-            <button className="wn-btn rounded-xl border px-4 py-2 font-medium">Submit application</button>
-          </div>
-        </form>
-      </section>
-    </main>
+          </aside>
+        </section>
+      </main>
+
+      {toast && <Toast {...toast} onDone={() => setToast(null)} />}
+    </>
   );
 }
 

--- a/frontend/pages/contact.jsx
+++ b/frontend/pages/contact.jsx
@@ -1,46 +1,173 @@
-export default function Contact() {
+import Head from "next/head";
+import Image from "next/image";
+import { useState } from "react";
+import { SUBJECTS } from "@/lib/cms-routing";
+import Toast from "@/components/Toast";
+
+export default function ContactPage() {
+  const [state, setState] = useState({ name: "", email: "", subject: "general", message: "" });
+  const [submitting, setSubmitting] = useState(false);
+  const [toast, setToast] = useState(null);
+
+  async function onSubmit(e) {
+    e.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      const fd = new FormData();
+      fd.append("subject", state.subject);
+      fd.append("name", state.name);
+      fd.append("email", state.email);
+      fd.append("message", state.message);
+      const r = await fetch("/api/inbox/create", { method: "POST", body: fd });
+      const json = await r.json();
+      if (!json.ok) throw new Error(json.error || "Failed");
+      setToast({ type: "success", message: "Thank you — submitted." });
+      setState({ name: "", email: "", subject: "general", message: "" });
+    } catch (_e) {
+      setToast({ type: "error", message: _e.message || "Something went wrong." });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   return (
-    <main className="mx-auto max-w-3xl px-4 pb-16">
-      {/* Hero band with soft brand gradient */}
-      <div className="sticky top-0 -mx-4 mb-6 h-28 bg-[image:var(--wn-grad-hero)] bg-[length:100%_100%] bg-no-repeat"></div>
-      <section className="wn-card-lg p-6">
-        <h1 className="mb-2 text-2xl font-semibold">Contact Us</h1>
-        <p className="mb-6 text-sm text-neutral-600">We’ll get back within 1–2 business days.</p>
+    <>
+      <Head>
+        <title>Contact Us — WaterNews</title>
+        <meta
+          name="description"
+          content="Reach WaterNews for tips, partnerships, advertising, and general inquiries."
+        />
+      </Head>
 
-        {/* a11y live region for submit state */}
-        <div aria-live="polite" aria-atomic="true" className="sr-only" id="contact-status" />
+      {/* HERO */}
+      <header className="relative grid min-h-[48vh] place-items-center overflow-hidden bg-gradient-to-b from-[#0f6cad] via-[#0b5d95] to-[#0a4f7f] px-4 text-white">
+        <div className="mx-auto flex max-w-5xl flex-col items-center text-center">
+          <Image
+            src="/placeholders/contact-hero.svg"
+            alt=""
+            width={520}
+            height={220}
+            priority
+          />
+          <h1 className="mt-4 text-3xl font-extrabold md:text-5xl">Contact WaterNews</h1>
+          <p className="mt-2 max-w-2xl text-sm opacity-95 md:text-base">
+            We read every message. For sensitive tips, email and request a secure channel.
+          </p>
+        </div>
+      </header>
 
-        <form
-          className="space-y-4"
-          onSubmit={(e) => {
-            const form = e.currentTarget;
-            const firstInvalid = form.querySelector(":invalid");
-            if (firstInvalid) {
-              e.preventDefault();
-              firstInvalid.scrollIntoView({ behavior: "smooth", block: "center" });
-              firstInvalid.focus();
-            }
-          }}
-        >
-          <div className="wn-field">
-            <label htmlFor="c-name">Your name</label>
-            <input id="c-name" name="name" required placeholder=" " className="wn-input w-full rounded-xl border p-3" />
-          </div>
-          <div className="wn-field">
-            <label htmlFor="c-email">Email</label>
-            <input id="c-email" name="email" type="email" required placeholder=" " className="wn-input w-full rounded-xl border p-3" />
-          </div>
-          <div className="wn-field">
-            <label htmlFor="c-msg">How can we help?</label>
-            <textarea id="c-msg" name="message" rows={6} required placeholder=" " className="wn-input w-full rounded-xl border p-3" />
-          </div>
-          <div className="flex items-center justify-between gap-3">
-            <span className="text-xs text-neutral-500">We’ll email you a confirmation.</span>
-            <button className="wn-btn rounded-xl border px-4 py-2 font-medium">Send</button>
-          </div>
-        </form>
-      </section>
-    </main>
+      <main className="mx-auto -mt-10 mb-16 max-w-5xl px-4">
+        {/* Quick routes */}
+        <section className="mb-8 grid gap-4 md:grid-cols-3">
+          {[
+            {
+              label: "News Tips",
+              email: "tips@waternewsgy.com",
+              desc: "Story ideas, documents, eyewitness info.",
+            },
+            {
+              label: "Corrections",
+              email: "corrections@waternewsgy.com",
+              desc: "Tell us what needs fixing.",
+            },
+            {
+              label: "Partnerships",
+              email: "hello@waternewsgy.com",
+              desc: "Press, events, advertising.",
+            },
+          ].map((c) => (
+            <a
+              key={c.label}
+              href={`mailto:${c.email}`}
+              className="rounded-2xl border border-slate-200 bg-white p-5 shadow transition hover:shadow-md"
+            >
+              <p className="m-0 text-sm font-semibold">{c.label}</p>
+              <p className="m-0 text-[13px] text-slate-600">{c.desc}</p>
+              <span className="mt-2 inline-block rounded-lg border border-[#cfe6f7] bg-[#eff7fd] px-3 py-1.5 text-xs font-semibold text-[#1583c2]">
+                {c.email}
+              </span>
+            </a>
+          ))}
+        </section>
+
+        {/* Contact form */}
+        <section className="grid gap-6 rounded-2xl bg-white p-6 shadow md:grid-cols-[1.1fr,0.9fr]">
+          <form onSubmit={onSubmit}>
+            <h2 className="text-xl font-bold">Send us a message</h2>
+            <div className="mt-3 grid gap-3">
+              <label className="block">
+                <span className="text-sm font-medium">Your name</span>
+                <input
+                  required
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  value={state.name}
+                  onChange={(e) => setState((s) => ({ ...s, name: e.target.value }))}
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium">Email</span>
+                <input
+                  required
+                  type="email"
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  value={state.email}
+                  onChange={(e) => setState((s) => ({ ...s, email: e.target.value }))}
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium">Subject</span>
+                <select
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  value={state.subject}
+                  onChange={(e) => setState((s) => ({ ...s, subject: e.target.value }))}
+                  name="subject"
+                >
+                  {SUBJECTS.map((s) => (
+                    <option key={s.value} value={s.value}>
+                      {s.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium">Message</span>
+                <textarea
+                  required
+                  rows={6}
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  value={state.message}
+                  onChange={(e) => setState((s) => ({ ...s, message: e.target.value }))}
+                />
+              </label>
+              <button
+                type="submit"
+                disabled={submitting}
+                className="mt-1 inline-flex items-center justify-center rounded-xl bg-[#1583c2] px-4 py-2 font-semibold text-white hover:brightness-110 disabled:opacity-60"
+              >
+                {submitting ? "Sending…" : "Send message"}
+              </button>
+            </div>
+          </form>
+
+          <aside className="grid place-items-center rounded-xl border border-slate-200 bg-gradient-to-br from-[#e8f4fd] to-[#f7fbff] p-4 text-slate-600">
+            <div className="text-center">
+              <Image src="/placeholders/community-1.svg" alt="" width={320} height={180} />
+              <p className="mt-3 text-sm">
+                Prefer social? Follow {" "}
+                <a className="font-semibold text-[#1583c2]" href="#">
+                  @WaterNewsGY
+                </a>{" "}
+                for headlines & highlights.
+              </p>
+            </div>
+          </aside>
+        </section>
+      </main>
+
+      {toast && <Toast {...toast} onDone={() => setToast(null)} />}
+    </>
   );
 }
 

--- a/frontend/pages/corrections.jsx
+++ b/frontend/pages/corrections.jsx
@@ -1,35 +1,154 @@
-export default function Corrections() {
+import Head from "next/head";
+import Image from "next/image";
+import { useState } from "react";
+import { SUBJECTS } from "@/lib/cms-routing";
+import Toast from "@/components/Toast";
+
+export default function CorrectionsPage() {
+  const [state, setState] = useState({ name: "", email: "", url: "", correction: "", subject: "correction" });
+  const [submitting, setSubmitting] = useState(false);
+  const [toast, setToast] = useState(null);
+
+  async function onSubmit(e) {
+    e.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      const fd = new FormData();
+      fd.append("subject", state.subject);
+      fd.append("name", state.name);
+      fd.append("email", state.email);
+      fd.append("message", `${state.correction}${state.url ? `\nURL: ${state.url}` : ""}`);
+      const r = await fetch("/api/inbox/create", { method: "POST", body: fd });
+      const json = await r.json();
+      if (!json.ok) throw new Error(json.error || "Failed");
+      setToast({ type: "success", message: "Thank you — submitted." });
+      setState({ name: "", email: "", url: "", correction: "", subject: "correction" });
+    } catch (e) {
+      setToast({ type: "error", message: e.message || "Something went wrong." });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   return (
-    <main className="mx-auto max-w-3xl px-4 pb-16">
-      <div className="sticky top-0 -mx-4 mb-6 h-28 bg-[image:var(--wn-grad-hero)] bg-[length:100%_100%] bg-no-repeat" />
-      <section className="wn-card p-6">
-        <h1 className="mb-2 text-2xl font-semibold">Request a Correction</h1>
-        <p className="mb-6 text-sm text-neutral-600">Provide the URL and what needs to be fixed.</p>
-        <form
-          className="space-y-4"
-          onSubmit={(e) => {
-            const el = e.currentTarget.querySelector(":invalid");
-            if (el) { e.preventDefault(); el.scrollIntoView({ behavior: "smooth", block: "center" }); el.focus(); }
-          }}
-        >
-          <div className="wn-field">
-            <label htmlFor="r-url">Article URL</label>
-            <input id="r-url" name="url" type="url" required placeholder=" " className="wn-input w-full rounded-xl border p-3" />
+    <>
+      <Head>
+        <title>Request a Correction — WaterNews</title>
+        <meta name="description" content="Report an error and we’ll review promptly." />
+      </Head>
+
+      <header className="bg-gradient-to-b from-[#0f6cad] via-[#0b5d95] to-[#0a4f7f] px-4 py-14 text-white">
+        <div className="mx-auto max-w-5xl">
+          <div className="mb-5 flex items-center gap-3">
+            <Image
+              src="/logo-waternews.svg"
+              alt="WaterNews"
+              width={220}
+              height={60}
+              priority
+            />
+            <h1 className="m-0 text-3xl font-extrabold leading-tight md:text-5xl">
+              Request a Correction
+            </h1>
           </div>
-          <div className="wn-field">
-            <label htmlFor="r-name">Your name (optional)</label>
-            <input id="r-name" name="name" placeholder=" " className="wn-input w-full rounded-xl border p-3" />
-          </div>
-          <div className="wn-field">
-            <label htmlFor="r-details">What’s incorrect?</label>
-            <textarea id="r-details" name="details" rows={6} required placeholder=" " className="wn-input w-full rounded-xl border p-3" />
-          </div>
-          <div className="flex items-center justify-end">
-            <button className="wn-btn rounded-xl border px-4 py-2 font-medium">Send correction</button>
-          </div>
-        </form>
-      </section>
-    </main>
+          <p className="max-w-3xl text-sm opacity-95 md:text-base">
+            We correct the record. Share the link and what needs fixing.
+          </p>
+        </div>
+      </header>
+
+      <main className="mx-auto my-10 max-w-5xl px-4">
+        <section className="grid gap-6 rounded-2xl bg-white p-6 shadow md:grid-cols-[1.1fr,0.9fr]">
+          <form onSubmit={onSubmit}>
+            <h2 className="text-xl font-bold">Submit a correction</h2>
+            <div className="mt-3 grid gap-3">
+              <label className="block">
+                <span className="text-sm font-medium">Your name</span>
+                <input
+                  required
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  value={state.name}
+                  onChange={(e) => setState((s) => ({ ...s, name: e.target.value }))}
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium">Email</span>
+                <input
+                  required
+                  type="email"
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  value={state.email}
+                  onChange={(e) => setState((s) => ({ ...s, email: e.target.value }))}
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium">Subject</span>
+                <select
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  value={state.subject}
+                  onChange={(e) => setState((s) => ({ ...s, subject: e.target.value }))}
+                  name="subject"
+                >
+                  {SUBJECTS.map((s) => (
+                    <option key={s.value} value={s.value}>
+                      {s.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium">Story URL</span>
+                <input
+                  required
+                  type="url"
+                  placeholder="https://waternews…"
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  value={state.url}
+                  onChange={(e) => setState((s) => ({ ...s, url: e.target.value }))}
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium">What should change?</span>
+                <textarea
+                  required
+                  rows={6}
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  value={state.correction}
+                  onChange={(e) => setState((s) => ({ ...s, correction: e.target.value }))}
+                />
+              </label>
+              <div className="flex flex-wrap items-center gap-3">
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="inline-flex items-center justify-center rounded-xl bg-[#1583c2] px-4 py-2 font-semibold text-white hover:brightness-110 disabled:opacity-60"
+                >
+                  {submitting ? "Sending…" : "Send request"}
+                </button>
+              </div>
+            </div>
+          </form>
+
+          <aside className="grid place-items-center rounded-xl border border-slate-200 bg-gradient-to-br from-[#e8f4fd] to-[#f7fbff] p-4 text-slate-600">
+            <div className="text-center">
+              <Image src="/placeholders/newsroom.svg" alt="" width={320} height={180} />
+              <p className="mt-3 text-sm">
+                Prefer email? Write {" "}
+                <a
+                  className="font-semibold text-[#1583c2]"
+                  href="mailto:corrections@waternewsgy.com"
+                >
+                  corrections@waternewsgy.com
+                </a>
+              </p>
+            </div>
+          </aside>
+        </section>
+      </main>
+
+      {toast && <Toast {...toast} onDone={() => setToast(null)} />}
+    </>
   );
 }
 

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -20,70 +20,12 @@ mark {
   --brand-wave-1: #1179C0;
   --brand-wave-2: #2DA6D9;
   --wn-slogan: #1e7fdc; /* matches logo slogan color; used by ticker when not breaking */
-
-  /* WaterNews surface & brand tints */
-  --wn-brand: 205 84% 37%;
-  --wn-surface: 0 0% 100%;
-  --wn-elev-1: 0 0% 0% / 0.06;  /* soft shadow */
-  --wn-elev-2: 0 0% 0% / 0.10;  /* medium shadow */
-  --wn-grad-hero-start: hsl(var(--wn-brand) / .10);
-  --wn-grad-hero: linear-gradient(180deg, var(--wn-grad-hero-start), transparent 60%);
 }
 h1,h2,h3 { line-height: var(--leading-tight); letter-spacing: -0.01em; }
 p { line-height: var(--leading-normal); }
 .line-clamp-2 { display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
 .line-clamp-3 { display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical; overflow:hidden; }
 .line-clamp-4 { display:-webkit-box; -webkit-line-clamp:4; -webkit-box-orient:vertical; overflow:hidden; }
-
-/* Elevation helpers */
-.wn-card {
-  background: hsl(var(--wn-surface));
-  border-radius: 1rem; /* rounded-2xl */
-  box-shadow: 0 1px 2px rgba(0,0,0,.04), 0 6px 24px hsla(0,0%,0%,.06);
-}
-.wn-card-lg {
-  background: hsl(var(--wn-surface));
-  border-radius: 1.25rem; /* rounded-3xl */
-  box-shadow: 0 1px 3px rgba(0,0,0,.06), 0 12px 32px hsla(0,0%,0%,.10);
-}
-
-/* Float label pattern (no layout shift) */
-.wn-field {
-  position: relative;
-}
-.wn-field input, .wn-field textarea, .wn-field select {
-  padding-top: 1.25rem; /* room for label */
-}
-.wn-field label {
-  position: absolute;
-  left: .75rem;
-  top: .6rem;
-  font-size: .75rem; /* text-xs */
-  color: rgb(107 114 128); /* gray-500 */
-  pointer-events: none;
-  transition: opacity .15s ease;
-}
-
-/* Focus ring + subtle glow (AA-safe) */
-.wn-input {
-  transition: box-shadow .15s ease, transform .06s ease;
-}
-.wn-input:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px rgba(59,130,246,.5), 0 8px 24px rgba(59,130,246,.08);
-}
-
-/* Buttons micro-interactions */
-.wn-btn {
-  transition: box-shadow .15s ease, transform .08s ease;
-}
-.wn-btn:hover { transform: translateY(-1px); box-shadow: 0 8px 24px var(--wn-elev-1); }
-.wn-btn:active { transform: translateY(0); box-shadow: 0 4px 12px var(--wn-elev-1); }
-
-/* Reduced motion respect */
-@media (prefers-reduced-motion: reduce) {
-  .wn-btn, .wn-input { transition: none }
-}
 
 /* Brand utility helpers */
 .text-brand { color: var(--brand-blue); }


### PR DESCRIPTION
## Summary
- restore pre-gradient Apply page with original form layout and styling
- revert Contact page to detailed layout and toast submission
- revert Corrections page and remove gradient additions in global styles

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find namespace 'React'; missing modules 'socket.io-client', 'socket.io', 'next-auth/jwt')*


------
https://chatgpt.com/codex/tasks/task_e_68a5441827e883298742ceccc469981b