### PR TITLE
WN-ProfilePhoto-01: finalize profile photo integration

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -5,6 +5,7 @@ import BreakingTicker from "@/components/BreakingTicker";
 import Link from "next/link";
 import BrandLogo from "./BrandLogo";
 import { useEffect, useState } from "react";
+import ProfilePhoto from "@/components/User/ProfilePhoto";
 
 export default function Header() {
   const [me, setMe] = useState<any>(null);
@@ -35,6 +36,18 @@ export default function Header() {
         <div className="flex items-center gap-2">
           <SearchBox />
           <NotificationsBellMenu />
+          {me && (
+            <Link href="/account" className="inline-flex items-center">
+              <ProfilePhoto
+                name={me.displayName || me.name}
+                url={me.profilePhotoUrl}
+                isVerified={me.verified?.status === true}
+                isOrganization={me.isOrganization === true}
+                size={32}
+                className="shrink-0"
+              />
+            </Link>
+          )}
         </div>
       </div>
       {/* Bottom row: ticker inside header so it always sticks */}

--- a/frontend/components/Newsroom/GlobalShell.tsx
+++ b/frontend/components/Newsroom/GlobalShell.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { ShellContext } from './ShellContext';
 import { signOut } from 'next-auth/react';
+import ProfilePhoto from '@/components/User/ProfilePhoto';
 
 // Global shell that shows the NewsRoom sidebar for LOGGED-IN users on every page.
 // Sidebar uses a water/sky tint; bio is data-only; nav mirrors NewsRoom sections.
@@ -76,11 +77,13 @@ export default function GlobalShell({ children }: { children: React.ReactNode })
           <div className="p-4 space-y-4 shrink-0">
             <div className="text-xs uppercase tracking-widest text-sky-700">NewsRoom</div>
             <div className="flex items-center gap-3">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={summary?.avatarUrl || summary?.image || '/apple-touch-icon.png'}
-                alt=""
-                className="w-12 h-12 rounded-full object-cover border border-sky-200"
+              <ProfilePhoto
+                name={summary?.displayName || summary?.name || 'Your Name'}
+                url={summary?.profilePhotoUrl || summary?.image || '/apple-touch-icon.png'}
+                isVerified={summary?.verified?.status === true}
+                isOrganization={summary?.isOrganization === true}
+                size={48}
+                className="border border-sky-200"
               />
               <div className="min-w-0">
                 <div className="font-medium truncate">{summary?.displayName || summary?.name || 'Your Name'}</div>

--- a/frontend/pages/about/masthead.jsx
+++ b/frontend/pages/about/masthead.jsx
@@ -2,6 +2,7 @@ import Head from "next/head";
 import Image from "next/image";
 import Link from "next/link";
 import Script from "next/script";
+import ProfilePhoto from "@/components/User/ProfilePhoto";
 
 const contacts = [
   {
@@ -138,12 +139,12 @@ export default function MastheadPage() {
             {people.map((p) => (
               <article key={p.name} className="rounded-2xl bg-white p-5 shadow">
                 <div className="grid min-h-[120px] place-items-center rounded-md border border-slate-200 bg-gradient-to-br from-[#e8f4fd] to-[#f7fbff]">
-                  <Image
-                    src={p.headshot || "/placeholders/headshot.svg"}
-                    alt={p.name}
-                    width={160}
-                    height={160}
-                    className="rounded-md object-cover"
+                  <ProfilePhoto
+                    name={p.name}
+                    url={p.headshot}
+                    isVerified={false}
+                    isOrganization={false}
+                    size={160}
                   />
                 </div>
                 <h3 className="mt-3 text-base font-semibold">{p.name}</h3>


### PR DESCRIPTION
## Summary
- render profile photos in header with verified ring and org support
- show profile photos on masthead cards
- replace leftover avatar usages in Newsroom shell

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8764d170c832991a501006039fd80