### PR TITLE
Refresh secondary pages to match About style

### DIFF
--- a/frontend/pages/faq.tsx
+++ b/frontend/pages/faq.tsx
@@ -1,25 +1,68 @@
 import Head from 'next/head';
+import Link from 'next/link';
 
-export default function FAQ(){
+export default function FAQ() {
   return (
-    <div className="max-w-3xl mx-auto p-6">
-      <Head><title>FAQ • WaterNews</title></Head>
-      <h1 className="text-3xl font-semibold mb-4">Frequently Asked Questions</h1>
-      <p className="text-gray-600 mb-6">Answers for readers and visitors. For member help, see the NewsRoom dashboard.</p>
-      <div className="space-y-6">
-        <section>
-          <h2 className="font-medium mb-1">How do I submit a story tip?</h2>
-          <p>Use the <a className="text-blue-600 underline" href="/suggest-story">Suggest a Story</a> page.</p>
-        </section>
-        <section>
-          <h2 className="font-medium mb-1">How do I contact the newsroom?</h2>
-          <p>Visit <a className="text-blue-600 underline" href="/contact">Contact</a> for email and forms.</p>
-        </section>
-        <section>
-          <h2 className="font-medium mb-1">Corrections policy?</h2>
-          <p>See <a className="text-blue-600 underline" href="/corrections">Corrections</a> and our <a className="text-blue-600 underline" href="/editorial-standards">Editorial Standards</a>.</p>
-        </section>
-      </div>
-    </div>
+    <>
+      <Head>
+        <title>FAQ — WaterNews</title>
+        <meta
+          name="description"
+          content="Answers for readers and visitors."
+        />
+      </Head>
+
+      <header className="bg-gradient-to-b from-[#0f6cad] via-[#0b5d95] to-[#0a4f7f] px-4 py-14 text-white">
+        <div className="mx-auto max-w-5xl">
+          <h1 className="m-0 text-3xl font-extrabold leading-tight md:text-5xl">
+            FAQ
+          </h1>
+          <p className="max-w-3xl text-sm opacity-95 md:text-base">
+            Answers for readers and visitors. For member help, see the NewsRoom dashboard.
+          </p>
+        </div>
+      </header>
+
+      <main className="mx-auto my-10 max-w-5xl px-4">
+        <article className="rounded-2xl bg-white p-6 shadow">
+          <div className="space-y-6">
+            <section>
+              <h2 className="font-medium">How do I submit a story tip?</h2>
+              <p>
+                Use the{' '}
+                <Link className="font-semibold text-[#1583c2]" href="/suggest-story">
+                  Suggest a Story
+                </Link>{' '}
+                page.
+              </p>
+            </section>
+            <section>
+              <h2 className="font-medium">How do I contact the newsroom?</h2>
+              <p>
+                Visit{' '}
+                <Link className="font-semibold text-[#1583c2]" href="/contact">
+                  Contact
+                </Link>{' '}
+                for email and forms.
+              </p>
+            </section>
+            <section>
+              <h2 className="font-medium">Corrections policy?</h2>
+              <p>
+                See{' '}
+                <Link className="font-semibold text-[#1583c2]" href="/corrections">
+                  Corrections
+                </Link>{' '}
+                and our{' '}
+                <Link className="font-semibold text-[#1583c2]" href="/editorial-standards">
+                  Editorial Standards
+                </Link>
+                .
+              </p>
+            </section>
+          </div>
+        </article>
+      </main>
+    </>
   );
 }

--- a/frontend/pages/newsroom/index.tsx
+++ b/frontend/pages/newsroom/index.tsx
@@ -7,6 +7,7 @@ export default function Publisher() {
   const [drafts, setDrafts] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [creating, setCreating] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
 
   useEffect(() => {
     let mounted = true;
@@ -41,6 +42,20 @@ export default function Publisher() {
     }
   }
 
+  async function onDelete(id: string) {
+    if (deleting) return;
+    if (!confirm("Delete this draft?")) return;
+    setDeleting(id);
+    try {
+      const r = await fetch(`/api/newsroom/drafts/${id}/delete`, { method: "POST" });
+      const json = await r.json();
+      if (!r.ok || !json?.ok) throw new Error("Failed to delete");
+      setDrafts((ds) => ds.filter((d) => d._id !== id));
+    } finally {
+      setDeleting(null);
+    }
+  }
+
   return (
     <Page
       title="Publisher"
@@ -49,7 +64,7 @@ export default function Publisher() {
         <button
           onClick={onNewDraft}
           disabled={creating}
-          className="px-4 py-2 rounded-md bg-black text-white hover:bg-gray-900 disabled:opacity-50"
+          className="rounded-xl bg-[#1583c2] px-4 py-2 font-semibold text-white hover:brightness-110 disabled:opacity-60"
         >
           {creating ? "Creating…" : "New draft"}
         </button>
@@ -69,9 +84,19 @@ export default function Publisher() {
                   <div className="text-xs text-gray-500">{d.status || "draft"}</div>
                 </div>
                 <div className="shrink-0 flex items-center gap-3">
-                  <Link href={`/newsroom/drafts/${d._id}`} className="text-sm text-blue-600 hover:underline">
+                  <Link
+                    href={`/newsroom/drafts/${d._id}`}
+                    className="text-sm font-semibold text-[#1583c2] hover:underline"
+                  >
                     Open
                   </Link>
+                  <button
+                    onClick={() => onDelete(d._id)}
+                    disabled={deleting === d._id}
+                    className="text-sm text-red-600 hover:underline disabled:opacity-50"
+                  >
+                    Delete
+                  </button>
                 </div>
               </li>
             ))}

--- a/frontend/pages/privacy.tsx
+++ b/frontend/pages/privacy.tsx
@@ -1,11 +1,35 @@
+import Head from "next/head";
+
 export default function Privacy() {
   return (
-    <div className="max-w-3xl mx-auto px-4 py-10 space-y-4">
-      <h1 className="text-3xl font-bold">Privacy Policy</h1>
-      <p className="text-gray-700">
-        We value your privacy. We use local storage for the Follow feature and do not track
-        personal data unless you explicitly provide it (e.g., via Suggest a Story). Full policy coming soon.
-      </p>
-    </div>
-  )
+    <>
+      <Head>
+        <title>Privacy Policy — WaterNews</title>
+        <meta
+          name="description"
+          content="Our commitment to protecting your data."
+        />
+      </Head>
+
+      <header className="bg-gradient-to-b from-[#0f6cad] via-[#0b5d95] to-[#0a4f7f] px-4 py-14 text-white">
+        <div className="mx-auto max-w-5xl">
+          <h1 className="m-0 text-3xl font-extrabold leading-tight md:text-5xl">
+            Privacy Policy
+          </h1>
+          <p className="max-w-3xl text-sm opacity-95 md:text-base">
+            How we handle your data and respect your privacy.
+          </p>
+        </div>
+      </header>
+
+      <main className="mx-auto my-10 max-w-5xl px-4">
+        <article className="rounded-2xl bg-white p-6 shadow text-[15px] text-slate-700">
+          <p>
+            We value your privacy. We use local storage for the Follow feature and do not track personal data unless you
+            explicitly provide it (e.g., via Suggest a Story). Full policy coming soon.
+          </p>
+        </article>
+      </main>
+    </>
+  );
 }

--- a/frontend/pages/profile.tsx
+++ b/frontend/pages/profile.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState, type FormEvent } from 'react'
 import { useSession } from 'next-auth/react'
 import Link from 'next/link'
+import Head from 'next/head'
 
 export default function Profile() {
   const { data: session, status } = useSession()
   const [name, setName] = useState('')
   const [bio, setBio] = useState('')
-  const [msg, setMsg] = useState('')
+  const [saved, setSaved] = useState(false)
 
   useEffect(() => {
     const load = async () => {
@@ -23,48 +24,115 @@ export default function Profile() {
 
   const save = async (e: FormEvent) => {
     e.preventDefault()
-    setMsg('')
+    setSaved(false)
     const res = await fetch('/api/users/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, bio })
     })
-    if (res.ok) setMsg('Saved ✓')
+    if (res.ok) {
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2500)
+    }
   }
 
   if (status === 'loading') return <div className="p-6 text-gray-500">Loading…</div>
-  if (!session?.user) return (
-    <div className="p-6">
-      <p className="text-gray-700">Please <Link href="/login" className="text-blue-700 underline">sign in</Link> to view your profile.</p>
-    </div>
-  )
+  if (!session?.user)
+    return (
+      <div className="p-6">
+        <p className="text-gray-700">
+          Please{' '}
+          <Link href="/login" className="font-semibold text-[#1583c2]">
+            sign in
+          </Link>{' '}
+          to view your profile.
+        </p>
+      </div>
+    )
 
   return (
-    <div className="max-w-3xl mx-auto px-4 py-10 space-y-6">
-      <h1 className="text-3xl font-bold">Author Profile</h1>
-      <form onSubmit={save} className="space-y-3">
-        <input className="w-full border rounded px-3 py-2" placeholder="Your display name" value={name} onChange={e=>setName(e.target.value)} />
-        <textarea className="w-full border rounded px-3 py-2 h-32" placeholder="Short bio (shown under your articles)" value={bio} onChange={e=>setBio(e.target.value)} />
-        <button className="px-4 py-2 bg-blue-600 text-white rounded">Save</button>
-        {msg && <span className="text-green-700 text-sm ml-3">{msg}</span>}
-      </form>
-      {/* Writer tools */}
-      <section className="mt-6">
-        <h2 className="text-lg font-medium mb-3">Writer tools</h2>
-        <div className="grid sm:grid-cols-2 gap-4">
-          <Link href="/newsroom" className="block border rounded-xl p-4 hover:shadow">
-            <div className="font-medium">Newsroom</div>
-            <div className="text-sm text-gray-600">Create drafts, edit, and schedule posts</div>
-          </Link>
-          <Link href="/newsroom/posts" className="block border rounded-xl p-4 hover:shadow">
-            <div className="font-medium">My drafts</div>
-            <div className="text-sm text-gray-600">View your published posts</div>
+    <>
+      <Head>
+        <title>Your Profile — WaterNews</title>
+      </Head>
+
+      <header className="bg-gradient-to-b from-[#0f6cad] via-[#0b5d95] to-[#0a4f7f] px-4 py-14 text-white">
+        <div className="mx-auto max-w-5xl">
+          <h1 className="m-0 text-3xl font-extrabold leading-tight md:text-5xl">
+            Author Profile
+          </h1>
+          <p className="max-w-3xl text-sm opacity-95 md:text-base">
+            Update your display name and bio shown on articles.
+          </p>
+        </div>
+      </header>
+
+      <main className="mx-auto my-10 max-w-5xl px-4 space-y-8">
+        <section className="rounded-2xl bg-white p-6 shadow">
+          <form onSubmit={save} className="grid gap-3">
+            <label className="block">
+              <span className="text-sm font-medium">Display name</span>
+              <input
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                placeholder="Your display name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </label>
+            <label className="block">
+              <span className="text-sm font-medium">Bio</span>
+              <textarea
+                className="mt-1 h-32 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                placeholder="Short bio (shown under your articles)"
+                value={bio}
+                onChange={(e) => setBio(e.target.value)}
+              />
+            </label>
+            <div className="flex items-center gap-3">
+              <button
+                className="rounded-xl bg-[#1583c2] px-4 py-2 font-semibold text-white hover:brightness-110"
+              >
+                Save changes
+              </button>
+              {saved && (
+                <span className="rounded-full bg-green-100 px-3 py-1 text-xs font-semibold text-green-700">
+                  Saved
+                </span>
+              )}
+            </div>
+          </form>
+        </section>
+
+        <section className="rounded-2xl bg-white p-6 shadow">
+          <h2 className="mb-3 text-lg font-bold">Writer tools</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Link
+              href="/newsroom"
+              className="rounded-xl border border-slate-200 p-4 hover:shadow-md"
+            >
+              <div className="font-medium">Newsroom</div>
+              <div className="text-sm text-slate-600">
+                Create drafts, edit, and schedule posts
+              </div>
+            </Link>
+            <Link
+              href="/newsroom/posts"
+              className="rounded-xl border border-slate-200 p-4 hover:shadow-md"
+            >
+              <div className="font-medium">My drafts</div>
+              <div className="text-sm text-slate-600">
+                View your published posts
+              </div>
+            </Link>
+          </div>
+        </section>
+
+        <div>
+          <Link href="/" className="font-semibold text-[#1583c2]">
+            ← Back to Home
           </Link>
         </div>
-      </section>
-      <div>
-        <Link href="/" className="text-blue-700 underline">← Back to Home</Link>
-      </div>
-    </div>
+      </main>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- Restyle FAQ and Privacy pages with gradient hero, card layout and consistent link CTAs
- Update profile page with new layout and show a temporary green "Saved" pill on save
- Allow deleting drafts inline from Publisher and align buttons with site styling

## Testing
- `npm test --prefix frontend`
- `npm run typecheck --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68aa7ef949a083298cfe37dbf4b41807