### PR TITLE
feat: add drafts workflow with media library

### DIFF
--- a/frontend/lib/cloudinary.js
+++ b/frontend/lib/cloudinary.js
@@ -29,3 +29,14 @@ export async function uploadLocalFile(filepath, folder = "waternews/uploads") {
     format: res.format,
   };
 }
+
+// NEW: list media for library
+export async function listMedia({ prefix = "waternews", max_results = 40, next_cursor } = {}) {
+  const res = await cloudinary.search
+    .expression(`folder:${prefix}*`)
+    .sort_by("created_at", "desc")
+    .max_results(max_results)
+    .next_cursor(next_cursor || undefined)
+    .execute();
+  return res; // { resources, next_cursor }
+}

--- a/frontend/lib/email.js
+++ b/frontend/lib/email.js
@@ -1,0 +1,18 @@
+import nodemailer from "nodemailer";
+
+let transporter = null;
+function getTransport() {
+  if (transporter) return transporter;
+  const url = process.env.SMTP_URL;
+  if (!url) return null; // email disabled
+  transporter = nodemailer.createTransport(url);
+  return transporter;
+}
+
+export async function sendEmail({ to, subject, html, text }) {
+  const t = getTransport();
+  if (!t) return { ok: false, disabled: true };
+  const from = process.env.EMAIL_FROM || "WaterNews CMS <no-reply@waternews.invalid>";
+  await t.sendMail({ from, to, subject, html: html || text, text });
+  return { ok: true };
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "marked": "^12.0.2",
+    "nodemailer": "^6.9.8",
     "socket.io": "^4.7.5",
     "socket.io-client": "^4.7.5"
   },

