### PR TITLE
Use NextAuth session for admin access control

### DIFF
--- a/frontend/pages/admin/inbox.jsx
+++ b/frontend/pages/admin/inbox.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/pages/api/auth/[...nextauth]";
 import { isAdminEmail, isAdminUser } from "@/lib/admin-auth";
 
 export default function AdminInbox() {
@@ -25,7 +27,8 @@ export default function AdminInbox() {
 }
 
 export async function getServerSideProps(ctx) {
-  const email = ctx.req?.headers["x-user-email"] || null;
+  const session = await getServerSession(ctx.req, ctx.res, authOptions);
+  const email = session?.user?.email || null;
   const ok = (await isAdminEmail(email)) || (await isAdminUser(email));
   if (!ok) {
     return { redirect: { destination: "/profile", permanent: false } };

--- a/frontend/pages/admin/inbox/[id].jsx
+++ b/frontend/pages/admin/inbox/[id].jsx
@@ -1,5 +1,7 @@
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/pages/api/auth/[...nextauth]";
 import { isAdminEmail, isAdminUser } from "@/lib/admin-auth";
 
 export default function TicketDetail() {
@@ -41,7 +43,8 @@ export default function TicketDetail() {
 }
 
 export async function getServerSideProps(ctx) {
-  const email = ctx.req?.headers["x-user-email"] || null;
+  const session = await getServerSession(ctx.req, ctx.res, authOptions);
+  const email = session?.user?.email || null;
   const ok = (await isAdminEmail(email)) || (await isAdminUser(email));
   if (!ok) {
     return { redirect: { destination: "/profile", permanent: false } };

--- a/frontend/pages/api/drafts/from-ticket.js
+++ b/frontend/pages/api/drafts/from-ticket.js
@@ -1,8 +1,15 @@
 import { getDb } from "@/lib/db";
 import { ObjectId } from "mongodb";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+import { isAdminEmail, isAdminUser } from "@/lib/admin-auth";
 
 export default async function handler(req, res) {
   if (req.method !== "POST") return res.status(405).json({ ok: false });
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  const ok = (await isAdminEmail(email)) || (await isAdminUser(email));
+  if (!ok) return res.status(401).json({ ok: false });
   try {
     const db = await getDb();
     if (!db) return res.status(200).json({ ok: true, id: null });

--- a/frontend/pages/api/inbox/[id].js
+++ b/frontend/pages/api/inbox/[id].js
@@ -1,7 +1,14 @@
 import { getDb } from "@/lib/db";
 import { ObjectId } from "mongodb";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+import { isAdminEmail, isAdminUser } from "@/lib/admin-auth";
 
 export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  const ok = (await isAdminEmail(email)) || (await isAdminUser(email));
+  if (!ok) return res.status(401).json({ ok: false, error: "Unauthorized" });
   const { id } = req.query;
   if (!id) return res.status(400).json({ ok: false, error: "Missing id" });
   const db = await getDb();

--- a/frontend/pages/api/inbox/[id]/notes.js
+++ b/frontend/pages/api/inbox/[id]/notes.js
@@ -1,7 +1,14 @@
 import { getDb } from "@/lib/db";
 import { ObjectId } from "mongodb";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../auth/[...nextauth]";
+import { isAdminEmail, isAdminUser } from "@/lib/admin-auth";
 
 export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  const ok = (await isAdminEmail(email)) || (await isAdminUser(email));
+  if (!ok) return res.status(401).json({ ok: false, error: "Unauthorized" });
   const { id } = req.query;
   if (!id) return res.status(400).json({ ok: false, error: "Missing id" });
   if (req.method !== "POST") return res.status(405).json({ ok: false, error: "Method not allowed" });

--- a/frontend/pages/api/inbox/get.js
+++ b/frontend/pages/api/inbox/get.js
@@ -1,8 +1,15 @@
 import { getDb } from "@/lib/db";
 import { ObjectId } from "mongodb";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+import { isAdminEmail, isAdminUser } from "@/lib/admin-auth";
 
 export default async function handler(req, res) {
   if (req.method !== "GET") return res.status(405).json({ ok: false, error: "Method not allowed" });
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  const ok = (await isAdminEmail(email)) || (await isAdminUser(email));
+  if (!ok) return res.status(401).json({ ok: false, error: "Unauthorized" });
   const { id } = req.query;
   if (!id) return res.status(400).json({ ok: false, error: "Missing id" });
   const db = await getDb();

--- a/frontend/pages/api/inbox/list.js
+++ b/frontend/pages/api/inbox/list.js
@@ -1,7 +1,14 @@
 import { getDb } from "@/lib/db";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+import { isAdminEmail, isAdminUser } from "@/lib/admin-auth";
 
 export default async function handler(req, res) {
   if (req.method !== "GET") return res.status(405).json({ ok: false, error: "Method not allowed" });
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  const ok = (await isAdminEmail(email)) || (await isAdminUser(email));
+  if (!ok) return res.status(401).json({ ok: false, error: "Unauthorized" });
   const db = await getDb();
   if (!db) return res.status(200).json({ ok: true, items: [] });
   const items = await db.collection("tickets").find().sort({ createdAt: -1 }).limit(100).toArray();


### PR DESCRIPTION
## Summary
- secure admin inbox pages by using `getServerSession` instead of `x-user-email`
- rely on NextAuth session for inbox and draft API routes with admin helpers

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68a557ff6f7c8329a0a6d092df0243c2