### PR TITLE
Rev.4 UX Series — Patch O (Slash menu, drag-drop upload, presence, activity trail, invite.js fix)

### DIFF
--- a/frontend/components/Newsroom/ActivityTrail.tsx
+++ b/frontend/components/Newsroom/ActivityTrail.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+export default function ActivityTrail({ draftId }: { draftId: string }) {
+  const [items, setItems] = useState<any[]>([]);
+  useEffect(()=>{ load(); const t=setInterval(load, 15000); return ()=>clearInterval(t); }, [draftId]);
+  async function load(){
+    const r = await fetch(`/api/newsroom/drafts/${encodeURIComponent(draftId)}/activity`);
+    const d = await r.json().catch(()=>({}));
+    setItems(d.items || []);
+  }
+  if (!items.length) return null;
+  return (
+    <section className="mt-6 border rounded-xl p-4">
+      <div className="font-medium mb-2">Activity</div>
+      <ul className="space-y-2 text-sm">
+        {items.map((a:any)=>(
+          <li key={String(a._id)} className="flex items-center gap-2">
+            <span className="text-gray-500">{new Date(a.createdAt).toLocaleTimeString()}</span>
+            <span className="px-2 py-0.5 rounded bg-gray-100">{a.type}</span>
+            <span className="text-gray-700 truncate">{a.authorEmail}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/components/Newsroom/MarkdownEditor.tsx
+++ b/frontend/components/Newsroom/MarkdownEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import MediaLibraryModal from '@/components/MediaLibraryModal';
 
  type MarkdownEditorProps = {
@@ -12,8 +12,19 @@ import MediaLibraryModal from '@/components/MediaLibraryModal';
    const { value, onChange, onSave } = props;
    const [local, setLocal] = useState(value || '');
    const [status, setStatus] = useState<'idle'|'dirty'|'saving'|'saved'>('idle');
-   const ref = useRef<any>(null);
-   const [mediaOpen, setMediaOpen] = useState(false);
+  const ref = useRef<any>(null);
+  const [mediaOpen, setMediaOpen] = useState(false);
+  // Slash menu state
+  const [slashOpen, setSlashOpen] = useState(false);
+  const [slashQuery, setSlashQuery] = useState('');
+  const commands = useMemo(() => ([
+    { key: 'h1', label: 'Heading 1', run: () => prefixLine('# ') },
+    { key: 'h2', label: 'Heading 2', run: () => prefixLine('## ') },
+    { key: 'list', label: 'Bulleted list', run: () => prefixLine('- ') },
+    { key: 'quote', label: 'Quote', run: () => prefixLine('> ') },
+    { key: 'image', label: 'Image (from library)', run: () => setMediaOpen(true) },
+    { key: 'embed', label: 'Embed URL (video/tweet)', run: () => insertAtCursor('\n[embed](https://...)') },
+  ]), []);
  
    useEffect(() => {
      setLocal(value || '');
@@ -34,13 +45,30 @@ import MediaLibraryModal from '@/components/MediaLibraryModal';
      return () => clearTimeout(t);
    }, [status, onSave]);
  
-   function handleKeyDown(e /* React.KeyboardEvent<HTMLTextAreaElement> */) {
-     // Ctrl/Cmd+S to save
-     if ((e.metaKey || e.ctrlKey) && e.key === 's') {
-       e.preventDefault?.();
-       onSave?.();
-     }
-   }
+  function handleKeyDown(e /* React.KeyboardEvent<HTMLTextAreaElement> */) {
+    // Ctrl/Cmd+S to save
+    if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+      e.preventDefault?.();
+      onSave?.();
+    }
+    // Slash menu
+    if (e.key === '/') {
+      setSlashOpen(true);
+      setSlashQuery('');
+    } else if (slashOpen) {
+      if (e.key === 'Escape') { setSlashOpen(false); return; }
+      if (e.key === 'Enter') {
+        e.preventDefault?.();
+        const match = (filterCommands(slashQuery)[0]);
+        if (match) match.run();
+        setSlashOpen(false);
+        return;
+      }
+      // crude query capture for letters/spaces/backspace
+      if (e.key.length === 1) setSlashQuery((q)=> (q + e.key));
+      if (e.key === 'Backspace') setSlashQuery((q)=> q.slice(0, -1));
+    }
+  }
  
    // Insert text at caret in the textarea
    function insertAtCursor(text: string) {
@@ -76,10 +104,82 @@ import MediaLibraryModal from '@/components/MediaLibraryModal';
              height: asset?.height || null,
              mime: asset?.resource_type || null
            })
-         });
-       } catch {}
-     }
-   }
+        });
+        logActivity('insert_media', { url });
+      } catch {}
+    }
+  }
+
+  function filterCommands(q: string) {
+    const s = q.trim().toLowerCase();
+    if (!s) return commands;
+    return commands.filter(c => c.label.toLowerCase().includes(s) || c.key.includes(s));
+  }
+
+  function prefixLine(prefix: string) {
+    const el = ref.current as any;
+    if (!el) return insertAtCursor(prefix);
+    const start = el.selectionStart || 0;
+    // find start of line
+    const text = local || '';
+    const lineStart = text.lastIndexOf('\n', Math.max(0, start - 1)) + 1;
+    const next = text.slice(0, lineStart) + prefix + text.slice(lineStart);
+    setLocal(next);
+    onChange(next);
+    setTimeout(()=>{ try{ el.focus(); el.selectionStart = el.selectionEnd = start + prefix.length; }catch{} }, 0);
+  }
+
+  // Drag & drop upload
+  async function handleDrop(e: any) {
+    e.preventDefault?.();
+    const files = Array.from(e.dataTransfer?.files || []) as File[];
+    if (!files.length) return;
+    for (const f of files) {
+      const dataUrl = await fileToDataUrl(f).catch(()=>null);
+      if (!dataUrl) continue;
+      // optimistic placeholder
+      const placeholder = f.type.startsWith('video/') ? `[media](uploading...)` : `![image](uploading...)`;
+      insertAtCursor(placeholder);
+      try{
+        const r = await fetch('/api/media/upload', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ dataUrl })});
+        const d = await r.json();
+        const url = d?.asset?.secure_url || d?.asset?.url;
+        if (url) {
+          // replace last "uploading..." occurrence with real URL
+          setLocal((cur)=> cur.replace('(uploading...)', `(${url})`));
+          onChange((local || '').replace('(uploading...)', `(${url})`));
+          if ((props as any).draftId) {
+            await fetch(`/api/newsroom/drafts/${encodeURIComponent((props as any).draftId)}/attach`, {
+              method:'POST', headers:{'Content-Type':'application/json'},
+              body: JSON.stringify({ url, publicId: d?.asset?.public_id || null, width: d?.asset?.width, height: d?.asset?.height, mime: d?.asset?.resource_type })
+            });
+            logActivity('upload_media', { name: (f as File).name, url });
+          }
+        }
+      }catch{}
+    }
+  }
+
+  function handleDragOver(e:any){ e.preventDefault?.(); }
+
+  function fileToDataUrl(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result));
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  }
+
+  // Activity logging helper
+  async function logActivity(type: string, data?: any){
+    if (!(props as any).draftId) return;
+    try{
+      await fetch(`/api/newsroom/drafts/${encodeURIComponent((props as any).draftId)}/activity`, {
+        method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ type, data })
+      });
+    }catch{}
+  }
  
    return (
      <div className="space-y-2">
@@ -107,17 +207,40 @@ import MediaLibraryModal from '@/components/MediaLibraryModal';
          </div>
        </div>
        <textarea
-         ref={ref}
-         className="w-full border rounded px-3 py-2 min-h-[320px]"
-         value={local}
-         onChange={(e)=>{ setLocal(e.target.value); onChange(e.target.value); setStatus('dirty'); }}
-         onKeyDown={handleKeyDown}
+        ref={ref}
+        className="w-full border rounded px-3 py-2 min-h-[320px]"
+        value={local}
+        onChange={(e)=>{ setLocal(e.target.value); onChange(e.target.value); setStatus('dirty'); }}
+        onKeyDown={handleKeyDown}
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
        />
        <MediaLibraryModal
          open={mediaOpen}
          onClose={()=> setMediaOpen(false)}
          onSelect={onPickAsset}
        />
+       {slashOpen ? (
+        <div className="mt-2 border rounded-xl shadow bg-white p-2 max-w-xs">
+          <input
+            autoFocus
+            value={slashQuery}
+            onChange={(e:any)=> setSlashQuery(e.target.value)}
+            placeholder="Type to filter…"
+            className="w-full border rounded px-2 py-1 text-sm mb-2"
+          />
+          <ul className="max-h-56 overflow-auto">
+            {filterCommands(slashQuery).map((c)=>(
+              <li key={c.key}>
+                <button className="w-full text-left px-2 py-1 rounded hover:bg-gray-100 text-sm" onClick={()=>{ c.run(); setSlashOpen(false); }}>
+                  {c.label}
+                </button>
+              </li>
+            ))}
+            {!filterCommands(slashQuery).length ? <li className="px-2 py-1 text-sm text-gray-500">No matches</li> : null}
+          </ul>
+        </div>
+       ) : null}
      </div>
    );
  }

