### PR TITLE
Refine newsroom sidebar UX with separate scroll and live updates

### DIFF
--- a/frontend/components/Newsroom/GlobalShell.tsx
+++ b/frontend/components/Newsroom/GlobalShell.tsx
@@ -67,10 +67,13 @@ export default function GlobalShell({ children }: { children: React.ReactNode })
   // Logged-in: persistent left sidebar across the site
   return (
     <ShellContext.Provider value={{ hasShell: true }}>
-      <div className="min-h-screen grid grid-cols-12">
-        {/* Sidebar (top→bottom; above footer; water/sky theme) */}
-        <aside className="col-span-12 lg:col-span-3 xl:col-span-2 border-r border-sky-200 text-slate-900 bg-gradient-to-b from-[#e8f4fd] to-[#f7fbff]">
-          <div className="p-4 space-y-4">
+      <div className="h-screen flex overflow-hidden">
+        {/* Sidebar with independent scroll and resizable width */}
+        <aside
+          className="flex-shrink-0 w-64 max-w-md min-w-[12rem] resize-x overflow-hidden border-r border-sky-200 text-slate-900 bg-gradient-to-b from-[#e8f4fd] to-[#f7fbff] flex flex-col"
+        >
+          {/* User bio at top (sticky) */}
+          <div className="p-4 space-y-4 shrink-0">
             <div className="text-xs uppercase tracking-widest text-sky-700">NewsRoom</div>
             <div className="flex items-center gap-3">
               {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -90,21 +93,33 @@ export default function GlobalShell({ children }: { children: React.ReactNode })
                 </div>
               </div>
             </div>
-            {/* Nav */}
-            <nav className="space-y-1">
-              <NavItem href="/newsroom/dashboard" label="Dashboard" active={active==='dashboard'} />
-              <NavItem href="/newsroom/notice-board" label="Notice Board" active={active==='notice'} badge={badges?.noticeUnread} />
-              <NavItem href="/newsroom" label="Publisher" active={active==='publisher'} badge={badges?.drafts || 0} />
-              <NavItem href="/newsroom/collab" label="Collaboration" active={active==='collab'} />
-              <NavItem href="/newsroom/media" label="Media" active={active==='media'} />
-              <NavItem href="/newsroom/assistant" label="AI Assistant" active={active==='assistant'} />
-              <NavItem href="/newsroom/profile" label="Profile & Settings" active={active==='profile'} />
-              <button onClick={()=>signOut({ callbackUrl: '/' })} className="w-full text-left px-3 py-2 rounded hover:bg-sky-100 text-red-700">Logout</button>
-            </nav>
           </div>
+          {/* Nav menu scrolls independently */}
+          <nav className="flex-1 overflow-y-auto px-4 space-y-1">
+            <NavItem href="/newsroom/dashboard" label="Dashboard" active={active==='dashboard'} />
+            <NavItem href="/newsroom/notice-board" label="Notice Board" active={active==='notice'} badge={badges?.noticeUnread} />
+            <NavGroup label="Publisher" items={[
+              { href: '/newsroom', label: 'Articles', badge: badges?.drafts },
+              { href: '/newsroom/drafts', label: 'Drafts' },
+            ]} />
+            <NavItem href="/newsroom/collab" label="Collaboration" active={active==='collab'} />
+            <NavItem href="/newsroom/media" label="Media" active={active==='media'} />
+            <NavItem href="/newsroom/assistant" label="AI Assistant" active={active==='assistant'} />
+            <NavItem href="/newsroom/profile" label="Profile & Settings" active={active==='profile'} />
+            <button
+              onClick={()=>signOut({ callbackUrl: '/' })}
+              className="w-full text-left px-3 py-2 rounded hover:bg-sky-100 text-red-700"
+            >
+              Logout
+            </button>
+          </nav>
+          {/* Live updates section */}
+          <LiveUpdates />
+          {/* Change log */}
+          <ChangeLog />
         </aside>
-        {/* Main content (Header + pages render inside) */}
-        <div className="col-span-12 lg:col-span-9 xl:col-span-10 min-h-screen flex flex-col">
+        {/* Main content has its own scroll */}
+        <div className="flex-1 overflow-y-auto flex flex-col">
           {children}
         </div>
       </div>
@@ -118,6 +133,76 @@ function NavItem({ href, label, active, badge }: { href: string; label: string; 
       <span>{label}</span>
       {badge ? <span className={`text-[11px] px-2 py-0.5 rounded-full ${active ? 'bg-white text-sky-800' : 'bg-sky-700 text-white'}`}>{badge}</span> : null}
     </Link>
+  );
+}
+
+function NavGroup({ label, items }: { label: string; items: { href: string; label: string; badge?: number }[] }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="w-full flex items-center justify-between px-3 py-2 rounded hover:bg-sky-100"
+      >
+        <span>{label}</span>
+        <span className="text-sm">{open ? '−' : '+'}</span>
+      </button>
+      {open && (
+        <div className="pl-4 space-y-1">
+          {items.map((item) => (
+            <div key={item.href}>
+              <NavItem href={item.href} label={item.label} badge={item.badge} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LiveUpdates() {
+  const [updates, setUpdates] = useState<string[]>([]);
+  useEffect(() => {
+    let mounted = true;
+    const fetchUpdates = async () => {
+      try {
+        const r = await fetch('/api/newsroom/live');
+        if (!mounted) return;
+        if (r.ok) {
+          const d = await r.json();
+          setUpdates(d?.updates || []);
+        }
+      } catch {/* ignore */}
+    };
+    fetchUpdates();
+    const id = setInterval(fetchUpdates, 10000);
+    return () => { mounted = false; clearInterval(id); };
+  }, []);
+  return (
+    <div className="border-t border-sky-200 p-3 max-h-32 overflow-y-auto text-xs">
+      <div className="font-semibold mb-1">Live Updates</div>
+      {updates.length === 0 ? (
+        <div className="text-slate-500">No updates</div>
+      ) : (
+        <ul className="space-y-1">
+          {updates.map((u, i) => (
+            <li key={i}>{u}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function ChangeLog() {
+  return (
+    <div className="border-t border-sky-200 p-3 text-[11px] text-slate-600">
+      <div className="font-semibold mb-1">Updates</div>
+      <ul className="space-y-1 list-disc list-inside">
+        <li>Sidebar now resizable</li>
+        <li>Menu supports sub-items</li>
+      </ul>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- make newsroom sidebar resizable and independently scrollable
- keep user bio pinned while menu scrolls and supports expandable groups
- add live updates feed and mini change log to sidebar bottom

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a873ad02408329bb941ffadb09ce97