### PR TITLE
Rev.4 UX Series — Patch M (Skeletons, Help/Invite, Media→Draft insert)

### DIFF
--- a/frontend/components/Newsroom/ShellContext.tsx
+++ b/frontend/components/Newsroom/ShellContext.tsx
@@ -1,3 +1,3 @@
-import { createContext, useContext } from 'react';
-export const ShellContext = createContext<{ hasShell: boolean }>({ hasShell: false });
-export function useShell(){ return useContext(ShellContext); }
+import * as React from 'react';
+export const ShellContext = React.createContext<{ hasShell: boolean }>({ hasShell: false });
+export function useShell(){ return React.useContext(ShellContext); }

--- a/frontend/components/UX/Skeleton.tsx
+++ b/frontend/components/UX/Skeleton.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+export const SkeletonLine: React.FC<{ className?: string }> = ({ className = '' }) => (
+  <div className={`animate-pulse bg-gray-200 rounded ${className}`} />
+);
+
+export const SkeletonCard: React.FC<{ lines?: number }> = ({ lines = 3 }) => (
+  <div className="border rounded-xl p-4">
+    <SkeletonLine className="h-5 w-1/3 mb-3" />
+    {Array.from({ length: lines }).map((_, i) => (
+      <SkeletonLine key={i} className={`h-4 ${i === lines - 1 ? 'w-2/3' : 'w-full'} mb-2`} />
+    ))}
+  </div>
+);
+
+export const SkeletonCardGrid: React.FC<{ count?: number }> = ({ count = 6 }) => (
+  <div className="grid md:grid-cols-3 gap-4">
+    {Array.from({ length: count }).map((_, i) => (
+      <SkeletonCard key={i} />
+    ))}
+  </div>
+);
+
+export const SkeletonTiles: React.FC<{ rows?: number }> = ({ rows = 8 }) => (
+  <ul className="divide-y rounded-xl border">
+    {Array.from({ length: rows }).map((_, i) => (
+      <li key={i} className="p-4">
+        <SkeletonLine className="h-5 w-1/2 mb-2" />
+        <SkeletonLine className="h-4 w-1/4" />
+      </li>
+    ))}
+  </ul>
+);
+
+export const SkeletonMediaGrid: React.FC<{ count?: number }> = ({ count = 12 }) => (
+  <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-3">
+    {Array.from({ length: count }).map((_, i) => (
+      <div key={i} className="border rounded overflow-hidden">
+        <div className="animate-pulse bg-gray-200 w-full h-32" />
+      </div>
+    ))}
+  </div>
+);

--- a/frontend/pages/api/newsroom/drafts/[id]/attach.js
+++ b/frontend/pages/api/newsroom/drafts/[id]/attach.js
@@ -1,0 +1,22 @@
+import { ObjectId } from 'mongodb';
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const session = await getServerSession(req, res, authOptions);
+  const who = session?.user?.email || null;
+  if (!who) return res.status(401).json({ error: 'Unauthorized' });
+  const { id } = req.query || {};
+  const { url, publicId, width, height, mime } = req.body || {};
+  if (!id || !url) return res.status(400).json({ error: 'id and url required' });
+  const db = await getDb();
+  const col = db.collection('drafts');
+  // author-owns or admin update is enforced elsewhere; keep it simple here by scoping to owner
+  const doc = await col.findOne({ _id: new ObjectId(String(id)) });
+  if (!doc || doc.authorEmail !== who) return res.status(403).json({ error: 'Not allowed' });
+  const item = { url, publicId, width, height, mime, addedAt: new Date().toISOString() };
+  await col.updateOne({ _id: doc._id }, { $push: { attachments: item }, $set: { updatedAt: new Date().toISOString() } });
+  res.json({ ok: true, item });
+}

