### PR TITLE
refactor: simplify newsroom layout

### DIFF
--- a/frontend/components/Newsroom/NewsroomLayout.tsx
+++ b/frontend/components/Newsroom/NewsroomLayout.tsx
@@ -1,8 +1,21 @@
-// Layout shim: with the GlobalShell active site-wide, this component becomes a simple wrapper that
-// renders its children inside the main column. Keeps signatures stable for newsroom pages.
-import { useShell } from './ShellContext';
+import React from "react";
 
-export default function NewsroomLayout({ children }: { active?: string; children: React.ReactNode }) {
-  const shell = useShell();
-  return shell?.hasShell ? <div className="p-6">{children}</div> : <div className="max-w-5xl mx-auto p-6">{children}</div>;
+type Props = {
+  title?: string;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+};
+
+// Minimal, shell-agnostic layout for Newsroom pages.
+// GlobalShell now owns all sidebar/topbar logic across the app.
+export default function NewsroomLayout({ title = "Newsroom", actions, children }: Props) {
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-6">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-semibold">{title}</h1>
+        <div>{actions}</div>
+      </div>
+      {children}
+    </div>
+  );
 }

--- a/frontend/pages/newsroom/assistant.tsx
+++ b/frontend/pages/newsroom/assistant.tsx
@@ -18,8 +18,7 @@ export default function AssistantHub() {
     } finally { setBusy(false); }
   }
   return (
-    <NewsroomLayout active="assistant">
-      <h1 className="text-2xl font-semibold mb-4">AI Assistant</h1>
+    <NewsroomLayout title="AI Assistant">
       <p className="text-sm text-gray-600 mb-3">Paste a draft. We’ll surface related context (site + web), angle suggestions, links, and outline tweaks.</p>
       <textarea className="w-full border rounded p-3 min-h-[200px]" placeholder="Paste your draft or notes…" value={input} onChange={e=>setInput(e.target.value)} />
       <div className="mt-2"><button disabled={!input.trim() || busy} onClick={run} className="px-3 py-2 rounded bg-black text-white text-sm disabled:opacity-50">{busy? 'Thinking…' : 'Get suggestions'}</button></div>


### PR DESCRIPTION
## Summary
- refactor NewsroomLayout to remove shell-specific logic and accept optional title/actions
- update assistant hub to use new layout API

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a8b4a6bd348329b97236ccde8ed0fe