### PR TITLE
Add post submission, publishing, and posts listing

### DIFF
--- a/frontend/pages/api/newsroom/drafts/[id]/publish.js
+++ b/frontend/pages/api/newsroom/drafts/[id]/publish.js
@@ -1,0 +1,62 @@
+import { ObjectId } from 'mongodb';
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+import { isAdminEmail, isAdminUser } from '@/lib/admin-auth';
+import { slugify } from '@/lib/slugify';
+
+async function ensureUniqueSlug(col, base) {
+  const s = slugify(base || 'untitled');
+  const exists = await col.findOne({ slug: s });
+  if (!exists) return s;
+  let i = 2;
+  while (true) {
+    const cand = `${s}-${i}`;
+    const hit = await col.findOne({ slug: cand });
+    if (!hit) return cand;
+    i++;
+  }
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  if (!email) return res.status(401).json({ error: 'Unauthorized' });
+
+  const db = await getDb();
+  const drafts = db.collection('drafts');
+  const posts = db.collection('posts');
+  const _id = new ObjectId(String(req.query.id));
+
+  const admin = (await isAdminEmail(email)) || (await isAdminUser(email));
+  if (!admin) return res.status(403).json({ error: 'Admins only' });
+
+  const draft = await drafts.findOne({ _id });
+  if (!draft) return res.status(404).json({ error: 'Draft not found' });
+
+  const now = new Date();
+  const publishedAt = now.toISOString();
+  const slug = await ensureUniqueSlug(posts, draft.slug || draft.title);
+  const postDoc = {
+    title: draft.title || 'Untitled',
+    slug,
+    body: draft.body || '',
+    excerpt: draft.excerpt || '',
+    tags: draft.tags || [],
+    authorEmail: draft.authorEmail || email.toLowerCase(),
+    media: draft.media || [],
+    createdAt: publishedAt,
+    updatedAt: publishedAt,
+    publishedAt
+  };
+  const ins = await posts.insertOne(postDoc);
+
+  await drafts.updateOne(
+    { _id },
+    { $set: { status: 'published', postId: ins.insertedId, publishedAt, updatedAt: publishedAt } }
+  );
+
+  const post = await posts.findOne({ _id: ins.insertedId });
+  return res.json({ ok: true, post });
+}

--- a/frontend/pages/api/newsroom/drafts/[id]/submit.js
+++ b/frontend/pages/api/newsroom/drafts/[id]/submit.js
@@ -1,0 +1,30 @@
+import { ObjectId } from 'mongodb';
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+import { isAdminEmail, isAdminUser } from '@/lib/admin-auth';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  if (!email) return res.status(401).json({ error: 'Unauthorized' });
+
+  const db = await getDb();
+  const drafts = db.collection('drafts');
+  const _id = new ObjectId(String(req.query.id));
+
+  const doc = await drafts.findOne({ _id });
+  if (!doc) return res.status(404).json({ error: 'Draft not found' });
+
+  const admin = (await isAdminEmail(email)) || (await isAdminUser(email));
+  const isOwner = (doc.authorEmail || '').toLowerCase() === email.toLowerCase();
+  if (!admin && !isOwner) return res.status(403).json({ error: 'Forbidden' });
+
+  // If second review is required, stay in 'needs_second_review'
+  const nextStatus = doc.requireSecondReview ? 'needs_second_review' : 'ready';
+  const now = new Date().toISOString();
+  await drafts.updateOne({ _id }, { $set: { status: nextStatus, updatedAt: now } });
+  const updated = await drafts.findOne({ _id });
+  return res.json({ ok: true, draft: updated });
+}