--- a/frontend/pages/api/media/upload.js
+++ b/frontend/pages/api/media/upload.js
@@ -1,0 +1,19 @@
+// Simple Cloudinary upload endpoint that accepts a Data URL or remote URL.
+// This is used by drag-drop in the editor. It avoids multipart parsing.
+export const config = { api: { bodyParser: { sizeLimit: '20mb' } } };
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  // Guard Cloudinary at runtime (no types required)
+  let cloudinary;
+  try { cloudinary = require('cloudinary').v2; } catch { return res.status(503).json({ error: 'Cloudinary unavailable' }); }
+  try {
+    if (!process.env.CLOUDINARY_URL) return res.status(503).json({ error: 'Cloudinary not configured' });
+    const { dataUrl, folder = 'waternews' } = req.body || {};
+    if (!dataUrl || typeof dataUrl !== 'string') return res.status(400).json({ error: 'dataUrl required' });
+    const r = await cloudinary.uploader.upload(dataUrl, { folder });
+    return res.json({ ok: true, asset: r });
+  } catch (e) {
+    return res.status(500).json({ error: 'Upload failed' });
+  }
+}

--- a/frontend/pages/api/newsroom/drafts/[id]/activity.js
+++ b/frontend/pages/api/newsroom/drafts/[id]/activity.js
@@ -1,0 +1,34 @@
+import { ObjectId } from 'mongodb';
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+
+// POST: log activity { type, data? }
+// GET: list recent
+export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  const who = session?.user?.email || null;
+  const { id } = req.query || {};
+  const db = await getDb();
+  const col = db.collection('draftActivity');
+  await col.createIndex({ draftId: 1, createdAt: -1 });
+  if (req.method === 'POST') {
+    if (!who) return res.status(401).json({ error: 'Unauthorized' });
+    const { type, data } = req.body || {};
+    if (!type) return res.status(400).json({ error: 'type required' });
+    const doc = {
+      draftId: new ObjectId(String(id)),
+      authorEmail: who,
+      type: String(type).slice(0, 64),
+      data: data || null,
+      createdAt: new Date().toISOString(),
+    };
+    const r = await col.insertOne(doc);
+    return res.json({ ok: true, id: r.insertedId });
+  }
+  if (req.method === 'GET') {
+    const items = await col.find({ draftId: new ObjectId(String(id)) }).sort({ createdAt: -1 }).limit(100).toArray();
+    return res.json({ items });
+  }
+  res.setHeader('Allow','GET,POST'); res.status(405).end();
+}

