### PR TITLE
refactor: use global react types

### DIFF
--- a/frontend/components/MasonryCard.tsx
+++ b/frontend/components/MasonryCard.tsx
@@ -9,6 +9,7 @@ type Props = {
   coverVideo?: string;
   tags?: string[];
   publishedAt?: string | Date;
+  key?: string;
 };
 
 export default function MasonryCard({

--- a/frontend/components/MasonryFeed.tsx
+++ b/frontend/components/MasonryFeed.tsx
@@ -14,7 +14,7 @@ export default function MasonryFeed({ items = [] as Item[] }) {
   return (
     <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
       {items.map((it) => (
-        <MasonryCard key={it.slug} {...it} />
+        <MasonryCard {...it} key={it.slug} />
       ))}
     </section>
   );

--- a/frontend/components/Newsroom/MarkdownEditor.tsx
+++ b/frontend/components/Newsroom/MarkdownEditor.tsx
@@ -1,5 +1,5 @@
-// Use the React namespace for event types to avoid shim/version mismatches.
-import type * as React from 'react';
+// Avoid importing React event types from the module; rely on the local React shim's global namespace.
+// (No type imports from 'react' in this file to prevent mixed origins.)
 import { useEffect, useRef, useState } from "react";
 import { readingTime } from "@/lib/readingTime";
 
@@ -53,7 +53,7 @@ export default function MarkdownEditor({ draft, onChange }: { draft: any; onChan
     });
   }
 
-  const onKeyDown: React.KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     const mod = e.metaKey || e.ctrlKey;
     if (!mod) return;
     if (e.key.toLowerCase() === "b") { e.preventDefault(); wrap("**"); }

--- a/frontend/types/react/index.d.ts
+++ b/frontend/types/react/index.d.ts
@@ -4,18 +4,32 @@ declare namespace JSX {
   interface IntrinsicAttributes { key?: any }
 }
 
-declare module "react" {
-  export type ReactNode = any;
-  export type FC<P = {}> = (props: P & { children?: ReactNode }) => any;
-  export interface KeyboardEvent<T = Element> { key: string; metaKey?: boolean; ctrlKey?: boolean; target: T; preventDefault(): void; [key: string]: any }
-  export type KeyboardEventHandler<T = Element> = (event: KeyboardEvent<T>) => void;
-  export interface FormEvent<T = Element> { currentTarget: T; preventDefault(): void; [key: string]: any }
-  export interface SVGProps<T> { [key: string]: any }
-  export function useState<S = any>(initial?: S): [S, (s: S | ((p: S) => S)) => void];
-  export function useEffect(effect: (...args: any[]) => any, deps?: any[]): void;
-  export function useMemo<T = any>(factory: () => T, deps?: any[]): T;
-  export function useRef<T = any>(initial?: T): { current: T };
-  export function useId(): string;
-  const React: any;
-  export default React;
+declare namespace React {
+  type ReactNode = any;
+  type FC<P = {}> = (props: P & { children?: ReactNode }) => any;
+  interface KeyboardEvent<T = Element> {
+    key: string;
+    metaKey?: boolean;
+    ctrlKey?: boolean;
+    target: T;
+    preventDefault(): void;
+    [key: string]: any;
+  }
+  type KeyboardEventHandler<T = Element> = (event: KeyboardEvent<T>) => void;
+  interface FormEvent<T = Element> {
+    currentTarget: T;
+    preventDefault(): void;
+    [key: string]: any;
+  }
+  interface SVGProps<T> {
+    [key: string]: any;
+  }
+  function useState<S = any>(initial?: S): [S, (s: S | ((p: S) => S)) => void];
+  function useEffect(effect: (...args: any[]) => any, deps?: any[]): void;
+  function useMemo<T = any>(factory: () => T, deps?: any[]): T;
+  function useRef<T = any>(initial?: T): { current: T };
+  function useId(): string;
 }
+export = React;
+export as namespace React;
+


### PR DESCRIPTION
## Summary
- rely on global React namespace in Markdown editor
- provide minimal React type shims via global namespace
- adjust Masonry components to satisfy type checks

## Testing
- `npm run typecheck`
- `npm run build` *(fails: next: not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cloudinary)*

------
https://chatgpt.com/codex/tasks/task_e_68a5def6aacc8329b0b440c7f5d568b6