### PR TITLE
feat: auto-create Patwua threads

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,12 @@
 # Frontend
 
+## Environment Variables
+- `PATWUA_FORWARD_URL`: optional URL to forward comments to Patwua.
+- `PATWUA_API_KEY`: optional API key for Patwua requests.
+- `PATWUA_CREATE_THREAD_URL`: optional endpoint to create Patwua discussion threads.
+- `COMMENTS_DIGEST_TOKEN`: token required to trigger the comments digest job.
+
+
 ## Troubleshooting
 - If `npm run typecheck` fails with “Cannot find type definition file for 'node'/'react'/'react-dom'`:
   - We intentionally rely on local `types/` and set "skipLibCheck": true.

--- a/frontend/lib/patwua.js
+++ b/frontend/lib/patwua.js
@@ -1,0 +1,20 @@
+export async function createPatwuaThread({ slug, title, excerpt, url }) {
+  const endpoint = process.env.PATWUA_CREATE_THREAD_URL;
+  if (!endpoint) return null;
+  try {
+    const r = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(process.env.PATWUA_API_KEY ? { Authorization: `Bearer ${process.env.PATWUA_API_KEY}` } : {})
+      },
+      body: JSON.stringify({ slug, title, excerpt, url })
+    });
+    if (!r.ok) return null;
+    const d = await r.json();
+    // Expect { threadUrl: "https://patwua.com/threads/abc123" }
+    return d?.threadUrl || null;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/pages/api/admin/posts/[slug]/create-thread.js
+++ b/frontend/pages/api/admin/posts/[slug]/create-thread.js
@@ -1,0 +1,31 @@
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+import { isAdminEmail, isAdminUser } from '@/lib/admin-auth';
+import { createPatwuaThread } from '@/lib/patwua';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const { slug } = req.query || {};
+  if (!slug) return res.status(400).json({ error: 'slug required' });
+
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  const admin = email && ((await isAdminEmail(email)) || (await isAdminUser(email)));
+  if (!admin) return res.status(401).json({ error: 'Unauthorized' });
+
+  const db = await getDb();
+  const posts = db.collection('posts');
+  const post = await posts.findOne({ slug: String(slug) });
+  if (!post) return res.status(404).json({ error: 'post not found' });
+  if (post.patwuaThreadUrl) return res.json({ ok: true, threadUrl: post.patwuaThreadUrl, already: true });
+
+  const base = process.env.NEXTAUTH_URL || '';
+  const url = `${base}/news/${post.slug}`;
+  const threadUrl = await createPatwuaThread({
+    slug: post.slug, title: post.title || 'Untitled', excerpt: post.excerpt || '', url
+  });
+  if (!threadUrl) return res.status(502).json({ error: 'Failed to create thread' });
+  await posts.updateOne({ _id: post._id }, { $set: { patwuaThreadUrl: threadUrl } });
+  return res.json({ ok: true, threadUrl });
+}


### PR DESCRIPTION
## Summary
- auto-provision Patwua threads on publish
- admin endpoint and UI to create missing Patwua threads
- document Patwua and comments digest environment variables

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a7c379a3a8832991698ac2483f6e4c