### PR TITLE
feat: add draft review moderation tools

### DIFF
--- a/frontend/pages/admin/index.tsx
+++ b/frontend/pages/admin/index.tsx
@@ -40,6 +40,10 @@ export default function AdminHome() {
           <div className="font-medium">Tools</div>
           <div className="text-sm text-gray-600">Link check, similarity, summaries</div>
         </Link>
+        <Link href="/admin/moderation/drafts" className="block border rounded-xl p-4 hover:shadow">
+          <div className="font-medium">Draft Reviews</div>
+          <div className="text-sm text-gray-600">Approve, request changes, assign reviewers</div>
+        </Link>
       </div>
     </div>
   );

--- a/frontend/pages/admin/moderation/drafts.tsx
+++ b/frontend/pages/admin/moderation/drafts.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { GetServerSideProps } from 'next';
+import { requireAdminSSR } from '@/lib/admin-guard';
+
+export const getServerSideProps: GetServerSideProps = (ctx) => requireAdminSSR(ctx as any);
+
+type DraftRow = {
+  _id: string;
+  title?: string;
+  authorEmail?: string;
+  status?: string;
+  requireSecondReview?: boolean;
+  reviewerEmail?: string;
+  assigneeEmail?: string;
+  updatedAt?: string;
+  publishAt?: string | null;
+};
+
+export default function DraftModerationQueue() {
+  const [rows, setRows] = useState<DraftRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [q, setQ] = useState('');
+  const [status, setStatus] = useState<'ready'|'needs_second_review'|'changes_requested'>('ready');
+  const [sel, setSel] = useState<Record<string, boolean>>({});
+  const [note, setNote] = useState('');
+  const [assignReviewer, setAssignReviewer] = useState('');
+  const [assignEditor, setAssignEditor] = useState('');
+
+  const selectedIds = useMemo(() => Object.keys(sel).filter(id => sel[id]), [sel]);
+  const allSelected = useMemo(() => rows.length > 0 && selectedIds.length === rows.length, [rows, selectedIds]);
+
+  useEffect(() => { void load(); }, [status]); // load on status change
+
+  async function load() {
+    try {
+      setLoading(true); setError(null);
+      const qs = new URLSearchParams({ status });
+      if (q) qs.set('q', q);
+      const r = await fetch('/api/moderation/drafts?' + qs.toString());
+      const d = await r.json();
+      if (!r.ok) throw new Error(d?.error || 'Failed to load');
+      setRows(d.items || []);
+      setSel({});
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function bulk(action: string, extra: Record<string, any> = {}) {
+    if (selectedIds.length === 0) return alert('Select at least one draft');
+    const r = await fetch('/api/moderation/drafts/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: selectedIds, action, ...extra })
+    });
+    const d = await r.json();
+    if (!r.ok) return alert(d?.error || 'Action failed');
+    setNote('');
+    setAssignReviewer('');
+    setAssignEditor('');
+    await load();
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto p-6 space-y-6">
+      <div className="flex items-center justify-between gap-3">
+        <h1 className="text-2xl font-semibold">Draft Reviews</h1>
+        <div className="flex items-center gap-2">
+          <input className="border rounded px-3 py-2 text-sm" placeholder="Search title/author…" value={q} onChange={e=>setQ(e.target.value)} />
+          <button className="text-sm px-3 py-2 border rounded" onClick={() => load()}>Search</button>
+        </div>
+      </div>
+      <div className="flex items-center gap-3">
+        <select className="border rounded px-3 py-2 text-sm" value={status} onChange={e=>setStatus(e.target.value as any)}>
+          <option value="ready">Ready</option>
+          <option value="needs_second_review">Needs second review</option>
+          <option value="changes_requested">Changes requested</option>
+        </select>
+        <div className="flex-1" />
+        <button className="px-3 py-2 rounded bg-green-600 text-white text-sm" onClick={() => bulk('approve')}>Approve</button>
+        <div className="flex items-center gap-2">
+          <input className="border rounded px-2 py-1 text-sm" placeholder="Note to author…" value={note} onChange={e=>setNote(e.target.value)} />
+          <button className="px-3 py-2 rounded bg-amber-600 text-white text-sm" onClick={() => bulk('request_changes', { note })}>Request changes</button>
+        </div>
+        <button className="px-3 py-2 rounded bg-purple-600 text-white text-sm" onClick={() => bulk('require_second_review', { on: true })}>Require 2nd review</button>
+        <div className="flex items-center gap-2">
+          <input className="border rounded px-2 py-1 text-sm" placeholder="Reviewer email" value={assignReviewer} onChange={e=>setAssignReviewer(e.target.value)} />
+          <button className="px-3 py-2 rounded bg-blue-600 text-white text-sm" onClick={() => bulk('assign_reviewer', { reviewerEmail: assignReviewer })}>Assign reviewer</button>
+        </div>
+        <div className="flex items-center gap-2">
+          <input className="border rounded px-2 py-1 text-sm" placeholder="Editor email" value={assignEditor} onChange={e=>setAssignEditor(e.target.value)} />
+          <button className="px-3 py-2 rounded bg-gray-900 text-white text-sm" onClick={() => bulk('assign_editor', { assigneeEmail: assignEditor })}>Assign editor</button>
+        </div>
+      </div>
+
+      <div className="rounded-xl border overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 text-left">
+            <tr>
+              <th className="p-3 w-10">
+                <input type="checkbox" checked={allSelected} onChange={e => {
+                  const val = e.target.checked; const next: Record<string, boolean> = {};
+                  if (val) rows.forEach(r => next[String(r._id)] = true);
+                  setSel(val ? next : {});
+                }} />
+              </th>
+              <th className="p-3">Title</th>
+              <th className="p-3">Author</th>
+              <th className="p-3">Reviewer</th>
+              <th className="p-3">Editor</th>
+              <th className="p-3">Status</th>
+              <th className="p-3">Updated</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr><td className="p-4 text-gray-500" colSpan={7}>Loading…</td></tr>
+            ) : error ? (
+              <tr><td className="p-4 text-red-600" colSpan={7}>{error}</td></tr>
+            ) : rows.length === 0 ? (
+              <tr><td className="p-4 text-gray-600" colSpan={7}>No drafts found.</td></tr>
+            ) : rows.map((r) => (
+              <tr key={String(r._id)} className="border-t">
+                <td className="p-3">
+                  <input type="checkbox" checked={!!sel[String(r._id)]} onChange={e => setSel({ ...sel, [String(r._id)]: e.target.checked })} />
+                </td>
+                <td className="p-3">
+                  <a href={`/admin/drafts/${r._id}`} className="font-medium hover:underline">{r.title || 'Untitled'}</a>
+                  {r.publishAt && r.status === 'scheduled' ? (
+                    <div className="text-xs text-gray-500">scheduled {new Date(r.publishAt).toLocaleString()}</div>
+                  ) : null}
+                </td>
+                <td className="p-3">{r.authorEmail || '—'}</td>
+                <td className="p-3">{r.reviewerEmail || '—'}</td>
+                <td className="p-3">{r.assigneeEmail || '—'}</td>
+                <td className="p-3 capitalize">{(r.status || 'draft').split('_').join(' ')}</td>
+                <td className="p-3">{r.updatedAt ? new Date(r.updatedAt).toLocaleString() : '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/pages/api/moderation/drafts/bulk.js
+++ b/frontend/pages/api/moderation/drafts/bulk.js
@@ -1,0 +1,65 @@
+import { ObjectId } from 'mongodb';
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+import { isAdminEmail, isAdminUser } from '@/lib/admin-auth';
+import sendEmail from '@/lib/email';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  const admin = email && ((await isAdminEmail(email)) || (await isAdminUser(email)));
+  if (!admin) return res.status(401).json({ error: 'Unauthorized' });
+
+  const { ids, action, note, reviewerEmail, assigneeEmail } = req.body || {};
+  if (!Array.isArray(ids) || ids.length === 0) return res.status(400).json({ error: 'ids required' });
+
+  const db = await getDb();
+  const col = db.collection('drafts');
+  const _ids = ids.map((s) => new ObjectId(String(s)));
+  const now = new Date().toISOString();
+
+  let update = null;
+  switch (action) {
+    case 'approve':
+      update = { $set: { status: 'ready', updatedAt: now } };
+      break;
+    case 'request_changes':
+      update = { $set: { status: 'changes_requested', reviewNotes: note || '', updatedAt: now } };
+      break;
+    case 'require_second_review':
+      update = { $set: { requireSecondReview: !!(req.body?.on ?? true), status: 'needs_second_review', updatedAt: now } };
+      break;
+    case 'assign_reviewer':
+      if (!reviewerEmail) return res.status(400).json({ error: 'reviewerEmail required' });
+      update = { $set: { reviewerEmail: String(reviewerEmail).toLowerCase(), updatedAt: now } };
+      break;
+    case 'assign_editor':
+      if (!assigneeEmail) return res.status(400).json({ error: 'assigneeEmail required' });
+      update = { $set: { assigneeEmail: String(assigneeEmail).toLowerCase(), updatedAt: now } };
+      break;
+    default:
+      return res.status(400).json({ error: 'Unknown action' });
+  }
+
+  await col.updateMany({ _id: { $in: _ids } }, update);
+
+  // Send author notifications for approval/changes
+  if (action === 'approve' || action === 'request_changes') {
+    try {
+      const docs = await col.find({ _id: { $in: _ids } }).project({ authorEmail: 1, title: 1, reviewNotes: 1 }).toArray();
+      for (const d of docs) {
+        if (!d?.authorEmail) continue;
+        const to = d.authorEmail;
+        const subj = action === 'approve' ? `Approved: ${d.title || 'Untitled'}` : `Changes requested: ${d.title || 'Untitled'}`;
+        const msg = action === 'approve'
+          ? `Your draft "${d.title || 'Untitled'}" was approved.`
+          : `Changes requested for "${d.title || 'Untitled'}". Notes: ${d.reviewNotes || note || ''}`;
+        await sendEmail({ to, subject: subj, text: msg, html: `<p>${msg}</p>` });
+      }
+    } catch {}
+  }
+
+  return res.json({ ok: true, count: _ids.length });
+}

--- a/frontend/pages/api/moderation/drafts/index.js
+++ b/frontend/pages/api/moderation/drafts/index.js
@@ -1,0 +1,26 @@
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+import { isAdminEmail, isAdminUser } from '@/lib/admin-auth';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  const admin = email && ((await isAdminEmail(email)) || (await isAdminUser(email)));
+  if (!admin) return res.status(401).json({ error: 'Unauthorized' });
+
+  const db = await getDb();
+  const col = db.collection('drafts');
+  const { status = 'ready', q = '' } = req.query || {};
+
+  const filter = { status: { $in: Array.isArray(status) ? status : [status] } };
+  if (q) {
+    filter['$or'] = [
+      { title: { $regex: String(q), $options: 'i' } },
+      { authorEmail: { $regex: String(q), $options: 'i' } }
+    ];
+  }
+  const items = await col.find(filter).sort({ updatedAt: -1 }).limit(500).toArray();
+  res.json({ items });
+}


### PR DESCRIPTION
## Summary
- add Draft Reviews tile on admin landing
- implement admin draft moderation queue with search, filters, and bulk actions
- provide APIs to list drafts and perform bulk actions with email notifications

## Testing
- `npm test --prefix frontend`
- `npm run typecheck --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68a722b9a78c8329a814f3bc5ac4fe72