--- a/frontend/pages/api/newsroom/posts.js
+++ b/frontend/pages/api/newsroom/posts.js
@@ -1,0 +1,26 @@
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+import { isAdminEmail, isAdminUser } from '@/lib/admin-auth';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  if (!email) return res.status(401).json({ error: 'Unauthorized' });
+
+  const db = await getDb();
+  const posts = db.collection('posts');
+
+  const admin = (await isAdminEmail(email)) || (await isAdminUser(email));
+  const { all, author, q } = req.query || {};
+  const filter = {};
+  if (admin && all === '1' && author) {
+    filter.authorEmail = String(author).toLowerCase();
+  } else {
+    filter.authorEmail = email.toLowerCase();
+  }
+  if (q) filter.title = { $regex: String(q), $options: 'i' };
+  const items = await posts.find(filter).sort({ publishedAt: -1 }).limit(200).toArray();
+  res.json({ items });
+}

--- a/frontend/pages/api/publish/run.js
+++ b/frontend/pages/api/publish/run.js
@@ -1,0 +1,64 @@
+// Cron-style endpoint to publish scheduled drafts whose publishAt <= now
+import { ObjectId } from 'mongodb';
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+import { isAdminEmail, isAdminUser } from '@/lib/admin-auth';
+import { slugify } from '@/lib/slugify';
+
+async function ensureUniqueSlug(col, base) {
+  const s = slugify(base || 'untitled');
+  const exists = await col.findOne({ slug: s });
+  if (!exists) return s;
+  let i = 2;
+  while (true) {
+    const cand = `${s}-${i}`;
+    const hit = await col.findOne({ slug: cand });
+    if (!hit) return cand;
+    i++;
+  }
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  // Allow only admins to trigger this (can be hooked up to a Render cron with a service account)
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  const admin = email && ((await isAdminEmail(email)) || (await isAdminUser(email)));
+  if (!admin) return res.status(401).json({ error: 'Unauthorized' });
+
+  const db = await getDb();
+  const drafts = db.collection('drafts');
+  const posts = db.collection('posts');
+  const nowIso = new Date().toISOString();
+
+  const due = await drafts.find({
+    status: 'scheduled',
+    publishAt: { $lte: nowIso }
+  }).toArray();
+
+  const results = [];
+  for (const d of due) {
+    const slug = await ensureUniqueSlug(posts, d.slug || d.title);
+    const publishedAt = new Date().toISOString();
+    const postDoc = {
+      title: d.title || 'Untitled',
+      slug,
+      body: d.body || '',
+      excerpt: d.excerpt || '',
+      tags: d.tags || [],
+      authorEmail: d.authorEmail || email?.toLowerCase() || 'system',
+      media: d.media || [],
+      createdAt: publishedAt,
+      updatedAt: publishedAt,
+      publishedAt
+    };
+    const ins = await posts.insertOne(postDoc);
+    await drafts.updateOne(
+      { _id: new ObjectId(String(d._id)) },
+      { $set: { status: 'published', postId: ins.insertedId, publishedAt, updatedAt: publishedAt } }
+    );
+    results.push({ draftId: d._id, postId: ins.insertedId, slug });
+  }
+  return res.json({ ok: true, published: results.length, results });
+}

--- a/frontend/pages/newsroom/drafts/[id].tsx
+++ b/frontend/pages/newsroom/drafts/[id].tsx
@@ -87,6 +87,31 @@ export default function WriterDraftEditor() {
             <option value="scheduled">Scheduled</option>
             <option value="published">Published</option>
           </select>
+          <button
+            onClick={async () => {
+              const r = await fetch(`/api/newsroom/drafts/${id}/submit`, { method: 'POST' });
+              const d = await r.json();
+              if (!r.ok) return alert(d?.error || 'Failed to submit for review');
+              setDoc(d.draft || doc);
+              alert('Submitted for review');
+            }}
+            className="px-3 py-2 rounded bg-gray-100 text-sm"
+          >
+            Submit for review
+          </button>
+          <button
+            onClick={async () => {
+              if (!confirm('Publish now? (Admins only)')) return;
+              const r = await fetch(`/api/newsroom/drafts/${id}/publish`, { method: 'POST' });
+              const d = await r.json();
+              if (!r.ok) return alert(d?.error || 'Failed to publish');
+              alert('Published');
+              location.href = `/news/${d?.post?.slug}`;
+            }}
+            className="px-3 py-2 rounded bg-black text-white text-sm"
+          >
+            Publish now
+          </button>
         </div>
       </div>
 
@@ -144,6 +169,9 @@ export default function WriterDraftEditor() {
           queueSave({ ...doc, media });
         }}
       />