--- a/frontend/pages/api/newsroom/invite.js
+++ b/frontend/pages/api/newsroom/invite.js
@@ -1,0 +1,29 @@
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+import { rateLimit } from '@/lib/rate-limit';
+import { sendEmail } from '@/lib/email';
+
+const limiter = rateLimit({ interval: 60_000, uniqueTokenPerInterval: 500, maxInInterval: 5 });
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const session = await getServerSession(req, res, authOptions);
+  if (!session?.user?.email) return res.status(401).json({ error: 'Unauthorized' });
+  const { email } = req.body || {};
+  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(email))) return res.status(400).json({ error: 'Valid email required' });
+  try {
+    await limiter.check(res, 5, session.user.email); // 5 invites/minute per user
+  } catch {
+    return res.status(429).json({ error: 'Too many invites, slow down.' });
+  }
+  const subject = 'Invitation to write with WaterNews';
+  const text = `You've been invited to join WaterNews. Visit ${process.env.NEXTAUTH_URL || 'https://waternews.onrender.com'}/login to get started.`;
+  try {
+    // Support both common signatures: sendEmail(to, subject, html|text) OR sendEmail({to, subject, text})
+    try { await (sendEmail as any)(email, subject, text); }
+    catch { await (sendEmail as any)({ to: email, subject, text }); }
+    return res.json({ ok: true });
+  } catch (e) {
+    return res.status(500).json({ error: 'Failed to send invite' });
+  }
+}

--- a/frontend/pages/newsroom/dashboard.tsx
+++ b/frontend/pages/newsroom/dashboard.tsx
@@ -4,6 +4,7 @@ import NewsroomLayout from '@/components/Newsroom/NewsroomLayout';
 import StatsCards from '@/components/Newsroom/StatsCards';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
+import { SkeletonCardGrid } from '@/components/UX/Skeleton';
 
 export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx as any);
 
