### PR TITLE
feat: add newsroom layout and sections

### DIFF
--- a/frontend/components/Newsroom/NewsroomLayout.tsx
+++ b/frontend/components/Newsroom/NewsroomLayout.tsx
@@ -1,0 +1,137 @@
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { signOut } from 'next-auth/react';
+import MediaLibraryModal from '@/components/MediaLibraryModal';
+
+export default function NewsroomLayout({ active, children }: { active: string; children: React.ReactNode }) {
+  const [me, setMe] = useState<any>(null);
+  const [editOpen, setEditOpen] = useState(false);
+  const [form, setForm] = useState<{ displayName?: string; handle?: string; photoUrl?: string }>({});
+
+  useEffect(() => {
+    (async () => {
+      const r = await fetch('/api/users/me');
+      if (r.ok) {
+        const d = await r.json();
+        setMe(d);
+        setForm({ displayName: d?.name || '', handle: d?.handle || '', photoUrl: d?.image || '' });
+      }
+    })();
+  }, []);
+
+  async function saveProfile() {
+    const r = await fetch('/api/users/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: form.displayName, handle: form.handle, image: form.photoUrl })
+    });
+    if (!r.ok) {
+      const d = await r.json().catch(()=>({}));
+      alert(d?.error || 'Failed to update profile');
+      return;
+    }
+    alert('Profile updated');
+    setEditOpen(false);
+    const meR = await fetch('/api/users/me');
+    setMe(meR.ok ? await meR.json(): me);
+  }
+
+  return (
+    <div className="min-h-screen grid grid-cols-12">
+      {/* Sidebar */}
+      <aside className="col-span-12 lg:col-span-3 xl:col-span-2 border-r bg-white">
+        <div className="p-4 space-y-4">
+          <div className="text-xs uppercase tracking-widest text-gray-500">NewsRoom</div>
+          <div className="flex items-center gap-3">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={me?.image || '/apple-touch-icon.png'}
+              alt=""
+              className="w-12 h-12 rounded-full object-cover border"
+            />
+            <div className="min-w-0">
+              <div className="font-medium truncate">{me?.name || 'Your Name'}</div>
+              <div className="text-xs text-gray-600 truncate">@{me?.handle || 'handle'}</div>
+              <button className="text-xs underline text-blue-600" onClick={() => setEditOpen(true)}>Edit profile</button>
+            </div>
+          </div>
+
+          {/* Quick actions */}
+          <div className="grid grid-cols-2 gap-2">
+            <Link href="/newsroom?new=1" className="border rounded px-3 py-2 text-center text-sm hover:shadow">New draft</Link>
+            <Link href="/newsroom" className="border rounded px-3 py-2 text-center text-sm hover:shadow">My drafts</Link>
+            <Link href="/newsroom/posts" className="border rounded px-3 py-2 text-center text-sm hover:shadow col-span-2">My posts</Link>
+          </div>
+
+          {/* Nav */}
+          <nav className="space-y-1">
+            <NavItem href="/newsroom/dashboard" label="Dashboard" active={active==='dashboard'} />
+            <NavItem href="/newsroom/notice-board" label="Notice Board" active={active==='notice'} />
+            <NavItem href="/newsroom" label="Publisher" active={active==='publisher'} />
+            <NavItem href="/newsroom/collab" label="Collaboration" active={active==='collab'} />
+            <NavItem href="/newsroom/media" label="Media" active={active==='media'} />
+            <NavItem href="/newsroom/assistant" label="AI Assistant" active={active==='assistant'} />
+            <NavItem href="/newsroom/profile" label="Profile" active={active==='profile'} />
+            <button onClick={()=>signOut({ callbackUrl: '/' })} className="w-full text-left px-3 py-2 rounded hover:bg-gray-100 text-red-700">Logout</button>
+          </nav>
+        </div>
+      </aside>
+
+      {/* Main */}
+      <main className="col-span-12 lg:col-span-9 xl:col-span-10 p-6">
+        {children}
+      </main>
+
+      {/* Profile editor modal (uses MediaLibraryModal for avatar) */}
+      {editOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-white rounded-xl shadow-xl p-4 w-[92vw] max-w-xl">
+            <div className="flex items-center justify-between mb-3">
+              <div className="font-medium">Edit Profile</div>
+              <button className="text-sm underline" onClick={()=>setEditOpen(false)}>Close</button>
+            </div>
+            <div className="space-y-3">
+              <div>
+                <label className="block text-sm text-gray-600">Display name</label>
+                <input className="w-full border rounded px-3 py-2" value={form.displayName || ''} onChange={e=>setForm({ ...form, displayName: e.target.value })}/>
+              </div>
+              <div>
+                <label className="block text-sm text-gray-600">Handle (unique; one-time)</label>
+                <input className="w-full border rounded px-3 py-2" value={form.handle || ''} onChange={e=>setForm({ ...form, handle: e.target.value.replace(/[^a-z0-9_]/gi,'') })}/>
+                <div className="text-xs text-gray-500 mt-1">Use letters, numbers, underscore. Choose wisely — one-time handle.</div>
+              </div>
+              <div>
+                <label className="block text-sm text-gray-600">Photo</label>
+                <div className="flex items-center gap-3">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={form.photoUrl || '/apple-touch-icon.png'} alt="" className="w-14 h-14 rounded-full border object-cover"/>
+                  <MediaPicker onPick={(url)=>setForm({ ...form, photoUrl: url })}/>
+                </div>
+              </div>
+              <div className="pt-2">
+                <button onClick={saveProfile} className="px-3 py-2 rounded bg-black text-white text-sm">Save changes</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NavItem({ href, label, active }: { href: string; label: string; active?: boolean }) {
+  return (
+    <Link href={href} className={`block px-3 py-2 rounded ${active ? 'bg-black text-white' : 'hover:bg-gray-100'}`}>{label}</Link>
+  );
+}
+
+function MediaPicker({ onPick }: { onPick: (url: string)=>void }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button className="px-3 py-2 border rounded text-sm" onClick={()=>setOpen(true)}>Choose from Library</button>
+      <MediaLibraryModal open={open} onClose={()=>setOpen(false)} onSelect={(asset:any)=>onPick(asset.secure_url || asset.url)} />
+    </>
+  );
+}
+

--- a/frontend/components/Newsroom/StatsCards.tsx
+++ b/frontend/components/Newsroom/StatsCards.tsx
@@ -1,0 +1,18 @@
+export default function StatsCards({ data }: { data: any }) {
+  const items = [
+    { label: 'Drafts', value: data?.drafts ?? 0 },
+    { label: 'Scheduled', value: data?.scheduled ?? 0 },
+    { label: 'Published', value: data?.published ?? 0 },
+    { label: 'Views (48h)', value: data?.views48h ?? 0 },
+  ];
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      {items.map((it)=>(
+        <div key={it.label} className="border rounded-xl p-4">
+          <div className="text-xs uppercase tracking-wide text-gray-500">{it.label}</div>
+          <div className="text-3xl font-semibold">{it.value}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/pages/api/newsroom/assistant/suggest.js
+++ b/frontend/pages/api/newsroom/assistant/suggest.js
@@ -1,0 +1,28 @@
+// Lightweight stub that surfaces related internal posts by keyword and echoes suggestions.
+// Replace later with a proper retrieval + web search pipeline.
+import { getDb } from '@/lib/db';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const { text } = req.body || {};
+  if (!text || String(text).length < 10) return res.status(400).json({ error: 'text too short' });
+  const db = await getDb();
+  const posts = db.collection('posts');
+  const q = String(text).slice(0,200);
+  const related = await posts.find({ $or: [{ title: { $regex: q, $options: 'i' } }, { excerpt: { $regex: q, $options: 'i' } }] })
+    .project({ title:1, slug:1, excerpt:1 }).limit(5).toArray();
+  const web = []; // fill with web search results later
+  const angles = [
+    'Add specific local context (locations, names, dates).',
+    'Verify all figures and include sources inline.',
+    'Balance sources: add at least one dissenting voice.',
+    'Clarify timeline; add a short “What’s next” section.'
+  ];
+  const media = ['Insert a map or timeline graphic', 'Add a pull quote image for social', 'Attach 1–2 contextual photos'];
+  res.json({
+    related: related.map(p=>({ title: p.title, url: `/news/${p.slug}` })),
+    web,
+    angles,
+    media
+  });
+}

--- a/frontend/pages/api/newsroom/collab/assist.js
+++ b/frontend/pages/api/newsroom/collab/assist.js
@@ -1,0 +1,17 @@
+import { ObjectId } from 'mongodb';
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  if (!email) return res.status(401).json({ error: 'Unauthorized' });
+  const { id } = req.body || {};
+  if (!id) return res.status(400).json({ error: 'id required' });
+  const db = await getDb();
+  const col = db.collection('drafts');
+  await col.updateOne({ _id: new ObjectId(String(id)), visibility: 'network' }, { $addToSet: { collabHelpers: email }, $set: { updatedAt: new Date().toISOString() } });
+  res.json({ ok: true });
+}

--- a/frontend/pages/api/newsroom/collab/toggle-visibility.js
+++ b/frontend/pages/api/newsroom/collab/toggle-visibility.js
@@ -1,0 +1,17 @@
+import { ObjectId } from 'mongodb';
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  if (!email) return res.status(401).json({ error: 'Unauthorized' });
+  const { id, visibility } = req.body || {};
+  if (!id || !visibility) return res.status(400).json({ error: 'id and visibility required' });
+  const db = await getDb();
+  const col = db.collection('drafts');
+  await col.updateOne({ _id: new ObjectId(String(id)), authorEmail: email }, { $set: { visibility: visibility === 'network' ? 'network' : 'private', updatedAt: new Date().toISOString() } });
+  res.json({ ok: true });
+}

--- a/frontend/pages/api/newsroom/notice/index.js
+++ b/frontend/pages/api/newsroom/notice/index.js
@@ -1,0 +1,26 @@
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+
+export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  if (!email) return res.status(401).json({ error: 'Unauthorized' });
+  const db = await getDb();
+  const col = db.collection('notices');
+  await col.createIndex({ createdAt: -1 });
+
+  if (req.method === 'GET') {
+    const items = await col.find({}).sort({ createdAt: -1 }).limit(200).toArray();
+    return res.json({ items });
+  }
+  if (req.method === 'POST') {
+    const { title, body } = req.body || {};
+    if (!title || !body) return res.status(400).json({ error: 'title and body required' });
+    const now = new Date().toISOString();
+    const doc = { title: String(title).slice(0,200), body: String(body).slice(0,5000), authorEmail: email, createdAt: now, updatedAt: now };
+    const r = await col.insertOne(doc);
+    return res.json({ ok: true, notice: { _id: r.insertedId, ...doc } });
+  }
+  res.setHeader('Allow', 'GET,POST'); res.status(405).end();
+}

--- a/frontend/pages/api/newsroom/stats.js
+++ b/frontend/pages/api/newsroom/stats.js
@@ -1,0 +1,25 @@
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+
+export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  if (!email) return res.status(401).json({ error: 'Unauthorized' });
+  const db = await getDb();
+  const drafts = db.collection('drafts');
+  const posts = db.collection('posts');
+  const events = db.collection('events');
+
+  const sinceIso = new Date(Date.now() - 48*60*60*1000).toISOString();
+  const [draftCount, scheduled, published, viewsAgg] = await Promise.all([
+    drafts.countDocuments({ authorEmail: email }),
+    drafts.countDocuments({ authorEmail: email, status: 'scheduled' }),
+    posts.countDocuments({ authorEmail: email }),
+    events.aggregate([
+      { $match: { type: 'view', ts: { $gte: sinceIso }, 'authorEmail': email } }
+    ]).toArray().catch(()=>[])
+  ]);
+  const views48h = Array.isArray(viewsAgg) ? viewsAgg.length : 0;
+  res.json({ drafts: draftCount, scheduled, published, views48h });
+}