--- a/frontend/pages/api/newsroom/drafts/[id]/presence.js
+++ b/frontend/pages/api/newsroom/drafts/[id]/presence.js
@@ -1,0 +1,33 @@
+import { ObjectId } from 'mongodb';
+import { getDb } from '@/lib/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+
+// GET: list active viewers/editors
+// POST: heartbeat current user
+export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  const who = session?.user?.email || null;
+  const { id } = req.query || {};
+  if (!id) return res.status(400).json({ error: 'id required' });
+  const db = await getDb();
+  const col = db.collection('draftPresence');
+  await col.createIndex({ draftId: 1, email: 1 }, { unique: true });
+  await col.createIndex({ seenAt: 1 }, { expireAfterSeconds: 120 }); // TTL-like cleanup (requires MongoDB TTL index on a Date; emulate with cron if not allowed)
+  if (req.method === 'POST') {
+    if (!who) return res.status(401).json({ error: 'Unauthorized' });
+    const now = new Date();
+    await col.updateOne(
+      { draftId: new ObjectId(String(id)), email: who },
+      { $set: { draftId: new ObjectId(String(id)), email: who, seenAt: now, name: session.user.name || null } },
+      { upsert: true }
+    );
+    return res.json({ ok: true });
+  }
+  if (req.method === 'GET') {
+    const cutoff = new Date(Date.now() - 120_000);
+    const items = await col.find({ draftId: new ObjectId(String(id)), seenAt: { $gte: cutoff } }).project({ email:1, name:1, seenAt:1 }).toArray();
+    return res.json({ items });
+  }
+  res.setHeader('Allow','GET,POST'); res.status(405).end();
+}