@@ -13,7 +14,7 @@ export default function NewsroomDashboard() {
   return (
     <NewsroomLayout>
       <h1 className="text-2xl font-semibold mb-4">Dashboard</h1>
-      <StatsCards data={stats} />
+      {stats ? <StatsCards data={stats} /> : <SkeletonCardGrid count={4} />}
       <div className="mt-6 grid md:grid-cols-3 gap-4">
         <Card title="Create a new publication" href="#" cta onClick={createNewDraft} />
         <Card title="New Notice" href="/newsroom/notice-board" />

--- a/frontend/pages/newsroom/drafts/[id].tsx
+++ b/frontend/pages/newsroom/drafts/[id].tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { GetServerSideProps } from 'next';
 import { requireAuthSSR } from '@/lib/user-guard';
-import MediaLibraryModal from '@/components/MediaLibraryModal';
 import StatusPill from '@/components/StatusPill';
 import NewsroomLayout from '@/components/Newsroom/NewsroomLayout';
+import Link from 'next/link';
 
 export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx);
 
@@ -11,7 +11,6 @@ export default function WriterDraftEditor() {
   const id = useMemo(() => (typeof window !== 'undefined' ? location.pathname.split('/').pop() : ''), []);
   const [doc, setDoc] = useState<any>(null);
   const [saving, setSaving] = useState<'idle' | 'dirty' | 'saving' | 'saved'>('idle');
-  const [openMedia, setOpenMedia] = useState(false);
   const timer = useRef<any>(null);
   const localKey = useMemo(() => `wn_user_draft_${id}`, [id]);
 
@@ -70,19 +69,20 @@ export default function WriterDraftEditor() {
               : 'Idle'}
           </span>
         </div>
-        <div className="flex gap-2">
-          <input
-            type="datetime-local"
-            value={doc.publishAt || ''}
-            onChange={(e) =>
-              queueSave({
-                ...doc,
-                publishAt: e.target.value || null,
-                status: e.target.value ? 'scheduled' : (doc.status || 'draft'),
-              })
-            }
-            className="border rounded px-2 py-1 text-sm"
-          />
+          <div className="flex gap-2">
+            <Link href={`/newsroom/media?draftId=${encodeURIComponent(id)}`} className="px-3 py-2 rounded border text-sm">Open Media Library</Link>
+            <input
+              type="datetime-local"
+              value={doc.publishAt || ''}
+              onChange={(e) =>
+                queueSave({
+                  ...doc,
+                  publishAt: e.target.value || null,
+                  status: e.target.value ? 'scheduled' : (doc.status || 'draft'),
+                })
+              }
+              className="border rounded px-2 py-1 text-sm"
+            />
           <select
             className="border rounded px-2 py-1 text-sm"
             value={doc.status || 'draft'}
@@ -147,46 +147,31 @@ export default function WriterDraftEditor() {
         onChange={(e) => queueSave({ ...doc, body: e.target.value })}
       />
 
-      <div className="flex flex-wrap items-center gap-2">
-        <input
-          className="border rounded px-2 py-1 text-sm"
-          placeholder="Comma, tags"
-          value={(doc.tags || []).join(',')}
-          onChange={(e) =>
-            queueSave({
-              ...doc,
-              tags: e.target.value.split(',').map((s) => s.trim()).filter(Boolean),
-            })
-          }
-        />
-        <button className="px-3 py-2 rounded bg-gray-100" onClick={() => setOpenMedia(true)}>
-          Insert Media
-        </button>
-      </div>
-
-      {!!(doc.media?.length) && (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
-          {doc.media.map((m: any) => (
-            <div key={m.public_id} className="border rounded overflow-hidden">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={m.secure_url || m.url} alt={m.public_id} className="w-full h-32 object-cover" />
-              <div className="text-xs p-2 truncate">{m.public_id}</div>
-            </div>
-          ))}
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            className="border rounded px-2 py-1 text-sm"
+            placeholder="Comma, tags"
+            value={(doc.tags || []).join(',')}
+            onChange={(e) =>
+              queueSave({
+                ...doc,
+                tags: e.target.value.split(',').map((s) => s.trim()).filter(Boolean),
+              })
+            }
+          />
         </div>
-      )}
 
-      <MediaLibraryModal
-        open={openMedia}
-        onClose={() => setOpenMedia(false)}
-        onSelect={(asset: any) => {
-          const media = [
-            ...(doc.media || []),
-            { public_id: asset.public_id, url: asset.url, secure_url: asset.secure_url },
-          ];
-          queueSave({ ...doc, media });
-        }}
-      />
+        {!!(doc.media?.length) && (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+            {doc.media.map((m: any) => (
+              <div key={m.public_id} className="border rounded overflow-hidden">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={m.secure_url || m.url} alt={m.public_id} className="w-full h-32 object-cover" />
+                <div className="text-xs p-2 truncate">{m.public_id}</div>
+              </div>
+            ))}
+          </div>
+        )}
         <div className="pt-6">
         <a href="/newsroom/posts" className="text-sm underline underline-offset-4">See my published posts →</a>
       </div>

--- a/frontend/pages/newsroom/help.tsx
+++ b/frontend/pages/newsroom/help.tsx
@@ -1,0 +1,31 @@
+import NewsroomLayout from '@/components/Newsroom/NewsroomLayout';
+import type { GetServerSideProps } from 'next';
+import { requireAuthSSR } from '@/lib/user-guard';
+
+export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx as any);
+
+export default function HelpPage(){
+  return (
+    <NewsroomLayout>
+      <h1 className="text-2xl font-semibold mb-4">Help for Members</h1>
+      <div className="grid md:grid-cols-2 gap-4">
+        <section className="border rounded-xl p-4">
+          <div className="font-medium mb-1">Getting started</div>
+          <p className="text-sm text-gray-600">Use Publisher to create drafts, insert media, and submit for review. The Dashboard shows your stats and quick actions.</p>
+        </section>
+        <section className="border rounded-xl p-4">
+          <div className="font-medium mb-1">Editorial workflow</div>
+          <p className="text-sm text-gray-600">Submit for review when ready. Editors will approve or request changes; you’ll receive email notifications.</p>
+        </section>
+        <section className="border rounded-xl p-4">
+          <div className="font-medium mb-1">Media tips</div>
+          <p className="text-sm text-gray-600">Open Media from the draft to insert images/videos. Uploads live in Cloudinary and can be reused across drafts.</p>
+        </section>
+        <section className="border rounded-xl p-4">
+          <div className="font-medium mb-1">Policies</div>
+          <p className="text-sm text-gray-600">Review our <a className="text-blue-600 underline" href="/editorial-standards">Editorial Standards</a> and <a className="text-blue-600 underline" href="/privacy">Privacy</a>.</p>
+        </section>
+      </div>
+    </NewsroomLayout>
+  );
+}

--- a/frontend/pages/newsroom/index.tsx
+++ b/frontend/pages/newsroom/index.tsx
@@ -4,16 +4,19 @@ import StatusPill from '@/components/StatusPill';
 import NewsroomLayout from '@/components/Newsroom/NewsroomLayout';
 import type { GetServerSideProps } from 'next';
 import { requireAuthSSR } from '@/lib/user-guard';
+import { SkeletonTiles } from '@/components/UX/Skeleton';
 
 export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx as any);
 
 export default function PublisherHub() {
   const [drafts, setDrafts] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
   useEffect(() => {
     (async () => {
       const r = await fetch('/api/newsroom/drafts');
       const d = await r.json();
       setDrafts(d.items || d.drafts || []);
+      setLoading(false);
     })();
   }, []);
   return (
@@ -22,6 +25,7 @@ export default function PublisherHub() {
         <h1 className="text-2xl font-semibold">Publisher</h1>
         <button onClick={createDraft} className="px-3 py-2 rounded bg-black text-white text-sm">New draft</button>
       </div>
+      {loading ? <SkeletonTiles rows={8} /> : (
       <ul className="divide-y rounded-xl border">
         {drafts.map((it: any) => (
           <li key={it._id} className="flex items-center justify-between p-4">
@@ -43,6 +47,7 @@ export default function PublisherHub() {
           </li>
         ))}
       </ul>
+      )}
     </NewsroomLayout>
   );
 }

--- a/frontend/pages/newsroom/invite.tsx
+++ b/frontend/pages/newsroom/invite.tsx
@@ -1,0 +1,32 @@
+import NewsroomLayout from '@/components/Newsroom/NewsroomLayout';
+import type { GetServerSideProps } from 'next';
+import { requireAuthSSR } from '@/lib/user-guard';
+import { useState } from 'react';
+
+export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx as any);
+
+export default function InvitePage(){
+  const [email, setEmail] = useState('');
+  const [sending, setSending] = useState(false);
+  const [msg, setMsg] = useState<string| null>(null);
+  async function send(){
+    setSending(true); setMsg(null);
+    try{
+      const r = await fetch('/api/newsroom/invite', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ email })});
+      const d = await r.json().catch(()=>({}));
+      if (!r.ok) setMsg(d?.error || 'Failed to send invite');
+      else setMsg('Invite sent!');
+    } finally { setSending(false); }
+  }
+  return (
+    <NewsroomLayout>
+      <h1 className="text-2xl font-semibold mb-4">Invite a Friend</h1>
+      <div className="max-w-md border rounded-xl p-4">
+        <label className="block text-sm text-gray-600 mb-1">Email address</label>
+        <input value={email} onChange={e=>setEmail(e.target.value)} type="email" className="w-full border rounded px-3 py-2 mb-3" placeholder="name@example.com"/>
+        <button onClick={send} disabled={!email || sending} className="px-3 py-2 rounded bg-black text-white text-sm disabled:opacity-50">{sending?'Sending…':'Send invite'}</button>
+        {msg ? <div className="mt-2 text-sm">{msg}</div> : null}
+      </div>
+    </NewsroomLayout>
+  );
+}

