### PR TITLE
Add Newsroom link in header

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -31,8 +31,14 @@ export default function Header() {
           <SmartMenu />
         </div>
 
-        {/* right actions: inline expanding search + bell */}
+        {/* right actions: newsroom link + inline expanding search + bell */}
         <div className="flex items-center gap-2">
+          <Link
+            href="/admin"
+            className="rounded-md px-3 py-2 text-sm font-medium text-gray-600 hover:text-blue-700"
+          >
+            Newsroom
+          </Link>
           <SearchBox />
           <NotificationsBellMenu />
         </div>


### PR DESCRIPTION
## Summary
- add Newsroom entry to header actions linking to /admin

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find type definition file for 'node', 'react', 'react-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68a557e7121c8329b887f624f2c85fea