### PR TITLE
Rev.4 UX Series — Patch P (Slash menu polish + AI rewrite chips + editor selection API)

### DIFF
--- a/frontend/components/Newsroom/MarkdownEditor.tsx
+++ b/frontend/components/Newsroom/MarkdownEditor.tsx
@@ -1,51 +1,76 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import MediaLibraryModal from '@/components/MediaLibraryModal';
 
- type MarkdownEditorProps = {
-   value: string;
-   onChange: (v: string) => void;
-   onSave?: () => void;
-   draftId?: string; // for inline media attach
- };
- 
- export default function MarkdownEditor(props: MarkdownEditorProps) {
-   const { value, onChange, onSave } = props;
-   const [local, setLocal] = useState(value || '');
-   const [status, setStatus] = useState<'idle'|'dirty'|'saving'|'saved'>('idle');
+type MarkdownEditorProps = {
+  value: string;
+  onChange: (v: string) => void;
+  onSave?: () => void;
+  draftId?: string; // for inline media attach
+  // Expose editor APIs (selection, replacement) to parent features like AI chips
+  exposeAPI?: (api: {
+    getText: () => string;
+    setText: (text: string) => void;
+    getSelection: () => { start: number; end: number; text: string };
+    replaceSelection: (next: string) => void;
+    insertAtCursor: (text: string) => void;
+  }) => void;
+};
+
+export default function MarkdownEditor(props: MarkdownEditorProps) {
+  const { value, onChange, onSave } = props;
+  const [local, setLocal] = useState(value || '');
+  const [status, setStatus] = useState<'idle'|'dirty'|'saving'|'saved'>('idle');
   const ref = useRef<any>(null);
   const [mediaOpen, setMediaOpen] = useState(false);
   // Slash menu state
   const [slashOpen, setSlashOpen] = useState(false);
   const [slashQuery, setSlashQuery] = useState('');
+  const [slashIdx, setSlashIdx] = useState(0);
   const commands = useMemo(() => ([
     { key: 'h1', label: 'Heading 1', run: () => prefixLine('# ') },
     { key: 'h2', label: 'Heading 2', run: () => prefixLine('## ') },
     { key: 'list', label: 'Bulleted list', run: () => prefixLine('- ') },
     { key: 'quote', label: 'Quote', run: () => prefixLine('> ') },
+    { key: 'pull', label: 'Pull-quote block', run: () => wrapSelection('> **Pull quote:** ', '') },
+    { key: 'callout', label: 'Callout/Note', run: () => wrapSelection('> **Note:** ', '') },
+    { key: 'figure', label: 'Figure + caption', run: () => insertAtCursor('\n![caption](https://...)\n*Figure: add caption here.*\n') },
     { key: 'image', label: 'Image (from library)', run: () => setMediaOpen(true) },
-    { key: 'embed', label: 'Embed URL (video/tweet)', run: () => insertAtCursor('\n[embed](https://...)') },
+    { key: 'embed', label: 'Embed URL (video/tweet)', run: () => insertAtCursor('\n[embed](https://...)\n') },
   ]), []);
- 
-   useEffect(() => {
-     setLocal(value || '');
-   }, [value]);
- 
-   useEffect(() => {
-     if (status !== 'dirty') return;
-     const t = setTimeout(async () => {
-       setStatus('saving');
-       try {
-         await onSave?.();
-         setStatus('saved');
-         setTimeout(()=> setStatus('idle'), 1000);
-       } catch {
-         setStatus('idle');
-       }
-     }, 600);
-     return () => clearTimeout(t);
-   }, [status, onSave]);
- 
-  function handleKeyDown(e /* React.KeyboardEvent<HTMLTextAreaElement> */) {
+
+  useEffect(() => {
+    setLocal(value || '');
+  }, [value]);
+
+  // Expose editor APIs to parent consumers (e.g., AI rewrite chips)
+  useEffect(() => {
+    if (!props.exposeAPI) return;
+    props.exposeAPI({
+      getText: () => local || '',
+      setText: (t: string) => { setLocal(t); onChange(t); },
+      getSelection,
+      replaceSelection,
+      insertAtCursor,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [local, props.exposeAPI]);
+
+  useEffect(() => {
+    if (status !== 'dirty') return;
+    const t = setTimeout(async () => {
+      setStatus('saving');
+      try {
+        await onSave?.();
+        setStatus('saved');
+        setTimeout(()=> setStatus('idle'), 1000);
+      } catch {
+        setStatus('idle');
+      }
+    }, 600);
+    return () => clearTimeout(t);
+  }, [status, onSave]);
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     // Ctrl/Cmd+S to save
     if ((e.metaKey || e.ctrlKey) && e.key === 's') {
       e.preventDefault?.();
@@ -55,13 +80,27 @@ import MediaLibraryModal from '@/components/MediaLibraryModal';
     if (e.key === '/') {
       setSlashOpen(true);
       setSlashQuery('');
+      setSlashIdx(0);
     } else if (slashOpen) {
       if (e.key === 'Escape') { setSlashOpen(false); return; }
       if (e.key === 'Enter') {
         e.preventDefault?.();
-        const match = (filterCommands(slashQuery)[0]);
+        const list = filterCommands(slashQuery);
+        const match = list[slashIdx] || list[0];
         if (match) match.run();
         setSlashOpen(false);
+        return;
+      }
+      if (e.key === 'ArrowDown' || e.key === 'Tab') {
+        e.preventDefault?.();
+        const list = filterCommands(slashQuery);
+        setSlashIdx((i) => (list.length ? (i + 1) % list.length : 0));
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault?.();
+        const list = filterCommands(slashQuery);
+        setSlashIdx((i) => (list.length ? (i - 1 + list.length) % list.length : 0));
         return;
       }
       // crude query capture for letters/spaces/backspace
@@ -69,41 +108,67 @@ import MediaLibraryModal from '@/components/MediaLibraryModal';
       if (e.key === 'Backspace') setSlashQuery((q)=> q.slice(0, -1));
     }
   }
- 
-   // Insert text at caret in the textarea
-   function insertAtCursor(text: string) {
-     const el = ref.current as any;
-     if (!el) { setLocal((s)=> (s + text)); onChange(local + text); return; }
-     const start = el.selectionStart || 0;
-     const end = el.selectionEnd || 0;
-     const next = (local || '').slice(0, start) + text + (local || '').slice(end);
-     setLocal(next);
-     onChange(next);
-     // restore caret
-     setTimeout(()=>{ try{ el.focus(); el.selectionStart = el.selectionEnd = start + text.length; }catch{} }, 0);
-   }
- 
-   async function onPickAsset(asset: any) {
-     const url = asset?.secure_url || asset?.url;
-     if (!url) return;
-     // Simple heuristic: image => !/video|mp4|webm/
-     const isImage = !/(\.mp4|\.webm|video)/i.test(url);
-     const md = isImage ? `![image](${url})` : `[media](${url})`;
-     insertAtCursor(md);
-     setMediaOpen(false);
-     // Attach to draft if id provided
-     if ((props as any).draftId) {
-       try {
-         await fetch(`/api/newsroom/drafts/${encodeURIComponent((props as any).draftId)}/attach`, {
-           method:'POST',
-           headers:{'Content-Type':'application/json'},
-           body: JSON.stringify({
-             url,
-             publicId: asset?.public_id || null,
-             width: asset?.width || null,
-             height: asset?.height || null,
-             mime: asset?.resource_type || null
-           })
+
+  // Insert text at caret in the textarea
+  function insertAtCursor(text: string) {
+    const el = ref.current as any;
+    if (!el) { setLocal((s)=> (s + text)); onChange(local + text); return; }
+    const start = el.selectionStart || 0;
+    const end = el.selectionEnd || 0;
+    const next = (local || '').slice(0, start) + text + (local || '').slice(end);
+    setLocal(next);
+    onChange(next);
+    // restore caret
+    setTimeout(()=>{ try{ el.focus(); el.selectionStart = el.selectionEnd = start + text.length; }catch{} }, 0);
+  }
+
+  function getSelection() {
+    const el = ref.current as any;
+    const start = el?.selectionStart ?? 0;
+    const end = el?.selectionEnd ?? 0;
+    const text = (local || '').slice(start, end);
+    return { start, end, text };
+  }
+
+  function replaceSelection(next: string) {
+    const el = ref.current as any;
+    if (!el) return;
+    const { start, end } = getSelection();
+    const before = (local || '').slice(0, start);
+    const after = (local || '').slice(end);
+    const combined = before + next + after;
+    setLocal(combined);
+    onChange(combined);
+    setTimeout(()=>{ try{ el.focus(); el.selectionStart = el.selectionEnd = before.length + next.length; }catch{} }, 0);
+  }
+
+  function wrapSelection(prefix: string, suffix: string) {
+    const { text } = getSelection();
+    const content = text || '…';
+    replaceSelection(`${prefix}${content}${suffix}`);
+  }
+
+  async function onPickAsset(asset: any) {
+    const url = asset?.secure_url || asset?.url;
+    if (!url) return;
+    // Simple heuristic: image => !/video|mp4|webm/
+    const isImage = !/(\.mp4|\.webm|video)/i.test(url);
+    const md = isImage ? `![image](${url})` : `[media](${url})`;
+    insertAtCursor(md);
+    setMediaOpen(false);
+    // Attach to draft if id provided
+    if ((props as any).draftId) {
+      try {
+        await fetch(`/api/newsroom/drafts/${encodeURIComponent((props as any).draftId)}/attach`, {
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body: JSON.stringify({
+            url,
+            publicId: asset?.public_id || null,
+            width: asset?.width || null,
+            height: asset?.height || null,
+            mime: asset?.resource_type || null
+          })
         });
         logActivity('insert_media', { url });
       } catch {}
@@ -180,48 +245,48 @@ import MediaLibraryModal from '@/components/MediaLibraryModal';
       });
     }catch{}
   }
- 
-   return (
-     <div className="space-y-2">
-       <div className="flex items-center justify-between text-xs">
-         <div className="text-gray-600">
-           {status === 'saving' ? 'Saving…' : status === 'saved' ? 'Saved' : status === 'dirty' ? 'Unsaved changes' : 'Idle'}
-         </div>
-         <div className="flex items-center gap-2">
-           <button
-             type="button"
-             className="px-2 py-1 rounded border hover:bg-gray-50"
-             onClick={()=> setMediaOpen(true)}
-             title="Insert media"
-           >
-             Insert media
-           </button>
-           <button
-             type="button"
-             className="px-2 py-1 rounded border hover:bg-gray-50"
-             onClick={()=> onSave?.()}
-             title="Save (⌘/Ctrl+S)"
-           >
-             Save
-           </button>
-         </div>
-       </div>
-       <textarea
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between text-xs">
+        <div className="text-gray-600">
+          {status === 'saving' ? 'Saving…' : status === 'saved' ? 'Saved' : status === 'dirty' ? 'Unsaved changes' : 'Idle'}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="px-2 py-1 rounded border hover:bg-gray-50"
+            onClick={()=> setMediaOpen(true)}
+            title="Insert media"
+          >
+            Insert media
+          </button>
+          <button
+            type="button"
+            className="px-2 py-1 rounded border hover:bg-gray-50"
+            onClick={()=> onSave?.()}
+            title="Save (⌘/Ctrl+S)"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+      <textarea
         ref={ref}
-        className="w-full border rounded px-3 py-2 min-h-[320px]"
+        className="w-full border rounded px-3 py-2 min-h-[320px] focus-visible:ring-2"
         value={local}
         onChange={(e)=>{ setLocal(e.target.value); onChange(e.target.value); setStatus('dirty'); }}
         onKeyDown={handleKeyDown}
         onDrop={handleDrop}
         onDragOver={handleDragOver}
-       />
-       <MediaLibraryModal
-         open={mediaOpen}
-         onClose={()=> setMediaOpen(false)}
-         onSelect={onPickAsset}
-       />
-       {slashOpen ? (
-        <div className="mt-2 border rounded-xl shadow bg-white p-2 max-w-xs">
+      />
+      <MediaLibraryModal
+        open={mediaOpen}
+        onClose={()=> setMediaOpen(false)}
+        onSelect={onPickAsset}
+      />
+      {slashOpen ? (
+        <div className="mt-2 border rounded-xl shadow bg-white p-2 max-w-xs relative">
           <input
             autoFocus
             value={slashQuery}
@@ -230,17 +295,29 @@ import MediaLibraryModal from '@/components/MediaLibraryModal';
             className="w-full border rounded px-2 py-1 text-sm mb-2"
           />
           <ul className="max-h-56 overflow-auto">
-            {filterCommands(slashQuery).map((c)=>(
+            {filterCommands(slashQuery).map((c, i)=>(
               <li key={c.key}>
-                <button className="w-full text-left px-2 py-1 rounded hover:bg-gray-100 text-sm" onClick={()=>{ c.run(); setSlashOpen(false); }}>
+                <button
+                  className={`w-full text-left px-2 py-1 rounded text-sm ${i===slashIdx ? 'bg-gray-100' : 'hover:bg-gray-100'}`}
+                  onMouseEnter={()=> setSlashIdx(i)}
+                  onClick={()=>{ c.run(); setSlashOpen(false); }}
+                >
                   {c.label}
                 </button>
               </li>
             ))}
             {!filterCommands(slashQuery).length ? <li className="px-2 py-1 text-sm text-gray-500">No matches</li> : null}
           </ul>
+          <div className="absolute right-2 bottom-2 text-[10px] text-gray-500">Enter • Esc</div>
         </div>
-       ) : null}
-     </div>
-   );
- }
+      ) : null}
+    </div>
+  );
+}
+
+// Provide APIs to parent once ready
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+MarkdownEditor.defaultProps = {
+  exposeAPI: undefined
+};

--- a/frontend/components/Newsroom/RewriteChips.tsx
+++ b/frontend/components/Newsroom/RewriteChips.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+
+type Props = {
+  getSelection: () => { start: number; end: number; text: string };
+  replaceSelection: (next: string) => void;
+  getText: () => string;
+  setText: (t: string) => void;
+};
+
+export default function RewriteChips({ getSelection, replaceSelection, getText, setText }: Props) {
+  const [busy, setBusy] = useState<string | null>(null);
+  const [preview, setPreview] = useState<{ mode: string; text: string } | null>(null);
+
+  async function run(mode: string) {
+    const sel = getSelection();
+    const source = (sel.text && sel.text.trim()) || getText();
+    if (!source.trim()) return;
+    setBusy(mode);
+    try {
+      const r = await fetch('/api/newsroom/assistant/rewrite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: source, mode }),
+      });
+      const d = await r.json();
+      if (r.ok && d?.text) setPreview({ mode, text: d.text });
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  function applyReplace() {
+    if (!preview) return;
+    const sel = getSelection();
+    if (sel.text) replaceSelection(preview.text);
+    else setText(preview.text);
+    setPreview(null);
+  }
+
+  function applyAppend() {
+    if (!preview) return;
+    const t = getText();
+    setText(t ? `${t}\n\n${preview.text}` : preview.text);
+    setPreview(null);
+  }
+
+  const Chip = ({ mode, label }: { mode: string; label: string }) => (
+    <button
+      disabled={!!busy}
+      onClick={() => run(mode)}
+      className="px-2 py-1 text-xs rounded-full border hover:bg-gray-50 disabled:opacity-50"
+      title={`Rewrite: ${label}`}
+    >
+      {busy === mode ? '…' : label}
+    </button>
+  );
+
+  return (
+    <div className="mt-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs text-gray-500 mr-1">AI Assist:</span>
+        <Chip mode="concise" label="Tighten" />
+        <Chip mode="neutral" label="Neutral tone" />
+        <Chip mode="seo_headline" label="SEO headline" />
+        <Chip mode="summarize" label="Summarize" />
+      </div>
+      {preview ? (
+        <div className="mt-2 border rounded-xl p-2 bg-white shadow-sm">
+          <div className="text-[11px] text-gray-500 mb-1 uppercase tracking-wide">{preview.mode}</div>
+          <div className="text-sm whitespace-pre-wrap">{preview.text}</div>
+          <div className="mt-2 flex items-center gap-2">
+            <button className="px-2 py-1 text-xs rounded border" onClick={applyReplace}>Replace selection</button>
+            <button className="px-2 py-1 text-xs rounded border" onClick={applyAppend}>Append</button>
+            <button className="px-2 py-1 text-xs rounded border" onClick={()=>setPreview(null)}>Dismiss</button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/pages/api/newsroom/assistant/rewrite.js
+++ b/frontend/pages/api/newsroom/assistant/rewrite.js
@@ -1,0 +1,56 @@
+import { rateLimit } from '@/lib/rate-limit';
+
+const limiter = rateLimit({ interval: 60_000, uniqueTokenPerInterval: 500, maxInInterval: 20 });
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  try { await limiter.check(res, 20, req.headers['x-forwarded-for'] || 'unknown'); } catch { return res.status(429).json({ error: 'Slow down' }); }
+  const { text = '', mode = 'concise' } = req.body || {};
+  const src = String(text || '').trim();
+  if (!src) return res.status(400).json({ error: 'text required' });
+  let out = src;
+  if (mode === 'concise') {
+    out = concise(src);
+  } else if (mode === 'neutral') {
+    out = neutral(src);
+  } else if (mode === 'seo_headline') {
+    out = seoHeadline(src);
+  } else if (mode === 'summarize') {
+    out = summarize(src);
+  }
+  res.json({ text: out });
+}
+
+function concise(s) {
+  // Collapse whitespace, remove filler words, trim length
+  const stop = /\b(just|really|very|that|quite|actually|basically|literally|kind of|sort of|some|many)\b/gi;
+  let t = s.replace(/\s+/g, ' ').replace(stop, '').replace(/\s{2,}/g, ' ').trim();
+  if (t.length > 600) t = t.slice(0, 600).replace(/[,;:]?\s+\S*$/, '…');
+  return t;
+}
+function neutral(s) {
+  let t = s.replace(/[!]+/g, '.').replace(/\b(awful|terrible|amazing|incredible|disaster|catastrophe)\b/gi, (m)=> {
+    const map = { awful:'poor', terrible:'poor', amazing:'notable', incredible:'notable', disaster:'setback', catastrophe:'setback' };
+    return map[m.toLowerCase()] || m;
+  });
+  t = t.replace(/\b(always|never)\b/gi, (m)=> m.toLowerCase()==='always'?'often':'rarely');
+  return t;
+}
+function seoHeadline(s) {
+  // Take first clause, Title Case-ish, <= 60 chars
+  let t = s.split(/[.\n]/)[0].trim();
+  t = t.replace(/[:;,\-–—]+/g, ' ').replace(/\s{2,}/g, ' ');
+  const small = new Set(['a','an','the','and','or','but','for','nor','on','at','to','from','by','of','in','with']);
+  t = t.split(' ').map((w,i)=> {
+    const lw = w.toLowerCase();
+    if (i>0 && small.has(lw)) return lw;
+    return lw.charAt(0).toUpperCase()+lw.slice(1);
+  }).join(' ');
+  if (t.length > 60) t = t.slice(0, 57) + '…';
+  return t;
+}
+function summarize(s) {
+  // Naive one-sentence extractor
+  const m = s.match(/[^.!?]+[.!?]/);
+  return (m ? m[0] : s.split('\n')[0]).trim();
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -91,6 +91,11 @@ h1, h2, h3, h4, h5, h6 { scroll-margin-top: 72px; }
 }
 .btn-ghost:hover { background-color: rgba(0,0,0,0.04); }
 
+/* Chips */
+.chip {
+  @apply px-2 py-1 text-xs rounded-full border;
+}
+
 /* Print styles — cleaner pages for readers */
 @media print {
   /* basic colors on white background */


### PR DESCRIPTION
## Summary
- Enhance markdown editor slash menu with arrow-key navigation and new blocks
- Expose editor selection APIs for parent features
- Add rewrite chips and local rewrite API

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a7f24c7d0c8329986cd977a6e2b922