### PR TITLE
fix: stabilize Next shims

### DIFF
--- a/frontend/components/Newsroom/MarkdownEditor.tsx
+++ b/frontend/components/Newsroom/MarkdownEditor.tsx
@@ -1,4 +1,6 @@
-import React, { useEffect, useRef, useState, type KeyboardEventHandler } from "react";
+// Use the React namespace for event types to avoid shim/version mismatches.
+import type * as React from 'react';
+import { useEffect, useRef, useState } from "react";
 import { readingTime } from "@/lib/readingTime";
 
 export default function MarkdownEditor({ draft, onChange }: { draft: any; onChange: (val: string) => void }) {
@@ -51,7 +53,7 @@ export default function MarkdownEditor({ draft, onChange }: { draft: any; onChan
     });
   }
 
-  const onKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
+  const onKeyDown: React.KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
     const mod = e.metaKey || e.ctrlKey;
     if (!mod) return;
     if (e.key.toLowerCase() === "b") { e.preventDefault(); wrap("**"); }

--- a/frontend/lib/user-guard.ts
+++ b/frontend/lib/user-guard.ts
@@ -1,4 +1,6 @@
-import type { GetServerSidePropsContext } from 'next';
+// Some local Next.js shims don't export GetServerSidePropsContext.
+// Use a portable alias derived from GetServerSideProps instead.
+import type { GetServerSideProps } from 'next';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/pages/api/auth/[...nextauth]';
 
@@ -7,7 +9,12 @@ import { authOptions } from '@/pages/api/auth/[...nextauth]';
  * Redirects visitors to /login?next=… if no session.
  * Does NOT enforce admin/staff; suitable for member-only newsroom.
  */
-export async function requireAuthSSR(ctx: GetServerSidePropsContext) {
+type GsspCtx = Parameters<GetServerSideProps>[0] & {
+  req: any;
+  res: any;
+  resolvedUrl?: string;
+};
+export async function requireAuthSSR(ctx: GsspCtx) {
   const session = await getServerSession(ctx.req, ctx.res, authOptions as any);
   if (!session?.user?.email) {
     return {


### PR DESCRIPTION
## Summary
- use `React.KeyboardEventHandler` to avoid mismatched event types in the markdown editor
- derive a portable server-side context type when shims lack `GetServerSidePropsContext`

## Testing
- `npm run typecheck`
- `npm run build` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/cloudinary)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d56084d8832989cd2c44438572bd