### PR TITLE
Replace logos and refresh About page imagery

### DIFF
--- a/frontend/components/BrandLogo.tsx
+++ b/frontend/components/BrandLogo.tsx
@@ -1,8 +1,12 @@
 import React from "react";
+import { withCloudinaryAuto } from "@/lib/media";
+
 export default function BrandLogo({ size = 28, className = "", title = "WaterNews" }) {
   return (
     <img
-      src="/logo-mini.svg"
+      src={withCloudinaryAuto(
+        "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755962658/logo-mini_uhsj21.png"
+      )}
       alt={title}
       width={size}
       height={size}

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -1,6 +1,7 @@
 // Add FAQ link to footer nav
 import Link from "next/link";
 import Image from "next/image";
+import { withCloudinaryAuto } from "@/lib/media";
 
 export default function Footer() {
   return (
@@ -8,7 +9,15 @@ export default function Footer() {
       <div className="mx-auto max-w-7xl px-4 py-10">
         <div className="flex flex-col items-center justify-center gap-6 text-center">
           <Link href="/" aria-label="WaterNews — Home" className="inline-flex items-center gap-2">
-            <Image src="/logo-mini.svg" alt="WaterNews mini logo" width={32} height={32} className="h-8 w-8" />
+            <Image
+              src={withCloudinaryAuto(
+                "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755962658/logo-mini_uhsj21.png"
+              )}
+              alt="WaterNews mini logo"
+              width={32}
+              height={32}
+              className="h-8 w-8"
+            />
             <span className="sr-only">WaterNews</span>
           </Link>
           <nav className="flex flex-wrap items-center justify-center gap-4">

--- a/frontend/components/Icon.jsx
+++ b/frontend/components/Icon.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { withCloudinaryAuto } from "@/lib/media";
 
 // Per-glyph viewBox so our logo (SVG file) renders crisply.
 const GLYPHS = {
@@ -61,11 +62,22 @@ const GLYPHS = {
   // NEW: brand mini logo as an Icon glyph.
   // We reference the real SVG file to preserve exact curves/colors and keep the bundle small.
   // It renders inside the same <svg>, so you can size/color it like other icons if desired.
-  logo: { viewBox: "0 0 24 24", node: (
-    // Note: we use an <image> tag to bring the vector file in at icon size.
-    // If you prefer fully-inlined paths, keep using <BrandLogo/> (img) or ask me to inline the paths next.
-    <image href="/logo-mini.svg" x="0" y="0" width="24" height="24" />
-  )},
+  logo: {
+    viewBox: "0 0 24 24",
+    node: (
+      // Note: we use an <image> tag to bring the vector file in at icon size.
+      // If you prefer fully-inlined paths, keep using <BrandLogo/> (img) or ask me to inline the paths next.
+      <image
+        href={withCloudinaryAuto(
+          "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755835806/WM_mini_logo_SVg_-_Black_ofk65a.svg"
+        )}
+        x="0"
+        y="0"
+        width="24"
+        height="24"
+      />
+    ),
+  },
 };
 
 export default function Icon({ name, size = 24, className = "" }) {

--- a/frontend/lib/seo.ts
+++ b/frontend/lib/seo.ts
@@ -1,6 +1,8 @@
 // Minimal, framework-agnostic JSON-LD builders for WaterNews
 // Keep objects small, avoid undefineds, and emit a single script per page.
 
+import { withCloudinaryAuto } from "@/lib/media";
+
 type Publisher = {
   name: string;
   logoUrl: string;
@@ -11,7 +13,9 @@ export function getPublisher(origin: string): Publisher {
   const site = origin || "https://www.waternewsgy.com";
   return {
     name: "WaterNewsGY",
-    logoUrl: `${site}/logo-waternews.svg`,
+    logoUrl: withCloudinaryAuto(
+      "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755961127/WN_Logo_Full_JPG_s1tkic_0238af.png"
+    ),
     url: site,
   };
 }

--- a/frontend/pages/about/index.jsx
+++ b/frontend/pages/about/index.jsx
@@ -15,7 +15,7 @@ const CTO = {
   name: "Dwuane Adams",
   title: "Chief Technology Officer",
   photo: withCloudinaryAuto(
-    "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755883745/file_0000000084bc61fb9c2f1f0e1c239ffa_shstq4.png"
+    "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755961624/file_0000000084bc61fb9c2f1f0e1c239ffa_shstq4.png"
   ),
   bio: `Jamaican-born to Guyanese parents, Dwuane pairs a love of the outdoors—buggy trails, boulders, and big horizons—with deep focus on scalable systems. A computer science geek and serial entrepreneur by career, he leads WaterNews technology with a builder’s grit: fast, safe, and reliable.`,
 };
@@ -32,6 +32,13 @@ const COMMUNITY_PHOTOS = [
     "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755882180/file_00000000b20461fdbf3edcda97f1c2ab_1_e7igtj.png"
   ),
 ];
+
+const MINI_LOGO = withCloudinaryAuto(
+  "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755962658/logo-mini_uhsj21.png"
+);
+const FULL_LOGO = withCloudinaryAuto(
+  "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755961127/WN_Logo_Full_JPG_s1tkic_0238af.png"
+);
 
 export default function AboutPage() {
   return (
@@ -50,12 +57,8 @@ export default function AboutPage() {
         style={{ backgroundImage: "linear-gradient(to bottom, #0f6cad, #0b5d95, #0a4f7f)" }}
       >
         <div className="mb-4 flex items-center justify-center gap-4">
-          <Image
-            src=
-            withCloudinaryAuto(
-            "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755882180/file_00000000b20461fdbf3edcda97f1c2ab_1_e7igtj.png"
-            ),
-          />
+          <Image src={MINI_LOGO} alt="WaterNews mini logo" width={48} height={48} />
+          <Image src={FULL_LOGO} alt="WaterNews logo" width={220} height={60} />
         </div>
         <h1 className="m-0 text-3xl font-extrabold leading-tight md:text-5xl">
           About WaterNews
@@ -132,7 +135,7 @@ export default function AboutPage() {
         {/* Our Story */}
         <section className="mb-10">
           <div className="mb-2 flex items-center gap-3">
-            <Image src="/logo-mini.svg" alt="" width={28} height={28} />
+            <Image src={MINI_LOGO} alt="" width={28} height={28} />
             <div>
               <h3 className="m-0 text-xl font-bold">Our Story</h3>
               <p className="m-0 text-sm text-slate-600">
@@ -154,7 +157,7 @@ export default function AboutPage() {
         {/* What We Publish */}
         <section className="mb-10">
           <div className="mb-3 flex items-center gap-3">
-            <Image src="/logo-mini.svg" alt="" width={28} height={28} />
+            <Image src={MINI_LOGO} alt="" width={28} height={28} />
             <div>
               <h3 className="m-0 text-xl font-bold">What We Publish</h3>
               <p className="m-0 text-sm text-slate-600">
@@ -193,7 +196,7 @@ export default function AboutPage() {
         {/* Values */}
         <section className="mb-10">
           <div className="mb-3 flex items-center gap-3">
-            <Image src="/logo-mini.svg" alt="" width={28} height={28} />
+            <Image src={MINI_LOGO} alt="" width={28} height={28} />
             <div>
               <h3 className="m-0 text-xl font-bold">Our Values</h3>
               <p className="m-0 text-sm text-slate-600">
@@ -228,7 +231,7 @@ export default function AboutPage() {
         {/* Leadership */}
         <section id="team" className="mb-10 rounded-2xl bg-white p-6 shadow">
           <div className="mb-3 flex items-center gap-3">
-            <Image src="/logo-mini.svg" alt="" width={28} height={28} />
+            <Image src={MINI_LOGO} alt="" width={28} height={28} />
             <h3 className="m-0 text-xl font-bold">Leadership</h3>
           </div>
 
@@ -289,7 +292,7 @@ export default function AboutPage() {
         {/* Editorial Standards & Fact-Check Policy */}
         <section className="mb-10 rounded-2xl bg-white p-6 shadow">
           <div className="mb-3 flex items-center gap-3">
-            <Image src="/logo-mini.svg" alt="" width={28} height={28} />
+            <Image src={MINI_LOGO} alt="" width={28} height={28} />
             <h3 className="m-0 text-xl font-bold">Editorial Standards &amp; Fact-Check Policy</h3>
           </div>
 
@@ -385,7 +388,7 @@ export default function AboutPage() {
 
       <footer className="px-4 pb-16 text-center text-slate-500">
         <Image
-          src="/logo-mini.svg"
+          src={MINI_LOGO}
           alt="WaterNews mini logo"
           width={36}
           height={36}

--- a/frontend/pages/about/masthead.jsx
+++ b/frontend/pages/about/masthead.jsx
@@ -77,7 +77,9 @@ export default function MastheadPage() {
             "@type": "NewsMediaOrganization",
             name: "WaterNews",
             url: "https://waternews.onrender.com",
-            logo: "https://waternews.onrender.com/logo-waternews.svg",
+            logo: withCloudinaryAuto(
+              "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755961127/WN_Logo_Full_JPG_s1tkic_0238af.png"
+            ),
             slogan: "Dive Into Current Stories",
             foundingLocation: "Georgetown, Guyana",
             contactPoint: [
@@ -100,7 +102,15 @@ export default function MastheadPage() {
       <header className="bg-gradient-to-b from-[#0f6cad] via-[#0b5d95] to-[#0a4f7f] px-4 py-14 text-white">
         <div className="mx-auto max-w-5xl">
           <div className="mb-5 flex items-center gap-3">
-            <Image src="/logo-mini.svg" alt="mini" width={40} height={40} className="rounded-full bg-white/95 p-1" />
+            <Image
+              src={withCloudinaryAuto(
+                "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755962658/logo-mini_uhsj21.png"
+              )}
+              alt="mini"
+              width={40}
+              height={40}
+              className="rounded-full bg-white/95 p-1"
+            />
             <h1 className="m-0 text-3xl font-extrabold leading-tight md:text-5xl">
               Masthead &amp; Contacts
             </h1>
@@ -134,7 +144,14 @@ export default function MastheadPage() {
         {/* Masthead */}
         <section className="mb-10">
           <div className="mb-3 flex items-center gap-3">
-            <Image src="/logo-mini.svg" alt="" width={28} height={28} />
+            <Image
+              src={withCloudinaryAuto(
+                "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755962658/logo-mini_uhsj21.png"
+              )}
+              alt=""
+              width={28}
+              height={28}
+            />
             <h2 className="m-0 text-xl font-bold">Editorial Team</h2>
           </div>
 
@@ -190,7 +207,9 @@ export default function MastheadPage() {
 
       <footer className="px-4 pb-16 text-center text-slate-500">
         <Image
-          src="/logo-mini.svg"
+          src={withCloudinaryAuto(
+            "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755962658/logo-mini_uhsj21.png"
+          )}
           alt="WaterNews mini logo"
           width={36}
           height={36}

--- a/frontend/pages/apply.jsx
+++ b/frontend/pages/apply.jsx
@@ -1,5 +1,6 @@
 import Head from "next/head";
 import Image from "next/image";
+import { withCloudinaryAuto } from "@/lib/media";
 import { useState } from "react";
 import { SUBJECTS } from "@/lib/cms-routing";
 import Toast from "@/components/Toast";
@@ -48,7 +49,9 @@ export default function ApplyPage() {
         <div className="mx-auto max-w-5xl">
           <div className="mb-5 flex items-center gap-3">
             <Image
-              src="/logo-waternews.svg"
+              src={withCloudinaryAuto(
+                "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755961127/WN_Logo_Full_JPG_s1tkic_0238af.png"
+              )}
               alt="WaterNews"
               width={220}
               height={60}

--- a/frontend/pages/corrections.jsx
+++ b/frontend/pages/corrections.jsx
@@ -1,5 +1,6 @@
 import Head from "next/head";
 import Image from "next/image";
+import { withCloudinaryAuto } from "@/lib/media";
 import { useState } from "react";
 import { SUBJECTS } from "@/lib/cms-routing";
 import Toast from "@/components/Toast";
@@ -42,7 +43,9 @@ export default function CorrectionsPage() {
         <div className="mx-auto max-w-5xl">
           <div className="mb-5 flex items-center gap-3">
             <Image
-              src="/logo-waternews.svg"
+              src={withCloudinaryAuto(
+                "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755961127/WN_Logo_Full_JPG_s1tkic_0238af.png"
+              )}
               alt="WaterNews"
               width={220}
               height={60}


### PR DESCRIPTION
## Summary
- Serve mini and full logos from Cloudinary across components and pages
- Refresh About page hero, mission image, and Dwuane Adams headshot
- Update SEO metadata and masthead schema to reference new logos

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9ca0a3f9c832991e0de2c37d6f5a3