--- a/frontend/pages/api/newsroom/invite.js
+++ b/frontend/pages/api/newsroom/invite.js
@@ -19,11 +19,15 @@ export default async function handler(req, res) {
   const subject = 'Invitation to write with WaterNews';
   const text = `You've been invited to join WaterNews. Visit ${process.env.NEXTAUTH_URL || 'https://waternews.onrender.com'}/login to get started.`;
   try {
-    // Support both common signatures: sendEmail(to, subject, html|text) OR sendEmail({to, subject, text})
-    try { await (sendEmail as any)(email, subject, text); }
-    catch { await (sendEmail as any)({ to: email, subject, text }); }
+    // Support both common signatures without TS syntax:
+    // 1) sendEmail(to, subject, text/html)
+    // 2) sendEmail({ to, subject, text })
+    try { await sendEmail(email, subject, text); }
+    catch {
+      await sendEmail({ to: email, subject, text });
+    }
     return res.json({ ok: true });
-  } catch (e) {
+  } catch {
     return res.status(500).json({ error: 'Failed to send invite' });
   }
 }

--- a/frontend/pages/newsroom/drafts/[id].tsx
+++ b/frontend/pages/newsroom/drafts/[id].tsx
@@ -6,6 +6,7 @@ import NewsroomLayout from '@/components/Newsroom/NewsroomLayout';
 import Link from 'next/link';
 import MarkdownEditor from '@/components/Newsroom/MarkdownEditor';
 import DraftComments from '@/components/Newsroom/DraftComments';
+import ActivityTrail from '@/components/Newsroom/ActivityTrail';
 
 export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx);
 
@@ -66,14 +67,14 @@ export default function WriterDraftEditor() {
             <StatusPill status={doc.status} />
             <span>
               {saving === 'saving'
-              ? 'Saving…'
-              : saving === 'saved'
-              ? 'Saved'
-              : saving === 'dirty'
-              ? 'Unsaved changes'
-              : 'Idle'}
-          </span>
-        </div>
+                ? 'Saving…'
+                : saving === 'saved'
+                ? 'Saved'
+                : saving === 'dirty'
+                ? 'Unsaved changes'
+                : 'Idle'}
+            </span>
+          </div>
           <div className="flex gap-2">
             <Link href={`/newsroom/media?draftId=${encodeURIComponent(id)}`} className="px-3 py-2 rounded border text-sm">Open Media Library</Link>
             <input
@@ -88,76 +89,79 @@ export default function WriterDraftEditor() {
               }
               className="border rounded px-2 py-1 text-sm"
             />
-          <select
-            className="border rounded px-2 py-1 text-sm"
-            value={doc.status || 'draft'}
-            onChange={(e) => queueSave({ ...doc, status: e.target.value })}
-          >
-            <option value="draft">Draft</option>
-            <option value="ready">Ready</option>
-            <option value="scheduled">Scheduled</option>
-            <option value="published">Published</option>
-          </select>
-          <button
-            onClick={async () => {
-              const r = await fetch(`/api/newsroom/drafts/${id}/submit`, { method: 'POST' });
-              const d = await r.json();
-              if (!r.ok) return alert(d?.error || 'Failed to submit for review');
-              setDoc(d.draft || doc);
-              alert('Submitted for review');
-            }}
-            className="px-3 py-2 rounded bg-gray-100 text-sm"
-          >
-            Submit for review
-          </button>
-          <button
-            onClick={async () => {
-              if (!confirm('Publish now? (Admins only)')) return;
-              const r = await fetch(`/api/newsroom/drafts/${id}/publish`, { method: 'POST' });
-              const d = await r.json();
-              if (!r.ok) return alert(d?.error || 'Failed to publish');
-              alert('Published');
-              location.href = `/news/${d?.post?.slug}`;
-            }}
-            className="px-3 py-2 rounded bg-black text-white text-sm"
-          >
-            Publish now
-          </button>
-          <button
-            className="px-3 py-2 rounded border text-sm"
-            onClick={async () => {
-              if (!confirm('Delete this draft? This cannot be undone.')) return;
-              const r = await fetch(`/api/newsroom/drafts/${encodeURIComponent(id)}/delete`, { method: 'POST' });
-              const d = await r.json().catch(() => ({}));
-              if (!r.ok) return alert(d?.error || 'Delete failed');
-              location.href = '/newsroom';
-            }}
-          >
-            Delete
-          </button>
+            <select
+              className="border rounded px-2 py-1 text-sm"
+              value={doc.status || 'draft'}
+              onChange={(e) => queueSave({ ...doc, status: e.target.value })}
+            >
+              <option value="draft">Draft</option>
+              <option value="ready">Ready</option>
+              <option value="scheduled">Scheduled</option>
+              <option value="published">Published</option>
+            </select>
+            <button
+              onClick={async () => {
+                const r = await fetch(`/api/newsroom/drafts/${id}/submit`, { method: 'POST' });
+                const d = await r.json();
+                if (!r.ok) return alert(d?.error || 'Failed to submit for review');
+                setDoc(d.draft || doc);
+                alert('Submitted for review');
+              }}
+              className="px-3 py-2 rounded bg-gray-100 text-sm"
+            >
+              Submit for review
+            </button>
+            <button
+              onClick={async () => {
+                if (!confirm('Publish now? (Admins only)')) return;
+                const r = await fetch(`/api/newsroom/drafts/${id}/publish`, { method: 'POST' });
+                const d = await r.json();
+                if (!r.ok) return alert(d?.error || 'Failed to publish');
+                alert('Published');
+                location.href = `/news/${d?.post?.slug}`;
+              }}
+              className="px-3 py-2 rounded bg-black text-white text-sm"
+            >
+              Publish now
+            </button>
+            <button
+              className="px-3 py-2 rounded border text-sm"
+              onClick={async () => {
+                if (!confirm('Delete this draft? This cannot be undone.')) return;
+                const r = await fetch(`/api/newsroom/drafts/${encodeURIComponent(id)}/delete`, { method: 'POST' });
+                const d = await r.json().catch(() => ({}));
+                if (!r.ok) return alert(d?.error || 'Delete failed');
+                location.href = '/newsroom';
+              }}
+            >
+              Delete
+            </button>
+          </div>
         </div>