--- a/frontend/pages/admin/drafts/[id].jsx
+++ b/frontend/pages/admin/drafts/[id].jsx
@@ -1,0 +1,180 @@
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/router";
+
+function useDebouncedCallback(cb, delay=600) {
+  const [t, setT] = useState(null);
+  return (...args) => {
+    if (t) clearTimeout(t);
+    setT(setTimeout(()=>cb(...args), delay));
+  };
+}
+
+export default function DraftEditor() {
+  const { query } = useRouter();
+  const { id } = query;
+  const [item, setItem] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [mediaOpen, setMediaOpen] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(`/api/drafts/get?id=${id}`).then(r=>r.json()).then(d=>setItem(d.item || null));
+  }, [id]);
+
+  const scheduleStr = useMemo(()=>{
+    if (!item?.scheduledAt) return "";
+    const dt = new Date(item.scheduledAt);
+    const z = n=>String(n).padStart(2,"0");
+    return `${dt.getFullYear()}-${z(dt.getMonth()+1)}-${z(dt.getDate())}T${z(dt.getHours())}:${z(dt.getMinutes())}`;
+  }, [item?.scheduledAt]);
+
+  const debouncedSave = useDebouncedCallback(async (patch) => {
+    setSaving(true);
+    await fetch("/api/drafts/update", {
+      method: "PATCH",
+      headers: { "Content-Type":"application/json" },
+      body: JSON.stringify({ id, patch })
+    });
+    const d = await (await fetch(`/api/drafts/get?id=${id}`)).json();
+    setItem(d.item || null);
+    setSaving(false);
+  }, 600);
+
+  if (!item) return <div className="p-6">Loading…</div>;
+
+  function insertAtCursor(textarea, snippet) {
+    const start = textarea.selectionStart || 0;
+    const end = textarea.selectionEnd || 0;
+    const before = textarea.value.slice(0,start);
+    const after = textarea.value.slice(end);
+    const next = before + snippet + after;
+    textarea.value = next;
+    debouncedSave({ body: next });
+  }
+
+  return (
+    <div className="p-6 grid gap-6 lg:grid-cols-3">
+      <div className="lg:col-span-2 bg-white rounded-xl shadow p-6">
+        <div className="flex items-center gap-3">
+          <input
+            className="w-full text-xl font-semibold border-b focus:outline-none"
+            defaultValue={item.title}
+            onChange={(e)=>debouncedSave({ title: e.target.value })}
+            placeholder="Title…"
+          />
+          <span className="text-xs text-gray-500">{saving ? "Saving…" : "Saved"}</span>
+        </div>
+
+        <div className="mt-4">
+          <textarea
+            id="editor"
+            className="w-full h-[420px] border rounded-lg p-3 font-mono"
+            defaultValue={item.body}
+            onChange={(e)=>debouncedSave({ body: e.target.value })}
+            placeholder="Write in Markdown…"
+          />
+          <div className="mt-3 flex gap-2">
+            <button onClick={()=>setMediaOpen(true)} className="px-3 py-2 rounded border">Insert Media</button>
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-xl shadow p-6 space-y-4">
+        <div>
+          <div className="text-sm font-medium text-gray-700">Status</div>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {["draft","in-review","ready","scheduled","published","archived"].map(s=>(
+              <button key={s} onClick={()=>debouncedSave({ status: s })} className={`px-3 py-1 rounded border ${item.status===s?"bg-blue-600 text-white":"bg-white"}`}>{s}</button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <div className="text-sm font-medium text-gray-700">Schedule</div>
+          <input
+            type="datetime-local"
+            className="mt-2 w-full border rounded px-3 py-2"
+            value={scheduleStr}
+            onChange={(e)=>debouncedSave({ scheduledAt: e.target.value || null })}
+          />
+        </div>
+
+        <div>
+          <div className="text-sm font-medium text-gray-700">Assignment</div>
+          <input className="mt-2 w-full border rounded px-3 py-2" placeholder="Assignee email"
+            defaultValue={item.assignedTo?.email || ""}
+            onBlur={(e)=>debouncedSave({ assignedTo: e.target.value ? { email: e.target.value } : null })}
+          />
+        </div>
+
+        <div>
+          <div className="text-sm font-medium text-gray-700">Reviewers</div>
+          <textarea className="mt-2 w-full border rounded px-3 py-2" placeholder="Comma-separated reviewer emails"
+            defaultValue={(item.reviewers||[]).map(r=>r.email).join(",")}
+            onBlur={(e)=>{
+              const list = e.target.value.split(",").map(s=>s.trim()).filter(Boolean).map(email=>({ email }));
+              debouncedSave({ reviewers: list });
+            }}
+          />
+          <label className="mt-2 flex items-center gap-2 text-sm">
+            <input type="checkbox" defaultChecked={!!item.secondReviewRequired}
+              onChange={(e)=>debouncedSave({ secondReviewRequired: e.target.checked })}/>
+            Second review required
+          </label>
+        </div>
+
+        {item.ticketId && (
+          <div className="text-xs text-gray-500">Linked Ticket: {String(item.ticketId)}</div>
+        )}
+      </div>
+
+      {/* Media Library Modal */}
+      {mediaOpen && <MediaModal onClose={()=>setMediaOpen(false)} onPick={(m)=>{
+        setMediaOpen(false);
+        const ta = document.getElementById("editor");
+        if (!ta) return;
+        const snippet = `\n![media](${m.url})\n`;
+        insertAtCursor(ta, snippet);
+      }} />}
+    </div>
+  );
+}
+
+function MediaModal({ onClose, onPick }) {
+  const [items, setItems] = useState([]);
+  const [cursor, setCursor] = useState(null);
+  useEffect(()=>{
+    fetch(`/api/media/list`).then(r=>r.json()).then(d=>{
+      setItems(d.resources || []);
+      setCursor(d.next_cursor || null);
+    });
+  },[]);
+  async function loadMore() {
+    const r = await fetch(`/api/media/list?cursor=${encodeURIComponent(cursor)}`);
+    const d = await r.json();
+    setItems(prev => [...prev, ...(d.resources||[])]);
+    setCursor(d.next_cursor || null);
+  }
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-xl shadow-xl max-w-4xl w-full p-6">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold">Media Library</h3>
+          <button onClick={onClose} className="text-gray-500">Close</button>
+        </div>
+        <div className="mt-4 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 max-h-[60vh] overflow-auto">
+          {items.map((r)=>(
+            <button key={r.public_id} className="border rounded-lg overflow-hidden hover:shadow"
+              onClick={()=>onPick({ url: r.secure_url || r.url, public_id: r.public_id, resource_type: r.resource_type })}>
+              <img src={r.secure_url || r.url} alt={r.public_id} className="w-full h-32 object-cover" />
+              <div className="p-2 text-xs truncate">{r.public_id}</div>
+            </button>
+          ))}
+        </div>
+        <div className="mt-4 flex justify-end">
+          {cursor && <button onClick={loadMore} className="px-4 py-2 rounded border">Load more</button>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/pages/admin/drafts/index.jsx
+++ b/frontend/pages/admin/drafts/index.jsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+export default function DraftsList() {
+  const [q, setQ] = useState("");
+  const [status, setStatus] = useState("all");
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (q) params.set("q", q);
+    if (status) params.set("status", status);
+    fetch(`/api/drafts/list?${params}`).then(r=>r.json()).then(d=>setItems(d.items||[]));
+  }, [q, status]);
+
+  async function createDraft() {
+    const r = await fetch("/api/drafts/create", { method:"POST", headers:{ "Content-Type":"application/json"}, body: JSON.stringify({}) });
+    const d = await r.json();
+    if (d.id) location.href = `/admin/drafts/${d.id}`;
+  }
+
+  return (
+    <div className="p-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Drafts</h1>
+        <button onClick={createDraft} className="px-4 py-2 bg-blue-600 text-white rounded-lg">New Draft</button>
+      </div>
+
+      <div className="mt-4 flex gap-3">
+        <input className="border rounded px-3 py-2" placeholder="Search…" value={q} onChange={e=>setQ(e.target.value)} />
+        <select className="border rounded px-3 py-2" value={status} onChange={e=>setStatus(e.target.value)}>
+          {["all","draft","in-review","ready","scheduled","published","archived"].map(s=><option key={s}>{s}</option>)}
+        </select>
+      </div>
+
+      <div className="mt-6 bg-white rounded-xl shadow overflow-hidden">
+        <table className="min-w-full">
+          <thead className="bg-gray-50 text-left text-sm">
+            <tr>
+              <th className="px-4 py-2">Updated</th>
+              <th className="px-4 py-2">Title</th>
+              <th className="px-4 py-2">Status</th>
+              <th className="px-4 py-2">Assigned</th>
+              <th className="px-4 py-2">Scheduled</th>
+              <th className="px-4 py-2"></th>
+            </tr>
+          </thead>
+          <tbody className="text-sm">
+            {items.map(x=>(
+              <tr key={x._id} className="border-t">
+                <td className="px-4 py-2">{new Date(x.updatedAt).toLocaleString()}</td>
+                <td className="px-4 py-2">{x.title}</td>
+                <td className="px-4 py-2 capitalize">{x.status}</td>
+                <td className="px-4 py-2">{x.assignedTo?.name || x.assignedTo?.email || "—"}</td>
+                <td className="px-4 py-2">{x.scheduledAt ? new Date(x.scheduledAt).toLocaleString() : "—"}</td>
+                <td className="px-4 py-2">
+                  <Link href={`/admin/drafts/${x._id}`} className="text-blue-600 underline">Open</Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/pages/admin/inbox/[id].jsx
+++ b/frontend/pages/admin/inbox/[id].jsx
@@ -13,10 +13,26 @@ export default function TicketDetail() {
       });
     }
   }, [id]);
+
+  async function createDraftFromTicket() {
+    const r = await fetch("/api/drafts/from-ticket", {
+      method: "POST",
+      headers: { "Content-Type":"application/json" },
+      body: JSON.stringify({ ticketId: id })
+    });
+    const d = await r.json();
+    if (d.id) location.href = `/admin/drafts/${d.id}`;
+  }
+
   if (!ticket) return <div className="p-6">Loading...</div>;
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">{ticket.subject}</h1>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-bold">{ticket.subject}</h1>
+        <button onClick={createDraftFromTicket} className="px-3 py-1 rounded bg-blue-600 text-white">
+          Create Draft
+        </button>
+      </div>
       <p><strong>Name:</strong> {ticket.name}</p>
       <p><strong>Email:</strong> {ticket.email}</p>
       <p className="mt-4 whitespace-pre-line">{ticket.body}</p>

--- a/frontend/pages/api/drafts/create.js
+++ b/frontend/pages/api/drafts/create.js
@@ -1,0 +1,60 @@
+import { getDb } from "@/lib/db";
+import { ObjectId } from "mongodb";
+import { sendEmail } from "@/lib/email";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") return res.status(405).json({ ok: false });
+  try {
+    const db = await getDb();
+    if (!db) return res.status(200).json({ ok: true, id: null }); // noop
+
+    const {
+      title = "Untitled Draft",
+      body = "",
+      ticketId = null,
+      assignedTo = null, // { email, name }
+      reviewers = [],     // [{ email, name }]
+      secondReviewRequired = false
+    } = req.body || {};
+
+    const now = new Date();
+    const doc = {
+      title: String(title),
+      body: String(body),
+      ticketId: ticketId ? new ObjectId(String(ticketId)) : null,
+      status: "draft",
+      scheduledAt: null,
+      assignedTo: assignedTo || null,
+      reviewers: Array.isArray(reviewers) ? reviewers : [],
+      secondReviewRequired: !!secondReviewRequired,
+      media: [],
+      createdAt: now,
+      updatedAt: now,
+      history: [{ at: now, by: null, action: "created", meta: { ticketId } }]
+    };
+
+    const r = await db.collection("drafts").insertOne(doc);
+
+    // Notify assignee (optional)
+    if (assignedTo?.email) {
+      await sendEmail({
+        to: assignedTo.email,
+        subject: `New Draft Assigned: ${doc.title}`,
+        text: `A draft has been assigned to you.\n\nTitle: ${doc.title}`
+      });
+    }
+
+    // Optionally link back to the ticket with draftId
+    if (doc.ticketId) {
+      await db.collection("tickets").updateOne(
+        { _id: doc.ticketId },
+        { $set: { draftId: r.insertedId }, $push: { history: { at: now, by: null, action: "draft-created", meta: { draftId: r.insertedId } } } }
+      );
+    }
+
+    return res.status(200).json({ ok: true, id: r.insertedId });
+  } catch (e) {
+    console.error(e);
+    return res.status(500).json({ ok: false, error: "Server error" });
+  }
+}

--- a/frontend/pages/api/drafts/from-ticket.js
+++ b/frontend/pages/api/drafts/from-ticket.js
@@ -1,0 +1,38 @@
+import { getDb } from "@/lib/db";
+import { ObjectId } from "mongodb";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") return res.status(405).json({ ok: false });
+  try {
+    const db = await getDb();
+    if (!db) return res.status(200).json({ ok: true, id: null });
+    const { ticketId } = req.body || {};
+    const t = await db.collection("tickets").findOne({ _id: new ObjectId(String(ticketId)) });
+    if (!t) return res.status(404).json({ ok: false, error: "Ticket not found" });
+
+    const now = new Date();
+    const draft = {
+      title: `[From Ticket] ${t.subject} • ${t.name || "Anonymous"}`,
+      body: t.body || "",
+      ticketId: t._id,
+      status: "draft",
+      scheduledAt: null,
+      assignedTo: null,
+      reviewers: [],
+      secondReviewRequired: false,
+      media: t.attachments || [],
+      createdAt: now,
+      updatedAt: now,
+      history: [{ at: now, by: null, action: "created-from-ticket", meta: { ticketId: t._id } }]
+    };
+    const r = await db.collection("drafts").insertOne(draft);
+    await db.collection("tickets").updateOne(
+      { _id: t._id },
+      { $set: { draftId: r.insertedId }, $push: { history: { at: now, by: null, action: "linked-to-draft", meta: { draftId: r.insertedId } } } }
+    );
+    return res.status(200).json({ ok: true, id: r.insertedId });
+  } catch (e) {
+    console.error(e);
+    return res.status(500).json({ ok: false });
+  }
+}

--- a/frontend/pages/api/drafts/get.js
+++ b/frontend/pages/api/drafts/get.js
@@ -1,0 +1,15 @@
+import { getDb } from "@/lib/db";
+import { ObjectId } from "mongodb";
+
+export default async function handler(req, res) {
+  try {
+    const db = await getDb();
+    if (!db) return res.status(200).json({ item: null });
+    const id = String(req.query.id || "");
+    const item = await db.collection("drafts").findOne({ _id: new ObjectId(id) });
+    return res.status(200).json({ item });
+  } catch (e) {
+    console.error(e);
+    return res.status(200).json({ item: null });
+  }
+}

--- a/frontend/pages/api/drafts/list.js
+++ b/frontend/pages/api/drafts/list.js
@@ -1,0 +1,26 @@
+import { getDb } from "@/lib/db";
+
+export default async function handler(req, res) {
+  try {
+    const db = await getDb();
+    if (!db) return res.status(200).json({ items: [] });
+    const { q = "", status = "", assigned = "" } = req.query;
+    const where = {};
+    if (status && status !== "all") where.status = status;
+    if (assigned === "me") {
+      // TODO: resolve actual user email via auth
+      where["assignedTo.email"] = "__your_email__";
+    }
+    if (q) {
+      where.$or = [
+        { title: { $regex: q, $options: "i" } },
+        { body: { $regex: q, $options: "i" } }
+      ];
+    }
+    const items = await db.collection("drafts").find(where).sort({ updatedAt: -1 }).limit(200).toArray();
+    return res.status(200).json({ items });
+  } catch (e) {
+    console.error(e);
+    return res.status(200).json({ items: [] });
+  }
+}

--- a/frontend/pages/api/drafts/update.js
+++ b/frontend/pages/api/drafts/update.js
@@ -1,0 +1,55 @@
+import { getDb } from "@/lib/db";
+import { ObjectId } from "mongodb";
+import { sendEmail } from "@/lib/email";
+
+export default async function handler(req, res) {
+  if (req.method !== "PATCH") return res.status(405).json({ ok: false });
+  try {
+    const db = await getDb();
+    if (!db) return res.status(200).json({ ok: true });
+    const { id, patch } = req.body || {};
+    const _id = new ObjectId(String(id));
+    const set = { updatedAt: new Date() };
+
+    if ("title" in patch) set.title = String(patch.title);
+    if ("body" in patch) set.body = String(patch.body);
+    if ("status" in patch) set.status = String(patch.status);
+    if ("scheduledAt" in patch) set.scheduledAt = patch.scheduledAt ? new Date(patch.scheduledAt) : null;
+    if ("assignedTo" in patch) set.assignedTo = patch.assignedTo || null;
+    if ("reviewers" in patch) set.reviewers = Array.isArray(patch.reviewers) ? patch.reviewers : [];
+    if ("secondReviewRequired" in patch) set.secondReviewRequired = !!patch.secondReviewRequired;
+    if ("media" in patch) set.media = Array.isArray(patch.media) ? patch.media : [];
+
+    await db.collection("drafts").updateOne(
+      { _id },
+      { $set: set, $push: { history: { at: new Date(), by: null, action: "update", meta: patch } } }
+    );
+
+    // notify reviewers when moving to in-review
+    if (patch.status === "in-review") {
+      const doc = await db.collection("drafts").findOne({ _id });
+      const emails = (doc.reviewers || []).map(r => r.email).filter(Boolean);
+      if (emails.length) {
+        await sendEmail({
+          to: emails.join(","),
+          subject: `Draft ready for review: ${doc.title}`,
+          text: `A draft is ready for review.\n\nTitle: ${doc.title}`
+        });
+      }
+    }
+
+    // notify assignee on assign
+    if (patch.assignedTo?.email) {
+      await sendEmail({
+        to: patch.assignedTo.email,
+        subject: `Draft assigned to you`,
+        text: `You have been assigned a draft.`
+      });
+    }
+
+    return res.status(200).json({ ok: true });
+  } catch (e) {
+    console.error(e);
+    return res.status(200).json({ ok: false });
+  }
+}

--- a/frontend/pages/api/media/list.js
+++ b/frontend/pages/api/media/list.js
@@ -1,0 +1,12 @@
+import { listMedia } from "@/lib/cloudinary";
+
+export default async function handler(req, res) {
+  try {
+    const { cursor, prefix = "waternews" } = req.query;
+    const r = await listMedia({ prefix, next_cursor: cursor || undefined, max_results: 40 });
+    return res.status(200).json({ resources: r.resources || [], next_cursor: r.next_cursor || null });
+  } catch (e) {
+    console.error(e);
+    return res.status(200).json({ resources: [], next_cursor: null });
+  }
+}


### PR DESCRIPTION
## Summary
- add optional SMTP email helper and Cloudinary media listing
- implement draft APIs with autosave editor, scheduling, assignment, reviewers, and media browser
- allow creating drafts from tickets and list/manage drafts in admin UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a54672e9b8832999f2baf7e30c0bd5