--- a/frontend/pages/newsroom/assistant.tsx
+++ b/frontend/pages/newsroom/assistant.tsx
@@ -1,0 +1,61 @@
+import type { GetServerSideProps } from 'next';
+import { requireAuthSSR } from '@/lib/user-guard';
+import NewsroomLayout from '@/components/Newsroom/NewsroomLayout';
+import { useState } from 'react';
+
+export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx as any);
+
+export default function AssistantHub() {
+  const [input, setInput] = useState('');
+  const [resp, setResp] = useState<any>(null);
+  const [busy, setBusy] = useState(false);
+  async function run() {
+    setBusy(true); setResp(null);
+    try {
+      const r = await fetch('/api/newsroom/assistant/suggest', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ text: input }) });
+      const d = await r.json();
+      setResp(d);
+    } finally { setBusy(false); }
+  }
+  return (
+    <NewsroomLayout active="assistant">
+      <h1 className="text-2xl font-semibold mb-4">AI Assistant</h1>
+      <p className="text-sm text-gray-600 mb-3">Paste a draft. We’ll surface related context (site + web), angle suggestions, links, and outline tweaks.</p>
+      <textarea className="w-full border rounded p-3 min-h-[200px]" placeholder="Paste your draft or notes…" value={input} onChange={e=>setInput(e.target.value)} />
+      <div className="mt-2"><button disabled={!input.trim() || busy} onClick={run} className="px-3 py-2 rounded bg-black text-white text-sm disabled:opacity-50">{busy? 'Thinking…' : 'Get suggestions'}</button></div>
+      {resp ? (
+        <div className="mt-6 space-y-4">
+          <Section title="Related posts" items={resp.related || []} />
+          <Section title="External sources" items={resp.web || []} />
+          <Bullets title="Angles & improvements" items={resp.angles || []} />
+          <Bullets title="Media suggestions" items={resp.media || []} />
+        </div>
+      ) : null}
+    </NewsroomLayout>
+  );
+}
+
+function Section({ title, items }: { title: string; items: any[] }) {
+  if (!items?.length) return null;
+  return (
+    <div>
+      <div className="font-medium mb-2">{title}</div>
+      <ul className="list-disc pl-5 space-y-1">
+        {items.map((it:any, i:number)=>(
+          <li key={i}><a className="text-blue-600 underline" href={it.url} target="_blank" rel="noreferrer">{it.title || it.url}</a></li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+function Bullets({ title, items }: { title: string; items: string[] }) {
+  if (!items?.length) return null;
+  return (
+    <div>
+      <div className="font-medium mb-2">{title}</div>
+      <ul className="list-disc pl-5 space-y-1">
+        {items.map((t, i)=>(<li key={i}>{t}</li>))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/pages/newsroom/collab.tsx
+++ b/frontend/pages/newsroom/collab.tsx
@@ -1,0 +1,78 @@
+import type { GetServerSideProps } from 'next';
+import { requireAuthSSR } from '@/lib/user-guard';
+import NewsroomLayout from '@/components/Newsroom/NewsroomLayout';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx as any);
+
+export default function CollabHub() {
+  const [mine, setMine] = useState<any[]>([]);
+  const [network, setNetwork] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  useEffect(()=>{ void load(); },[]);
+  async function load() {
+    setLoading(true);
+    const [a,b] = await Promise.all([
+      fetch('/api/newsroom/drafts').then(r=>r.json()), // author-scoped
+      fetch('/api/newsroom/drafts?q=visibility:network').then(r=>r.json()).catch(()=>({items:[]}))
+    ]);
+    setMine(a?.items || a?.drafts || []); // accommodate your endpoint shape
+    setNetwork(b?.items || b?.drafts || []);
+    setLoading(false);
+  }
+  async function setVisibility(id:string, v:'private'|'network') {
+    const r = await fetch('/api/newsroom/collab/toggle-visibility', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ id, visibility: v })});
+    if (r.ok) await load();
+  }
+  async function offerHelp(id:string) {
+    const r = await fetch('/api/newsroom/collab/assist', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ id })});
+    if (r.ok) { alert('Offered to help'); await load(); }
+  }
+  return (
+    <NewsroomLayout active="collab">
+      <h1 className="text-2xl font-semibold mb-4">Collaboration</h1>
+      <section className="mb-8">
+        <h2 className="font-medium mb-2">My drafts</h2>
+        {loading ? 'Loading…' : (
+          <ul className="divide-y border rounded-xl">
+            {mine.map((d:any)=>(
+              <li key={d._id} className="p-4 flex items-center justify-between">
+                <div>
+                  <div className="font-medium">{d.title || 'Untitled'}</div>
+                  <div className="text-xs text-gray-500">Visibility: {d.visibility || 'private'}</div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Link className="text-blue-600 underline text-sm" href={`/newsroom/drafts/${d._id}`}>Open</Link>
+                  <select className="border rounded px-2 py-1 text-sm" value={d.visibility || 'private'} onChange={e=>setVisibility(d._id, e.target.value as any)}>
+                    <option value="private">Private</option>
+                    <option value="network">Network</option>
+                  </select>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+      <section>
+        <h2 className="font-medium mb-2">Network drafts (open for collaboration)</h2>
+        {loading ? 'Loading…' : (
+          <ul className="divide-y border rounded-xl">
+            {network.map((d:any)=>(
+              <li key={d._id} className="p-4 flex items-center justify-between">
+                <div>
+                  <div className="font-medium">{d.title || 'Untitled'}</div>
+                  <div className="text-xs text-gray-500">Author: {d.authorEmail}</div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Link className="text-blue-600 underline text-sm" href={`/newsroom/drafts/${d._id}`}>Preview</Link>
+                  <button className="px-3 py-1 border rounded text-sm" onClick={()=>offerHelp(d._id)}>Offer help</button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </NewsroomLayout>
+  );
+}

--- a/frontend/pages/newsroom/dashboard.tsx
+++ b/frontend/pages/newsroom/dashboard.tsx
@@ -1,0 +1,33 @@
+import type { GetServerSideProps } from 'next';
+import { requireAuthSSR } from '@/lib/user-guard';
+import NewsroomLayout from '@/components/Newsroom/NewsroomLayout';
+import StatsCards from '@/components/Newsroom/StatsCards';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx as any);
+
+export default function NewsroomDashboard() {
+  const [stats, setStats] = useState<any>(null);
+  useEffect(()=>{ (async()=>{ const r=await fetch('/api/newsroom/stats'); setStats(r.ok? await r.json(): {}); })(); },[]);
+  return (
+    <NewsroomLayout active="dashboard">
+      <h1 className="text-2xl font-semibold mb-4">Dashboard</h1>
+      <StatsCards data={stats} />
+      <div className="mt-6 grid md:grid-cols-3 gap-4">
+        <Card title="Create a new publication" href="/newsroom?new=1" />
+        <Card title="See my drafts" href="/newsroom" />
+        <Card title="View my posts" href="/newsroom/posts" />
+      </div>
+    </NewsroomLayout>
+  );
+}
+
+function Card({ title, href }: { title: string; href: string }) {
+  return (
+    <Link href={href} className="border rounded-xl p-4 hover:shadow block">
+      <div className="font-medium">{title}</div>
+      <div className="text-sm text-gray-600 mt-1">Jump right in.</div>
+    </Link>
+  );
+}

--- a/frontend/pages/newsroom/drafts/[id].tsx
+++ b/frontend/pages/newsroom/drafts/[id].tsx
@@ -3,6 +3,7 @@ import type { GetServerSideProps } from 'next';
 import { requireAuthSSR } from '@/lib/user-guard';
 import MediaLibraryModal from '@/components/MediaLibraryModal';
 import StatusPill from '@/components/StatusPill';
+import NewsroomLayout from '@/components/Newsroom/NewsroomLayout';
 
 export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx);
 
@@ -54,12 +55,13 @@ export default function WriterDraftEditor() {
   if (!doc) return <div className="p-4">Loading…</div>;
 
   return (
-    <div className="max-w-5xl mx-auto p-6 space-y-4">
-      <div className="flex items-center justify-between">
-        <div className="text-sm text-gray-500 flex items-center gap-3">
-          <StatusPill status={doc.status} />
-          <span>
-            {saving === 'saving'
+    <NewsroomLayout active="publisher">
+      <div className="max-w-5xl mx-auto p-6 space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="text-sm text-gray-500 flex items-center gap-3">
+            <StatusPill status={doc.status} />
+            <span>
+              {saving === 'saving'
               ? 'Saving…'
               : saving === 'saved'
               ? 'Saved'
@@ -173,10 +175,11 @@ export default function WriterDraftEditor() {
           queueSave({ ...doc, media });
         }}
       />
-      <div className="pt-6">
+        <div className="pt-6">
         <a href="/newsroom/posts" className="text-sm underline underline-offset-4">See my published posts →</a>
       </div>
-    </div>
+      </div>
+    </NewsroomLayout>
   );
 }
 

--- a/frontend/pages/newsroom/index.tsx
+++ b/frontend/pages/newsroom/index.tsx
@@ -1,111 +1,67 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
+import StatusPill from '@/components/StatusPill';
+import NewsroomLayout from '@/components/Newsroom/NewsroomLayout';
 import type { GetServerSideProps } from 'next';
 import { requireAuthSSR } from '@/lib/user-guard';
-import StatusPill from '@/components/StatusPill';
 
-export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx);
+export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx as any);
 
-export default function NewsroomHome() {
-  const [loading, setLoading] = useState(true);
+export default function PublisherHub() {
   const [drafts, setDrafts] = useState<any[]>([]);
-  const [error, setError] = useState<string | null>(null);
-
   useEffect(() => {
-    let mounted = true;
     (async () => {
-      try {
-        const r = await fetch('/api/newsroom/drafts');
-        if (!r.ok) throw new Error('Failed to load drafts');
-        const d = await r.json();
-        if (!mounted) return;
-        setDrafts(d.items || d.drafts || []);
-      } catch (e: any) {
-        if (!mounted) return;
-        setError(e?.message || 'Failed to load drafts');
-      } finally {
-        if (mounted) setLoading(false);
-      }
+      const r = await fetch('/api/newsroom/drafts');
+      const d = await r.json();
+      setDrafts(d.items || d.drafts || []);
     })();
-    return () => {
-      mounted = false;
-    };
   }, []);
-
-  const createDraft = async () => {
-    try {
-      const r = await fetch('/api/newsroom/drafts', {
+  useEffect(() => {
+    // quick-create new draft if ?new=1
+    if (typeof window === 'undefined') return;
+    const u = new URL(window.location.href);
+    if (u.searchParams.get('new') === '1') {
+      u.searchParams.delete('new');
+      history.replaceState({}, '', u.toString());
+      fetch('/api/newsroom/drafts', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: 'Untitled', body: '' }),
-      });
-      const d = await r.json();
-      if (r.ok && d?._id) {
-        location.href = `/newsroom/drafts/${d._id}`;
-      } else {
-        throw new Error(d?.error || 'Could not create draft');
-      }
-    } catch (e: any) {
-      alert(e?.message || 'Could not create draft');
+        body: JSON.stringify({ title: 'Untitled draft' })
+      })
+        .then(r => r.json())
+        .then(d => {
+          if (d?.id || d?._id) location.href = `/newsroom/drafts/${d.id || d._id}`;
+        });
     }
-  };
-
+  }, []);
   return (
-    <div className="max-w-5xl mx-auto p-6 space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">Your Newsroom</h1>
-        <button
-          onClick={createDraft}
-          className="px-4 py-2 rounded-xl bg-black text-white hover:opacity-90"
-        >
-          Start a Draft
-        </button>
+    <NewsroomLayout active="publisher">
+      <div className="flex items-center justify-between mb-2">
+        <h1 className="text-2xl font-semibold">Publisher</h1>
+        <Link href="/newsroom?new=1" className="px-3 py-2 rounded bg-black text-white text-sm">
+          New draft
+        </Link>
       </div>
-
-      <p className="text-gray-600">
-        Write, save, and schedule your stories. Only logged-in members can access this area.
-      </p>
-
-      {loading ? (
-        <div className="text-gray-500">Loading your drafts…</div>
-      ) : error ? (
-        <div className="text-red-600">{error}</div>
-      ) : drafts.length === 0 ? (
-        <div className="border rounded-xl p-6 text-gray-600">
-          No drafts yet. Click <span className="font-medium">Start a Draft</span> to begin.
-        </div>
-      ) : (
-        <ul className="divide-y rounded-xl border">
-          {drafts.map((it: any) => (
-            <li key={it._id} className="flex items-center justify-between p-4">
-              <div>
-                <div className="font-medium flex items-center gap-2">
-                  {it.title || 'Untitled'} <StatusPill status={it.status} />
-                </div>
-                <div className="text-xs text-gray-500">
-                  {it.status === 'scheduled' && it.publishAt ? (
-                    <>scheduled for {new Date(it.publishAt).toLocaleString()} • </>
-                  ) : null}
-                  updated {it.updatedAt ? new Date(it.updatedAt).toLocaleString() : '—'}
-                </div>
+      <ul className="divide-y rounded-xl border">
+        {drafts.map((it: any) => (
+          <li key={it._id} className="flex items-center justify-between p-4">
+            <div>
+              <div className="font-medium flex items-center gap-2">
+                {it.title || 'Untitled'} <StatusPill status={it.status} />
               </div>
-              <Link href={`/newsroom/drafts/${it._id}`} className="text-blue-600 hover:underline">
-                Open
-              </Link>
-            </li>
-          ))}
-        </ul>
-      )}
-
-      <div className="pt-4 flex items-center gap-6">
-        <Link href="/newsroom/posts" className="text-sm underline underline-offset-4">
-          My posts
-        </Link>
-        <Link href="/profile" className="text-sm text-gray-600 underline underline-offset-4">
-          Go to your profile
-        </Link>
-      </div>
-    </div>
+              <div className="text-xs text-gray-500">
+                {it.status === 'scheduled' && it.publishAt ? (
+                  <>scheduled for {new Date(it.publishAt).toLocaleString()} • </>
+                ) : null}
+                updated {it.updatedAt ? new Date(it.updatedAt).toLocaleString() : '—'}
+              </div>
+            </div>
+            <Link href={`/newsroom/drafts/${it._id}`} className="text-blue-600 hover:underline">
+              Open
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </NewsroomLayout>
   );
 }
-

--- a/frontend/pages/newsroom/media.tsx
+++ b/frontend/pages/newsroom/media.tsx
@@ -1,0 +1,27 @@
+import type { GetServerSideProps } from 'next';
+import { requireAuthSSR } from '@/lib/user-guard';
+import NewsroomLayout from '@/components/Newsroom/NewsroomLayout';
+import MediaLibraryModal from '@/components/MediaLibraryModal';
+import { useState } from 'react';
+
+export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx as any);
+
+export default function MediaHub() {
+  const [open, setOpen] = useState(true);
+  const [picked, setPicked] = useState<any>(null);
+  return (
+    <NewsroomLayout active="media">
+      <h1 className="text-2xl font-semibold mb-4">Media Library</h1>
+      <p className="text-sm text-gray-600 mb-3">Search and pick images/videos from Cloudinary. Recently used media appears first.</p>
+      <button className="px-3 py-2 border rounded text-sm" onClick={()=>setOpen(true)}>Open Library</button>
+      {picked ? (
+        <div className="mt-4">
+          <div className="text-sm text-gray-600 mb-2">Selected:</div>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={picked.secure_url || picked.url} alt="" className="w-48 h-48 object-cover rounded border"/>
+        </div>
+      ) : null}
+      <MediaLibraryModal open={open} onClose={()=>setOpen(false)} onSelect={(asset:any)=>{ setPicked(asset); setOpen(false); }} />
+    </NewsroomLayout>
+  );
+}

--- a/frontend/pages/newsroom/notice-board.tsx
+++ b/frontend/pages/newsroom/notice-board.tsx
@@ -1,0 +1,39 @@
+import type { GetServerSideProps } from 'next';
+import { requireAuthSSR } from '@/lib/user-guard';
+import NewsroomLayout from '@/components/Newsroom/NewsroomLayout';
+import { useEffect, useState } from 'react';
+
+export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx as any);
+
+export default function NoticeBoard() {
+  const [items, setItems] = useState<any[]>([]);
+  const [title, setTitle] = useState(''); const [body, setBody] = useState('');
+  const [loading, setLoading] = useState(true);
+  useEffect(()=>{ (async()=>{ const r=await fetch('/api/newsroom/notice'); const d=await r.json(); setItems(d.items||[]); setLoading(false); })(); },[]);
+  async function post() {
+    const r = await fetch('/api/newsroom/notice', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ title, body }) });
+    const d = await r.json(); if (!r.ok) return alert(d?.error || 'Failed');
+    setItems([d.notice, ...items]); setTitle(''); setBody('');
+  }
+  return (
+    <NewsroomLayout active="notice">
+      <h1 className="text-2xl font-semibold mb-4">Notice Board</h1>
+      <div className="border rounded-xl p-4 space-y-2 mb-6">
+        <input className="w-full border rounded px-3 py-2" placeholder="Title" value={title} onChange={e=>setTitle(e.target.value)} />
+        <textarea className="w-full border rounded px-3 py-2 min-h-[120px]" placeholder="Write a platform update, suggestion, or discussion topic…" value={body} onChange={e=>setBody(e.target.value)} />
+        <div><button onClick={post} className="px-3 py-2 rounded bg-black text-white text-sm">Publish notice</button></div>
+      </div>
+      {loading ? <div>Loading…</div> : (
+        <ul className="space-y-4">
+          {items.map((n:any)=>(
+            <li key={String(n._id)} className="border rounded-xl p-4">
+              <div className="font-medium">{n.title}</div>
+              <div className="text-xs text-gray-500 mb-2">{new Date(n.createdAt).toLocaleString()} • {n.authorEmail}</div>
+              <div>{n.body}</div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </NewsroomLayout>
+  );
+}

--- a/frontend/pages/newsroom/profile.tsx
+++ b/frontend/pages/newsroom/profile.tsx
@@ -1,0 +1,14 @@
+import type { GetServerSideProps } from 'next';
+import { requireAuthSSR } from '@/lib/user-guard';
+import NewsroomLayout from '@/components/Newsroom/NewsroomLayout';
+
+export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx as any);
+
+export default function NewsroomProfile() {
+  return (
+    <NewsroomLayout active="profile">
+      <h1 className="text-2xl font-semibold mb-4">Profile</h1>
+      <p className="text-sm text-gray-600">Use the sidebar “Edit profile” to change your avatar, display name, and handle.</p>
+    </NewsroomLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce NewsroomLayout with sidebar navigation and profile editing
- scaffold dashboard, notice board, collaboration, media, and assistant hubs
- add newsroom stats and collaboration APIs

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a7d1fde6048329a3c055699fc2264f