--- a/frontend/pages/newsroom/media.tsx
+++ b/frontend/pages/newsroom/media.tsx
@@ -1,7 +1,9 @@
 import type { GetServerSideProps } from 'next';
 import { requireAuthSSR } from '@/lib/user-guard';
 import NewsroomLayout from '@/components/Newsroom/NewsroomLayout';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import Toast from '@/components/Toast';
+import { SkeletonMediaGrid } from '@/components/UX/Skeleton';
 
 export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx as any);
 
@@ -9,7 +11,14 @@ export default function MediaHub() {
   const [items, setItems] = useState<any[]>([]);
   const [q, setQ] = useState('');
   const [searching, setSearching] = useState(false);
-  useEffect(()=>{ loadRecent(); },[]);
+  const [toast, setToast] = useState<{ type: 'success'|'error', msg: string }|null>(null);
+  const [loading, setLoading] = useState(true);
+  const draftId = useMemo(() => {
+    if (typeof window === 'undefined') return '';
+    return new URL(window.location.href).searchParams.get('draftId') || '';
+  }, []);
+
+  useEffect(()=>{ (async()=>{ await loadRecent(); setLoading(false); })(); },[]);
   async function loadRecent(){
     const r = await fetch('/api/newsroom/media/recent'); const d = await r.json();
     setItems(d.items || []);
@@ -23,22 +32,49 @@ export default function MediaHub() {
       setItems(d.items || d.assets || []);
     } finally { setSearching(false); }
   }
+  async function attachToDraft(asset: any){
+    if (!draftId) return;
+    const body = {
+      url: asset.secure_url || asset.url,
+      publicId: asset.public_id || null,
+      width: asset.width || null,
+      height: asset.height || null,
+      mime: asset.resource_type || null
+    };
+    const r = await fetch(`/api/newsroom/drafts/${encodeURIComponent(draftId)}/attach`, {
+      method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)
+    });
+    const d = await r.json().catch(()=>({}));
+    if (!r.ok) setToast({ type:'error', msg: d?.error || 'Failed to attach' });
+    else setToast({ type:'success', msg: 'Added to draft' });
+  }
   return (
     <NewsroomLayout>
-      <h1 className="text-2xl font-semibold mb-4">Media Library</h1>
-      <p className="text-sm text-gray-600 mb-3">Search images/videos. We’ll show recent picks first — Cloudinary is only queried when you search.</p>
+      <h1 className="text-2xl font-semibold mb-2">Media Library</h1>
+      <p className="text-sm text-gray-600 mb-3">
+        Search images/videos. We show recent picks first — Cloudinary is queried when you search.
+        {draftId ? <span className="ml-2 text-sky-700">Click any tile to insert into your draft.</span> : null}
+      </p>
       <form onSubmit={search} className="flex gap-2 mb-4">
         <input value={q} onChange={e=>setQ(e.target.value)} className="border rounded px-3 py-2 flex-1" placeholder="Search library…" />
         <button className="px-3 py-2 rounded bg-black text-white text-sm" disabled={!q.trim() || searching}>{searching?'Searching…':'Search'}</button>
       </form>
-      <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-3">
-        {items.map((it:any, i:number)=>(
-          <figure key={it.public_id || it.secure_url || it.url || i} className="border rounded overflow-hidden">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={it.secure_url || it.url || it.thumb || '/placeholders/newsroom.svg'} alt="" className="w-full h-32 object-cover"/>
-          </figure>
-        ))}
-      </div>
+      {loading ? <SkeletonMediaGrid /> : (
+        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-3">
+          {items.map((it:any, i:number)=>(
+            <button
+              key={it.public_id || it.secure_url || it.url || i}
+              className="border rounded overflow-hidden group"
+              onClick={()=> draftId ? attachToDraft(it) : null}
+              title={draftId ? 'Insert into draft' : 'Media'}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={it.secure_url || it.url || it.thumb || '/placeholders/newsroom.svg'} alt="" className="w-full h-32 object-cover group-hover:opacity-90"/>
+            </button>
+          ))}
+        </div>
+      )}
+      {toast ? <div className="fixed bottom-4 right-4 z-50"><Toast type={toast.type} message={toast.msg} onDone={()=>setToast(null)} /></div> : null}
     </NewsroomLayout>
   );
 }