-      </div>
 
-      <input
-        className="w-full text-2xl font-semibold border-b outline-none pb-2"
-        placeholder="Headline…"
-        value={doc.title || ''}
-        onChange={(e) => queueSave({ ...doc, title: e.target.value })}
-      />
+        <input
+          className="w-full text-2xl font-semibold border-b outline-none pb-2"
+          placeholder="Headline…"
+          value={doc.title || ''}
+          onChange={(e) => queueSave({ ...doc, title: e.target.value })}
+        />
 
-      <MarkdownEditor
-        value={doc.body || ''}
-        onChange={(v) => {
-          const next = { ...doc, body: v };
-          setDoc(next);
-          setSaving('dirty');
-          localStorage.setItem(localKey, JSON.stringify(next));
-        }}
-        onSave={() => save()}
-        draftId={id as string}
-      />
+        <MarkdownEditor
+          value={doc.body || ''}
+          onChange={(v) => {
+            const next = { ...doc, body: v };
+            setDoc(next);
+            setSaving('dirty');
+            localStorage.setItem(localKey, JSON.stringify(next));
+          }}
+          onSave={() => save()}
+          draftId={id as string}
+        />
 
         <DraftComments draftId={id as string} />
+
+        <PresenceStrip draftId={id as string} />
+        <ActivityTrail draftId={id as string} />
 
         <div className="flex flex-wrap items-center gap-2">
           <input
@@ -185,10 +189,36 @@ export default function WriterDraftEditor() {
           </div>
         )}
         <div className="pt-6">
-        <a href="/newsroom/posts" className="text-sm underline underline-offset-4">See my published posts →</a>
-      </div>
+          <a href="/newsroom/posts" className="text-sm underline underline-offset-4">See my published posts →</a>
+        </div>
       </div>
     </NewsroomLayout>
+  );
+}
+
+function PresenceStrip({ draftId }: { draftId: string }) {
+  const [who, setWho] = useState<any[]>([]);
+  useEffect(()=> {
+    let alive = true;
+    const ping = async () => {
+      try { await fetch(`/api/newsroom/drafts/${encodeURIComponent(draftId)}/presence`, { method:'POST' }); } catch {}
+    };
+    const load = async () => {
+      try {
+        const r = await fetch(`/api/newsroom/drafts/${encodeURIComponent(draftId)}/presence`);
+        const d = await r.json(); if (alive) setWho(d.items||[]);
+      } catch {}
+    };
+    ping(); load();
+    const t1 = setInterval(ping, 25000);
+    const t2 = setInterval(load, 25000);
+    return ()=>{ alive=false; clearInterval(t1); clearInterval(t2); };
+  }, [draftId]);
+  if (!who.length) return null;
+  return (
+    <div className="text-xs text-gray-600 mt-2">
+      Currently viewing: {who.map((p:any)=> p.name || p.email).join(', ')}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- fix invite.js sendEmail call by removing TypeScript casts
- add Cloudinary-backed `/api/media/upload` endpoint and drag-and-drop upload in Markdown editor
- implement slash menu, presence tracking, and activity trail for drafts

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a7ee2e2b1c832981d3dd03228b892f