+      <div className="pt-6">
+        <a href="/newsroom/posts" className="text-sm underline underline-offset-4">See my published posts →</a>
+      </div>
     </div>
   );
 }

--- a/frontend/pages/newsroom/index.tsx
+++ b/frontend/pages/newsroom/index.tsx
@@ -91,7 +91,10 @@ export default function NewsroomHome() {
         </ul>
       )}
 
-      <div className="pt-4">
+      <div className="pt-4 flex items-center gap-6">
+        <Link href="/newsroom/posts" className="text-sm underline underline-offset-4">
+          My posts
+        </Link>
         <Link href="/profile" className="text-sm text-gray-600 underline underline-offset-4">
           Go to your profile
         </Link>

--- a/frontend/pages/newsroom/posts/index.tsx
+++ b/frontend/pages/newsroom/posts/index.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import type { GetServerSideProps } from 'next';
+import Link from 'next/link';
+import { requireAuthSSR } from '@/lib/user-guard';
+
+export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx);
+
+export default function MyPosts() {
+  const [items, setItems] = useState<any[]>([]);
+  const [q, setQ] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const qs = new URLSearchParams({});
+        if (q) qs.set('q', q);
+        const r = await fetch(`/api/newsroom/posts?${qs.toString()}`);
+        if (!r.ok) throw new Error('Failed to load');
+        const d = await r.json();
+        if (!mounted) return;
+        setItems(d.items || []);
+      } catch (e: any) {
+        if (!mounted) return;
+        setError(e?.message || 'Error');
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => { mounted = false; };
+  }, [q]);
+
+  return (
+    <div className="max-w-5xl mx-auto p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">My Posts</h1>
+        <Link href="/newsroom" className="text-sm underline underline-offset-4">Back to Newsroom</Link>
+      </div>
+      <div className="flex gap-2">
+        <input className="border rounded px-3 py-2 w-full" placeholder="Search posts…" value={q} onChange={e=>setQ(e.target.value)} />
+      </div>
+      {loading ? (
+        <div className="text-gray-500">Loading…</div>
+      ) : error ? (
+        <div className="text-red-600">{error}</div>
+      ) : items.length === 0 ? (
+        <div className="border rounded-xl p-6 text-gray-600">No published posts yet.</div>
+      ) : (
+        <ul className="divide-y rounded-xl border">
+          {items.map((it: any) => (
+            <li key={it._id} className="flex items-center justify-between p-4">
+              <div>
+                <div className="font-medium">{it.title}</div>
+                <div className="text-xs text-gray-500">
+                  {it.publishedAt ? new Date(it.publishedAt).toLocaleString() : '—'}
+                </div>
+              </div>
+              <Link href={`/news/${it.slug}`} className="text-blue-600 hover:underline">View</Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/pages/profile.tsx
+++ b/frontend/pages/profile.tsx
@@ -56,9 +56,9 @@ export default function Profile() {
             <div className="font-medium">Newsroom</div>
             <div className="text-sm text-gray-600">Create drafts, edit, and schedule posts</div>
           </Link>
-          <Link href="/newsroom" className="block border rounded-xl p-4 hover:shadow">
+          <Link href="/newsroom/posts" className="block border rounded-xl p-4 hover:shadow">
             <div className="font-medium">My drafts</div>
-            <div className="text-sm text-gray-600">Jump back to your in-progress stories</div>
+            <div className="text-sm text-gray-600">View your published posts</div>
           </Link>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- add API endpoints for draft submission, direct publish, and scheduled publishing
- expose posts listing for authors with new UI to manage posts
- update newsroom and profile pages with links and publish controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a56aec84f8832989a639b06cd40617