### PR TITLE
Add moderation dashboard and recirculation widgets

### DIFF
--- a/frontend/components/Recirculation/RecircWidget.tsx
+++ b/frontend/components/Recirculation/RecircWidget.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+export default function RecircWidget() {
+  const [trending, setTrending] = useState<any[]>([]);
+  const [latest, setLatest] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const r = await fetch('/api/recs/recirculation');
+        const d = await r.json();
+        if (!mounted) return;
+        setTrending(d.trending || []);
+        setLatest(d.latest || []);
+      } catch (e: any) {
+        setError(e?.message || 'Failed to load');
+      } finally { if (mounted) setLoading(false); }
+    })();
+    return () => { mounted = false; };
+  }, []);
+
+  if (loading) return <div className="border rounded-xl p-4">Loading…</div>;
+  if (error) return <div className="border rounded-xl p-4 text-red-600">{error}</div>;
+
+  return (
+    <div className="grid lg:grid-cols-2 gap-6">
+      <Section title="Trending" items={trending} />
+      <Section title="Latest" items={latest} />
+    </div>
+  );
+}
+
+function Section({ title, items }: { title: string; items: any[] }) {
+  return (
+    <div className="border rounded-xl p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-lg font-semibold">{title}</h2>
+        <Link href="/?sort=trending" className="text-sm underline underline-offset-4">See all</Link>
+      </div>
+      <ul className="space-y-3">
+        {items.map((it) => (
+          <li key={it.slug} className="flex items-center gap-3">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            {it?.media?.[0]?.secure_url || it?.media?.[0]?.url ? (
+              <img src={it.media[0].secure_url || it.media[0].url} alt="" className="w-16 h-16 object-cover rounded" />
+            ) : (
+              <div className="w-16 h-16 bg-gray-100 rounded" />
+            )}
+            <div className="min-w-0">
+              <Link href={`/news/${it.slug}`} className="font-medium hover:underline line-clamp-2">{it.title}</Link>
+              {it.publishedAt && (
+                <div className="text-xs text-gray-500">{new Date(it.publishedAt).toLocaleString()}</div>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/components/Recirculation/TrendingRail.tsx
+++ b/frontend/components/Recirculation/TrendingRail.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+export default function TrendingRail() {
+  const [items, setItems] = useState<any[]>([]);
+  useEffect(() => {
+    (async () => {
+      try {
+        const r = await fetch('/api/recs/recirculation');
+        const d = await r.json();
+        setItems(d.trending || []);
+      } catch {}
+    })();
+  }, []);
+  if (!items.length) return null;
+  return (
+    <aside className="border rounded-xl p-4">
+      <div className="font-medium mb-3">Trending</div>
+      <ul className="space-y-2">
+        {items.slice(0, 6).map((it) => (
+          <li key={it.slug}>
+            <Link href={`/news/${it.slug}`} className="hover:underline">{it.title}</Link>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/frontend/pages/admin/moderation/dashboard.tsx
+++ b/frontend/pages/admin/moderation/dashboard.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react';
+import type { GetServerSideProps } from 'next';
+import { requireAdminSSR } from '@/lib/admin-guard';
+
+export const getServerSideProps: GetServerSideProps = (ctx) => requireAdminSSR(ctx as any);
+
+export default function ModerationDashboard() {
+  const [stats, setStats] = useState<any>(null);
+  const [work, setWork] = useState<any>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const [a, b] = await Promise.all([
+          fetch('/api/moderation/stats').then(r => r.json()),
+          fetch('/api/moderation/workload').then(r => r.json()),
+        ]);
+        if (!mounted) return;
+        setStats(a); setWork(b);
+      } catch (e: any) {
+        setErr(e?.message || 'Failed to load');
+      } finally { if (mounted) setLoading(false); }
+    })();
+    return () => { mounted = false; };
+  }, []);
+
+  if (loading) return <div className="p-6">Loading…</div>;
+  if (err) return <div className="p-6 text-red-600">{err}</div>;
+
+  return (
+    <div className="max-w-6xl mx-auto p-6 space-y-6">
+      <h1 className="text-2xl font-semibold">Moderation Dashboard</h1>
+
+      {/* KPI cards */}
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+        <Kpi title="Pending" value={stats?.pending ?? 0} />
+        <Kpi title="Ready" value={stats?.ready ?? 0} />
+        <Kpi title="Needs 2nd" value={stats?.needs_second_review ?? 0} />
+        <Kpi title="Changes" value={stats?.changes_requested ?? 0} />
+        <Kpi title="Scheduled" value={stats?.scheduled ?? 0} />
+        <Kpi title="Published (24h)" value={stats?.published_24h ?? 0} />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="border rounded-xl p-4">
+          <div className="font-medium mb-2">Avg pending age</div>
+          <div className="text-3xl">{stats?.avg_pending_hours ?? 0} <span className="text-base text-gray-500">hours</span></div>
+          <div className="text-xs text-gray-500 mt-1">as of {new Date(stats?.asOf || Date.now()).toLocaleString()}</div>
+        </div>
+        <div className="border rounded-xl p-4">
+          <div className="font-medium mb-2">Reviewer workload</div>
+          <SimpleTable rows={work?.reviewer || []} />
+        </div>
+      </div>
+      <div className="border rounded-xl p-4">
+        <div className="font-medium mb-2">Editor workload</div>
+        <SimpleTable rows={work?.editor || []} />
+      </div>
+    </div>
+  );
+}
+
+function Kpi({ title, value }: { title: string; value: number }) {
+  return (
+    <div className="border rounded-xl p-4">
+      <div className="text-xs uppercase tracking-wide text-gray-500">{title}</div>
+      <div className="text-3xl font-semibold">{value}</div>
+    </div>
+  );
+}
+
+function SimpleTable({ rows }: { rows: Array<{ email: string; count: number }> }) {
+  if (!rows || rows.length === 0) return <div className="text-sm text-gray-600">No data.</div>;
+  return (
+    <table className="w-full text-sm">
+      <thead className="text-left bg-gray-50">
+        <tr>
+          <th className="p-2">User</th>
+          <th className="p-2">Count</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r) => (
+          <tr key={r.email} className="border-t">
+            <td className="p-2">{r.email}</td>
+            <td className="p-2">{r.count}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/pages/api/moderation/stats.js
+++ b/frontend/pages/api/moderation/stats.js
@@ -1,0 +1,44 @@
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+import { isAdminEmail, isAdminUser } from '@/lib/admin-auth';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  const admin = email && ((await isAdminEmail(email)) || (await isAdminUser(email)));
+  if (!admin) return res.status(401).json({ error: 'Unauthorized' });
+
+  const db = await getDb();
+  const drafts = db.collection('drafts');
+  const posts = db.collection('posts');
+  const now = new Date();
+  const dayAgoIso = new Date(now.getTime() - 24*60*60*1000).toISOString();
+
+  const [
+    ready, second, changes, scheduled, published24
+  ] = await Promise.all([
+    drafts.countDocuments({ status: 'ready' }),
+    drafts.countDocuments({ status: 'needs_second_review' }),
+    drafts.countDocuments({ status: 'changes_requested' }),
+    drafts.countDocuments({ status: 'scheduled' }),
+    posts.countDocuments({ publishedAt: { $gte: dayAgoIso } }),
+  ]);
+
+  // Avg age (hours) for ready/needs_second_review
+  const ages = await drafts.aggregate([
+    { $match: { status: { $in: ['ready', 'needs_second_review'] } } },
+    { $project: { diffMs: { $subtract: [now, { $toDate: '$updatedAt' }] } } },
+    { $group: { _id: null, avgMs: { $avg: '$diffMs' } } }
+  ]).toArray();
+  const avgPendingHours = ages?.[0]?.avgMs ? (ages[0].avgMs / 3600000) : 0;
+
+  res.json({
+    ready, needs_second_review: second, changes_requested: changes,
+    scheduled, published_24h: published24,
+    pending: ready + second + changes,
+    avg_pending_hours: Number(avgPendingHours.toFixed(2)),
+    asOf: now.toISOString()
+  });
+}

--- a/frontend/pages/api/moderation/workload.js
+++ b/frontend/pages/api/moderation/workload.js
@@ -1,0 +1,32 @@
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+import { isAdminEmail, isAdminUser } from '@/lib/admin-auth';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  const admin = email && ((await isAdminEmail(email)) || (await isAdminUser(email)));
+  if (!admin) return res.status(401).json({ error: 'Unauthorized' });
+
+  const db = await getDb();
+  const drafts = db.collection('drafts');
+
+  const reviewer = await drafts.aggregate([
+    { $match: { status: { $in: ['ready', 'needs_second_review'] } } },
+    { $group: { _id: '$reviewerEmail', count: { $sum: 1 } } },
+    { $sort: { count: -1 } }
+  ]).toArray();
+
+  const editor = await drafts.aggregate([
+    { $match: { status: { $in: ['ready', 'needs_second_review', 'changes_requested', 'scheduled'] } } },
+    { $group: { _id: '$assigneeEmail', count: { $sum: 1 } } },
+    { $sort: { count: -1 } }
+  ]).toArray();
+
+  res.json({
+    reviewer: reviewer.map(r => ({ email: r._id || '(unassigned)', count: r.count })),
+    editor: editor.map(r => ({ email: r._id || '(unassigned)', count: r.count })),
+  });
+}

--- a/frontend/pages/api/recs/recirculation.js
+++ b/frontend/pages/api/recs/recirculation.js
@@ -1,0 +1,42 @@
+import { getDb } from '@/lib/db';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const db = await getDb();
+  const posts = db.collection('posts');
+  const events = db.collection('events'); // falls back if unavailable
+
+  // Latest posts (simple & reliable)
+  const latest = await posts.find({})
+    .project({ title: 1, slug: 1, excerpt: 1, media: 1, authorEmail: 1, publishedAt: 1 })
+    .sort({ publishedAt: -1 }).limit(10).toArray();
+
+  // Trending: last 48h by view events (best-effort)
+  const sinceIso = new Date(Date.now() - 48*60*60*1000).toISOString();
+  let trending = [];
+  try {
+    const agg = await events.aggregate([
+      { $match: { type: 'view', ts: { $gte: sinceIso } } },
+      { $project: {
+          postSlug: { $ifNull: ['$postSlug', '$target.slug'] },
+          ts: 1
+        } },
+      { $match: { postSlug: { $ne: null } } },
+      { $group: { _id: '$postSlug', views: { $sum: 1 }, last: { $max: '$ts' } } },
+      { $sort: { views: -1, last: -1 } },
+      { $limit: 10 }
+    ]).toArray();
+    if (agg.length) {
+      const slugs = agg.map(a => a._id);
+      const map = new Map(agg.map(a => [a._id, a.views]));
+      const docs = await posts.find({ slug: { $in: slugs } })
+        .project({ title: 1, slug: 1, excerpt: 1, media: 1, authorEmail: 1, publishedAt: 1 }).toArray();
+      trending = docs.sort((a, b) => (map.get(b.slug) || 0) - (map.get(a.slug) || 0));
+    }
+  } catch {
+    trending = [];
+  }
+  if (!trending.length) trending = latest.slice(0, 6);
+
+  res.json({ trending, latest });
+}

--- a/frontend/pages/article/[slug].tsx
+++ b/frontend/pages/article/[slug].tsx
@@ -3,6 +3,9 @@ import { useEffect, useState } from 'react'
 import Head from 'next/head'
 import axios from 'axios'
 import { buildBreadcrumbsJsonLd, buildNewsArticleJsonLd, jsonLdScript } from '@/lib/seo'
+import dynamic from 'next/dynamic'
+
+const TrendingRail = dynamic(() => import('@/components/Recirculation/TrendingRail'), { ssr: false })
 
 export default function ArticlePage() {
   const router = useRouter()
@@ -72,6 +75,9 @@ export default function ArticlePage() {
           👍 {article.engagement.likes} | 🔁 {article.engagement.shares} | 💬 {article.engagement.comments}
         </div>
       )}
+      </div>
+      <div className="max-w-3xl mx-auto px-4 py-6">
+        <TrendingRail />
       </div>
     </>
   )

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -3,7 +3,10 @@ import { useRouter } from 'next/router'
 import axios from 'axios'
 import Hero from '../components/Hero'
 import MasonryFeed from '../components/MasonryFeed'
+import dynamic from 'next/dynamic'
 import { getFollowedAuthors, getFollowedTags, toggleFollowAuthor, toggleFollowTag, syncFollowsIfAuthed, pushServerFollows } from '../utils/follow'
+
+const RecircWidget = dynamic(() => import('../components/Recirculation/RecircWidget'), { ssr: false })
 
 type Article = {
   _id?: string
@@ -147,17 +150,21 @@ export default function HomePage() {
     <div className="min-h-screen bg-gray-50">
       <div className="px-3 py-4 md:px-4 max-w-7xl mx-auto">
         {/* Contextual hero */}
-        <Hero
-          category={activeCategory}
-          articles={
-            (activeCategory
-              ? articles.filter(a => (a.tags || []).some(t => (t || '').toLowerCase() === activeCategory!.toLowerCase()))
-              : articles
-            ).slice(0, 6)
-          }
-        />
+          <Hero
+            category={activeCategory}
+            articles={
+              (activeCategory
+                ? articles.filter(a => (a.tags || []).some(t => (t || '').toLowerCase() === activeCategory!.toLowerCase()))
+                : articles
+              ).slice(0, 6)
+            }
+          />
+          {/* Recirculation: Trending + Latest */}
+          <div className="mt-8">
+            <RecircWidget />
+          </div>
 
-        {/* Results banner (when server search) */}
+          {/* Results banner (when server search) */}
         {typeof resultCount === 'number' && (
           <div className="text-xs text-gray-600 mt-3 mb-2" aria-live="polite">
             {resultCount} results for ‘{(router.query.q as string) || ''}’


### PR DESCRIPTION
## Summary
- add admin moderation stats and workload APIs
- implement moderation dashboard with KPIs and workload tables
- add recirculation API and widgets for trending and latest content; integrate on home and article pages

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a72bb8b8908329bf2d8dac84a83df4