### PR TITLE
Fix React keyboard event target typing for global React shim

### DIFF
--- a/frontend/types/react/index.d.ts
+++ b/frontend/types/react/index.d.ts
@@ -11,7 +11,8 @@ declare namespace React {
     key: string;
     metaKey?: boolean;
     ctrlKey?: boolean;
-    target: T;
+    target: EventTarget;
+    currentTarget: T;
     preventDefault(): void;
     [key: string]: any;
   }


### PR DESCRIPTION
## Summary
- align custom React shim's KeyboardEvent with React's expectations by typing `target` as `EventTarget` and adding `currentTarget`

## Testing
- `npm run typecheck`
- `npm run build` *(fails: next: not found)*
- `npm ci` *(fails: lock file out of sync)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e1c269c0832985c2ed7168888b01