### PR TITLE
fix: unify mongoose connection handling

### DIFF
--- a/frontend/lib/mongodb.ts
+++ b/frontend/lib/mongodb.ts
@@ -11,9 +11,11 @@ if (!cached) cached = (global as any)._mongoose = { conn: null, promise: null }
 export async function dbConnect() {
   if (cached.conn) return cached.conn
   if (!cached.promise) {
-    // Cast options as any to avoid ConnectOptions type dependency
     cached.promise = mongoose
-      .connect(MONGODB_URI, { bufferCommands: false } as any)
+      .connect(
+        MONGODB_URI,
+        { dbName: process.env.MONGODB_DB || 'patwua' } as any
+      )
       .then((m) => m)
   }
   cached.conn = await cached.promise

--- a/frontend/lib/server/db.ts
+++ b/frontend/lib/server/db.ts
@@ -1,23 +1,3 @@
-import mongoose from "mongoose";
+export { dbConnect } from '../mongodb';
 
-const MONGODB_URI = process.env.MONGODB_URI || process.env.MONGO_URL || "";
 
-if (!MONGODB_URI) {
-  // Non-fatal log; API routes will throw if called.
-  console.warn("⚠️  MONGODB_URI is not set");
-}
-
-let cached = (global as any).db || { conn: null, promise: null };
-
-export async function dbConnect() {
-  if (cached.conn) return cached.conn;
-  if (!cached.promise) {
-    // Loosen option typing to keep typecheck green without Mongoose types
-    cached.promise = mongoose
-      .connect(MONGODB_URI, { dbName: process.env.MONGODB_DB || "patwua" } as any)
-      .then((m) => m);
-  }
-  cached.conn = await cached.promise;
-  (global as any).db = cached;
-  return cached.conn;
-}


### PR DESCRIPTION
## Summary
- use single Mongoose connection helper and drop `bufferCommands: false`
- re-export shared DB connector for server code

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aa09e00c1c8329879ce004a404cc63