### PR TITLE
Add reactions and comment system with moderation

### DIFF
--- a/frontend/components/Comments/CommentsBox.tsx
+++ b/frontend/components/Comments/CommentsBox.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react';
+
+export default function CommentsBox({ slug }: { slug: string }) {
+  const [me, setMe] = useState<any>(null);
+  const [items, setItems] = useState<any[]>([]);
+  const [body, setBody] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const [u, c] = await Promise.all([
+          fetch('/api/users/me').then(r => r.ok ? r.json() : null),
+          fetch(`/api/comments?slug=${encodeURIComponent(slug)}`).then(r => r.json())
+        ]);
+        if (!mounted) return;
+        setMe(u);
+        setItems(c?.items || []);
+      } catch (e: any) {
+        setError(e?.message || 'Failed to load comments');
+      } finally { if (mounted) setLoading(false); }
+    })();
+    return () => { mounted = false; };
+  }, [slug]);
+
+  async function submit() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const r = await fetch('/api/comments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slug, body })
+      });
+      const d = await r.json();
+      if (!r.ok) throw new Error(d?.error || 'Failed to comment');
+      setBody('');
+      // optimistic: show pending comment locally
+      setItems([{ ...d }, ...items]);
+      alert(d.status === 'approved' ? 'Comment posted' : 'Submitted for review');
+    } catch (e: any) {
+      setError(e?.message || 'Failed to comment');
+    } finally { setSubmitting(false); }
+  }
+
+  return (
+    <section className="border rounded-xl p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="font-medium">Comments</h3>
+        <a href="https://patwua.com" target="_blank" rel="noreferrer" className="text-sm underline underline-offset-4">
+          Discuss on Patwua →
+        </a>
+      </div>
+
+      {loading ? <div className="text-gray-500 text-sm">Loading…</div> : null}
+      {error ? <div className="text-red-600 text-sm">{error}</div> : null}
+
+      {me?.email ? (
+        <div className="space-y-2">
+          <textarea
+            className="w-full border rounded p-3 min-h-[100px]"
+            placeholder="Add your comment…"
+            value={body}
+            onChange={(e)=>setBody(e.target.value)}
+          />
+          <div className="flex items-center gap-2">
+            <button disabled={submitting || body.trim().length < 3} onClick={submit} className="px-3 py-2 rounded bg-black text-white text-sm disabled:opacity-50">
+              {submitting ? 'Submitting…' : 'Post comment'}
+            </button>
+            <div className="text-xs text-gray-500">Comments may be moderated.</div>
+          </div>
+        </div>
+      ) : (
+        <div className="text-sm text-gray-600">
+          <a href={`/login?next=${encodeURIComponent(location.pathname)}`} className="underline">Log in</a> to comment.
+        </div>
+      )}
+
+      <ul className="divide-y">
+        {items.map((c) => (
+          <li key={String(c._id)} className="py-3">
+            <div className="text-sm">
+              <span className="font-medium">{c.authorEmail || 'anonymous'}</span>
+              <span className="text-gray-500"> • {new Date(c.createdAt).toLocaleString()}</span>
+              {c.status !== 'approved' ? <span className="ml-2 text-xs text-amber-600">({c.status})</span> : null}
+            </div>
+            <div className="mt-1">{c.body}</div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/components/Engagement/ReactionBar.tsx
+++ b/frontend/components/Engagement/ReactionBar.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+type Counts = { like: number; insight: number; question: number };
+const types: Array<keyof Counts> = ['like','insight','question'];
+
+export default function ReactionBar({ slug }: { slug: string }) {
+  const [counts, setCounts] = useState<Counts>({ like: 0, insight: 0, question: 0 });
+  const [busy, setBusy] = useState<keyof Counts | ''>('');
+
+  async function load() {
+    const r = await fetch(`/api/reactions/summary?slug=${encodeURIComponent(slug)}`);
+    const d = await r.json();
+    if (r.ok) setCounts(d);
+  }
+  useEffect(() => { void load(); }, [slug]);
+
+  async function toggle(type: keyof Counts) {
+    setBusy(type);
+    try {
+      const r = await fetch('/api/reactions/toggle', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slug, type })
+      });
+      if (!r.ok) return;
+      await load();
+    } finally {
+      setBusy('');
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      {types.map((t) => (
+        <button key={t} onClick={()=>toggle(t)} className="px-3 py-2 rounded-full border text-sm">
+          {busy === t ? '…' : null}
+          {t === 'like' ? '👍' : t === 'insight' ? '💡' : '❓'}{' '}
+          <span className="capitalize">{t}</span> {counts[t] ? `(${counts[t]})` : ''}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/lib/email.js
+++ b/frontend/lib/email.js
@@ -16,3 +16,5 @@ export async function sendEmail({ to, subject, html, text }) {
   await t.sendMail({ from, to, subject, html: html || text, text });
   return { ok: true };
 }
+
+export default sendEmail;

--- a/frontend/lib/rate-limit.js
+++ b/frontend/lib/rate-limit.js
@@ -1,0 +1,25 @@
+import { getDb } from '@/lib/db';
+
+let ensured = false;
+async function ensureIndexes(db) {
+  if (ensured) return;
+  const col = db.collection('ratelimits');
+  await col.createIndex({ key: 1, ip: 1 }, { unique: true });
+  await col.createIndex({ expireAt: 1 }, { expireAfterSeconds: 0 });
+  ensured = true;
+}
+
+export async function checkRateLimit({ req, key, max = 5, windowMs = 60000 }) {
+  const db = await getDb();
+  await ensureIndexes(db);
+  const ip = (req.headers['x-forwarded-for'] || req.socket?.remoteAddress || 'unknown').toString();
+  const expireAt = new Date(Date.now() + Number(windowMs));
+  const col = db.collection('ratelimits');
+  const r = await col.findOneAndUpdate(
+    { key, ip },
+    { $inc: { count: 1 }, $setOnInsert: { expireAt } },
+    { upsert: true, returnDocument: 'after' }
+  );
+  if ((r.value?.count || 0) > Number(max)) return false;
+  return true;
+}

--- a/frontend/pages/admin/index.tsx
+++ b/frontend/pages/admin/index.tsx
@@ -44,6 +44,10 @@ export default function AdminHome() {
           <div className="font-medium">Draft Reviews</div>
           <div className="text-sm text-gray-600">Approve, request changes, assign reviewers</div>
         </Link>
+        <Link href="/admin/moderation/comments" className="block border rounded-xl p-4 hover:shadow">
+          <div className="font-medium">Comments Moderation</div>
+          <div className="text-sm text-gray-600">Approve/reject/delete comments</div>
+        </Link>
       </div>
     </div>
   );

--- a/frontend/pages/admin/moderation/comments.tsx
+++ b/frontend/pages/admin/moderation/comments.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { GetServerSideProps } from 'next';
+import { requireAdminSSR } from '@/lib/admin-guard';
+
+export const getServerSideProps: GetServerSideProps = (ctx) => requireAdminSSR(ctx as any);
+
+export default function CommentsModeration() {
+  const [rows, setRows] = useState<any[]>([]);
+  const [status, setStatus] = useState<'pending'|'approved'|'rejected'>('pending');
+  const [q, setQ] = useState('');
+  const [sel, setSel] = useState<Record<string, boolean>>({});
+  const ids = useMemo(() => Object.keys(sel).filter(id => sel[id]), [sel]);
+
+  async function load() {
+    const qs = new URLSearchParams({ status });
+    if (q) qs.set('q', q);
+    const r = await fetch('/api/moderation/comments?' + qs.toString());
+    const d = await r.json();
+    if (!r.ok) return alert(d?.error || 'Failed to load');
+    setRows(d.items || []);
+    setSel({});
+  }
+  useEffect(() => { void load(); }, [status]);
+
+  async function bulk(action: string) {
+    if (ids.length === 0) return alert('Select comments');
+    const r = await fetch('/api/moderation/comments/bulk', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids, action })
+    });
+    const d = await r.json();
+    if (!r.ok) return alert(d?.error || 'Action failed');
+    await load();
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto p-6 space-y-6">
+      <div className="flex items-center justify-between gap-2">
+        <h1 className="text-2xl font-semibold">Comments Moderation</h1>
+        <div className="flex items-center gap-2">
+          <input className="border rounded px-3 py-2 text-sm" placeholder="Search text/email/slug…" value={q} onChange={e=>setQ(e.target.value)} />
+          <button className="text-sm px-3 py-2 border rounded" onClick={()=>load()}>Search</button>
+        </div>
+      </div>
+      <div className="flex items-center gap-3">
+        <select className="border rounded px-3 py-2 text-sm" value={status} onChange={e=>setStatus(e.target.value as any)}>
+          <option value="pending">Pending</option>
+          <option value="approved">Approved</option>
+          <option value="rejected">Rejected</option>
+        </select>
+        <div className="flex-1" />
+        <button className="px-3 py-2 rounded bg-green-600 text-white text-sm" onClick={()=>bulk('approve')}>Approve</button>
+        <button className="px-3 py-2 rounded bg-amber-600 text-white text-sm" onClick={()=>bulk('reject')}>Reject</button>
+        <button className="px-3 py-2 rounded bg-red-700 text-white text-sm" onClick={()=>bulk('delete')}>Delete</button>
+      </div>
+      <div className="rounded-xl border overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 text-left">
+            <tr>
+              <th className="p-3 w-10" />
+              <th className="p-3">Post</th>
+              <th className="p-3">Body</th>
+              <th className="p-3">Author</th>
+              <th className="p-3">Status</th>
+              <th className="p-3">Created</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 ? (
+              <tr><td className="p-4 text-gray-600" colSpan={6}>No comments.</td></tr>
+            ) : rows.map((c) => (
+              <tr key={String(c._id)} className="border-t">
+                <td className="p-3">
+                  <input type="checkbox" checked={!!sel[String(c._id)]} onChange={e=>setSel({ ...sel, [String(c._id)]: e.target.checked })} />
+                </td>
+                <td className="p-3">{c.postSlug}</td>
+                <td className="p-3 max-w-xl"><span className="line-clamp-2">{c.body}</span></td>
+                <td className="p-3">{c.authorEmail || 'anonymous'}</td>
+                <td className="p-3">{c.status}</td>
+                <td className="p-3">{c.createdAt ? new Date(c.createdAt).toLocaleString() : '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/pages/api/comments/index.js
+++ b/frontend/pages/api/comments/index.js
@@ -1,0 +1,79 @@
+import { ObjectId } from 'mongodb';
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+import { isAdminEmail, isAdminUser } from '@/lib/admin-auth';
+import { checkRateLimit } from '@/lib/rate-limit';
+
+async function forwardToPatwua(payload) {
+  const url = process.env.PATWUA_FORWARD_URL;
+  if (!url) return;
+  try {
+    await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(process.env.PATWUA_API_KEY ? { 'Authorization': `Bearer ${process.env.PATWUA_API_KEY}` } : {})
+      },
+      body: JSON.stringify(payload)
+    }).catch(()=>{});
+  } catch {}
+}
+
+export default async function handler(req, res) {
+  const db = await getDb();
+  const col = db.collection('comments');
+  await col.createIndex({ postSlug: 1, status: 1, createdAt: -1 });
+
+  if (req.method === 'GET') {
+    const { slug, all } = req.query || {};
+    if (!slug) return res.status(400).json({ error: 'slug required' });
+    const session = await getServerSession(req, res, authOptions);
+    const email = session?.user?.email || null;
+    const admin = email && ((await isAdminEmail(email)) || (await isAdminUser(email)));
+    const query = { postSlug: String(slug), status: admin && all === '1' ? { $in: ['pending','approved','rejected'] } : 'approved' };
+    const items = await col.find(query).sort({ createdAt: -1 }).limit(200).toArray();
+    return res.json({ items });
+  }
+
+  if (req.method === 'POST') {
+    if (String(process.env.COMMENTS_ENABLED || 'true') !== 'true') {
+      return res.status(503).json({ error: 'Comments disabled' });
+    }
+    const requireLogin = String(process.env.COMMENTS_REQUIRE_LOGIN || 'true') === 'true';
+    const session = await getServerSession(req, res, authOptions);
+    const email = session?.user?.email || null;
+    if (requireLogin && !email) return res.status(401).json({ error: 'Login required' });
+
+    const { slug, body, parentId } = req.body || {};
+    if (!slug || !body || String(body).trim().length < 3) {
+      return res.status(400).json({ error: 'Invalid payload' });
+    }
+    const ok = await checkRateLimit({
+      req,
+      key: `comment:${slug}`,
+      max: Number(process.env.COMMENTS_RATE_MAX || 5),
+      windowMs: Number(process.env.COMMENTS_RATE_WINDOW_MS || 60000)
+    });
+    if (!ok) return res.status(429).json({ error: 'Too many comments, please slow down.' });
+
+    const now = new Date().toISOString();
+    const doc = {
+      postSlug: String(slug),
+      body: String(body).slice(0, 5000),
+      authorEmail: email || 'anonymous',
+      parentId: parentId ? new ObjectId(String(parentId)) : null,
+      status: String(process.env.COMMENTS_AUTO_APPROVE || 'false') === 'true' ? 'approved' : 'pending',
+      createdAt: now,
+      updatedAt: now
+    };
+    const r = await col.insertOne(doc);
+    const saved = { _id: r.insertedId, ...doc };
+    // forward to Patwua (best effort)
+    forwardToPatwua({ type: 'comment.created', data: saved }).catch(()=>{});
+    return res.json(saved);
+  }
+
+  res.setHeader('Allow', 'GET,POST');
+  res.status(405).end();
+}

--- a/frontend/pages/api/moderation/comments/bulk.js
+++ b/frontend/pages/api/moderation/comments/bulk.js
@@ -1,0 +1,50 @@
+import { ObjectId } from 'mongodb';
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+import { isAdminEmail, isAdminUser } from '@/lib/admin-auth';
+import { sendEmail } from '@/lib/email';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  const admin = email && ((await isAdminEmail(email)) || (await isAdminUser(email)));
+  if (!admin) return res.status(401).json({ error: 'Unauthorized' });
+
+  const { ids, action } = req.body || {};
+  if (!Array.isArray(ids) || !ids.length) return res.status(400).json({ error: 'ids required' });
+  const _ids = ids.map((s) => new ObjectId(String(s)));
+
+  const db = await getDb();
+  const col = db.collection('comments');
+  const now = new Date().toISOString();
+
+  if (action === 'approve') {
+    await col.updateMany({ _id: { $in: _ids } }, { $set: { status: 'approved', updatedAt: now } });
+  } else if (action === 'reject') {
+    await col.updateMany({ _id: { $in: _ids } }, { $set: { status: 'rejected', updatedAt: now } });
+  } else if (action === 'delete') {
+    await col.deleteMany({ _id: { $in: _ids } });
+  } else {
+    return res.status(400).json({ error: 'Unknown action' });
+  }
+
+  // Optional: notify authors on approval (quietly ignore failures)
+  if (action === 'approve') {
+    try {
+      const docs = await col.find({ _id: { $in: _ids } }).project({ authorEmail: 1, postSlug: 1 }).toArray();
+      for (const d of docs) {
+        if (!d?.authorEmail) continue;
+        await sendEmail({
+          to: d.authorEmail,
+          subject: 'Your comment is now visible',
+          text: `Your comment on ${d.postSlug} was approved.`,
+          html: `<p>Your comment on <b>${d.postSlug}</b> was approved.</p>`
+        });
+      }
+    } catch {}
+  }
+
+  res.json({ ok: true, count: _ids.length });
+}

--- a/frontend/pages/api/moderation/comments/index.js
+++ b/frontend/pages/api/moderation/comments/index.js
@@ -1,0 +1,26 @@
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+import { isAdminEmail, isAdminUser } from '@/lib/admin-auth';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  const admin = email && ((await isAdminEmail(email)) || (await isAdminUser(email)));
+  if (!admin) return res.status(401).json({ error: 'Unauthorized' });
+
+  const { status = 'pending', q = '' } = req.query || {};
+  const db = await getDb();
+  const col = db.collection('comments');
+  const filter = { status: Array.isArray(status) ? { $in: status } : status };
+  if (q) {
+    filter['$or'] = [
+      { body: { $regex: String(q), $options: 'i' } },
+      { authorEmail: { $regex: String(q), $options: 'i' } },
+      { postSlug: { $regex: String(q), $options: 'i' } },
+    ];
+  }
+  const items = await col.find(filter).sort({ createdAt: -1 }).limit(300).toArray();
+  res.json({ items });
+}

--- a/frontend/pages/api/reactions/summary.js
+++ b/frontend/pages/api/reactions/summary.js
@@ -1,0 +1,16 @@
+import { getDb } from '@/lib/db';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return res.status(405).end();
+  const { slug } = req.query || {};
+  if (!slug) return res.status(400).json({ error: 'slug required' });
+  const db = await getDb();
+  const col = db.collection('reactions');
+  const agg = await col.aggregate([
+    { $match: { slug: String(slug) } },
+    { $group: { _id: '$type', count: { $sum: 1 } } }
+  ]).toArray();
+  const out = { like: 0, insight: 0, question: 0 };
+  for (const a of agg) if (a?._id in out) out[a._id] = a.count;
+  res.json(out);
+}

--- a/frontend/pages/api/reactions/toggle.js
+++ b/frontend/pages/api/reactions/toggle.js
@@ -1,0 +1,28 @@
+import { getDb } from '@/lib/db';
+
+function getDeviceId(req, res) {
+  const cookie = (req.headers.cookie || '').split(';').map(s=>s.trim()).find(s=>s.startsWith('wn_did='));
+  let did = cookie ? cookie.split('=')[1] : '';
+  if (!did) {
+    did = Math.random().toString(36).slice(2) + Date.now().toString(36);
+    res.setHeader('Set-Cookie', `wn_did=${did}; Path=/; Max-Age=31536000; SameSite=Lax`);
+  }
+  return did;
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const { slug, type } = req.body || {};
+  if (!slug || !type) return res.status(400).json({ error: 'slug and type required' });
+  const db = await getDb();
+  const col = db.collection('reactions');
+  const did = getDeviceId(req, res);
+  const key = { slug, type, deviceId: did };
+  const found = await col.findOne(key);
+  if (found) {
+    await col.deleteOne(key);
+    return res.json({ toggled: false });
+  }
+  await col.updateOne(key, { $set: { createdAt: new Date().toISOString() } }, { upsert: true });
+  return res.json({ toggled: true });
+}

--- a/frontend/pages/article/[slug].tsx
+++ b/frontend/pages/article/[slug].tsx
@@ -6,6 +6,8 @@ import { buildBreadcrumbsJsonLd, buildNewsArticleJsonLd, jsonLdScript } from '@/
 import dynamic from 'next/dynamic'
 
 const TrendingRail = dynamic(() => import('@/components/Recirculation/TrendingRail'), { ssr: false })
+const ReactionBar = dynamic(() => import('@/components/Engagement/ReactionBar'), { ssr: false })
+const CommentsBox = dynamic(() => import('@/components/Comments/CommentsBox'), { ssr: false })
 
 export default function ArticlePage() {
   const router = useRouter()
@@ -75,6 +77,12 @@ export default function ArticlePage() {
           👍 {article.engagement.likes} | 🔁 {article.engagement.shares} | 💬 {article.engagement.comments}
         </div>
       )}
+      <div className="mt-8">
+        <ReactionBar slug={String(slug)} />
+      </div>
+      <div className="mt-8">
+        <CommentsBox slug={String(slug)} />
+      </div>
       </div>
       <div className="max-w-3xl mx-auto px-4 py-6">
         <TrendingRail />


### PR DESCRIPTION
## Summary
- add rate-limited article comments with optional Patwua forwarding
- add like/insight/question reaction bar scoped to device
- add admin interface and APIs for moderating comments

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a7b5838fb483299f74856cac57ae06