--- a/frontend/pages/newsroom/notice-board.tsx
+++ b/frontend/pages/newsroom/notice-board.tsx
@@ -2,6 +2,7 @@ import type { GetServerSideProps } from 'next';
 import { requireAuthSSR } from '@/lib/user-guard';
 import NewsroomLayout from '@/components/Newsroom/NewsroomLayout';
 import { useEffect, useState } from 'react';
+import { SkeletonTiles } from '@/components/UX/Skeleton';
 
 export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx as any);
 
@@ -28,7 +29,7 @@ export default function NoticeBoard() {
         <textarea className="w-full border rounded px-3 py-2 min-h-[120px]" placeholder="Write a platform update, suggestion, or discussion topic…" value={body} onChange={e=>setBody(e.target.value)} />
         <div><button onClick={post} className="px-3 py-2 rounded bg-black text-white text-sm">Publish notice</button></div>
       </div>
-      {loading ? <div>Loading…</div> : (
+      {loading ? <SkeletonTiles rows={6} /> : (
         <ul className="space-y-4">
           {items.map((n:any)=>(
             <li key={String(n._id)} className="border rounded-xl p-4">

--- a/frontend/types/react/index.d.ts
+++ b/frontend/types/react/index.d.ts
@@ -6,7 +6,7 @@ declare namespace JSX {
 
 declare namespace React {
   type ReactNode = any;
-  type FC<P = {}> = (props: P & { children?: ReactNode }) => any;
+  type FC<P = {}> = (props: P & { children?: ReactNode; key?: any }) => any;
   interface KeyboardEvent<T = Element> {
     key: string;
     metaKey?: boolean;
@@ -30,6 +30,8 @@ declare namespace React {
   function useMemo<T = any>(factory: () => T, deps?: any[]): T;
   function useRef<T = any>(initial?: T): { current: T };
   function useId(): string;
+  function createContext<T = any>(defaultValue: T): any;
+  function useContext<T = any>(ctx: any): T;
 }
 export = React;
 export as namespace React;


### PR DESCRIPTION
## Summary
- add reusable skeleton loaders and apply them to dashboard, draft list, notice board and media views
- introduce member Help and Invite pages with invite email API and rate limiting
- enhance media library to attach assets to a draft via `draftId` and new `/attach` endpoint

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a7e870363c8329b78460ef7711749f