### PR TITLE
Rev.4 UX — Patch Z-3 (Notice board, collab, dashboard KPIs)

### DIFF
--- a/frontend/components/UX/KPI.tsx
+++ b/frontend/components/UX/KPI.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import Sparkline from "./Sparkline";
+
+export default function KPI({
+  title,
+  value,
+  delta,
+  data,
+}: {
+  title: string;
+  value: string | number;
+  delta?: number; // percentage (can be negative)
+  data?: number[]; // for sparkline
+}) {
+  const up = typeof delta === "number" && delta > 0;
+  const down = typeof delta === "number" && delta < 0;
+  return (
+    <div className="rounded-2xl ring-1 ring-gray-200 p-4 bg-white">
+      <div className="text-xs text-gray-500">{title}</div>
+      <div className="mt-1 flex items-baseline gap-2">
+        <div className="text-2xl font-semibold">{value}</div>
+        {typeof delta === "number" && (
+          <div
+            className={`text-xs font-medium ${
+              up ? "text-green-700" : down ? "text-red-700" : "text-gray-600"
+            }`}
+          >
+            {up ? "▲" : down ? "▼" : "•"} {Math.abs(delta)}%
+          </div>
+        )}
+      </div>
+      {Array.isArray(data) && data.length > 0 && (
+        <div className="mt-2 text-gray-400">
+          <Sparkline data={data} />
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/components/UX/Sparkline.tsx
+++ b/frontend/components/UX/Sparkline.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+export default function Sparkline({
+  data,
+  width = 120,
+  height = 36,
+  strokeWidth = 2,
+  className = "",
+}: {
+  data: number[];
+  width?: number;
+  height?: number;
+  strokeWidth?: number;
+  className?: string;
+}) {
+  const safe = Array.isArray(data) && data.length > 0 ? data : [0];
+  const min = Math.min(...safe);
+  const max = Math.max(...safe);
+  const range = max - min || 1;
+  const stepX = width / Math.max(1, safe.length - 1);
+  const pts = safe
+    .map((v, i) => {
+      const x = i * stepX;
+      const norm = (v - min) / range;
+      const y = height - norm * height;
+      return `${x},${y}`;
+    })
+    .join(" ");
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={className}
+      aria-hidden="true"
+    >
+      <polyline
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        points={pts}
+      />
+    </svg>
+  );
+}
+

--- a/frontend/pages/newsroom/collab.tsx
+++ b/frontend/pages/newsroom/collab.tsx
@@ -1,38 +1,158 @@
-import NewsroomLayout from '@/components/Newsroom/NewsroomLayout';
-import type { GetServerSideProps } from 'next';
-import { requireAuthSSR } from '@/lib/user-guard';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from "react";
+import Page from "@/components/UX/Page";
+import SectionCard from "@/components/UX/SectionCard";
+import Callout from "@/components/UX/Callout";
 
-export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx as any);
+type Draft = {
+  _id: string;
+  title?: string;
+  collabVisible?: boolean;
+  updatedAt?: string;
+  author?: any;
+};
 
-export default function CollabPage(){
-  const [tab, setTab] = useState<'network'|'mine'>('network');
-  const [mine, setMine] = useState<any[]>([]);
-  const [network, setNetwork] = useState<any[]>([]);
-  useEffect(()=>{ (async()=>{
-    const r = await fetch('/api/newsroom/collab/list'); const d = await r.json();
-    setMine(d.myShared||[]); setNetwork(d.network||[]);
-  })(); },[]);
+export default function Collab() {
+  const [mine, setMine] = useState<Draft[]>([]);
+  const [network, setNetwork] = useState<Draft[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        // Assume /api/newsroom/drafts?mine=1 and /api/newsroom/collab/assist list network-visible
+        const [r1, r2] = await Promise.all([
+          fetch("/api/newsroom/drafts?mine=1"),
+          fetch("/api/newsroom/collab/assist"),
+        ]);
+        const d1 = await r1.json();
+        const d2 = await r2.json();
+        if (!alive) return;
+        setMine(Array.isArray(d1?.items) ? d1.items : []);
+        setNetwork(Array.isArray(d2?.items) ? d2.items : []);
+      } catch {
+        if (!alive) return;
+        setMine([]);
+        setNetwork([]);
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  async function toggle(id: string, on: boolean) {
+    setBusy(id);
+    try {
+      const r = await fetch("/api/newsroom/collab/toggle-visibility", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ draftId: id, visible: on }),
+      });
+      const d = await r.json();
+      if (!r.ok) throw new Error(d?.error || "Failed");
+      setMine((prev) => prev.map((x) => (x._id === id ? { ...x, collabVisible: on } : x)));
+    } catch (e: any) {
+      alert(e.message || "Failed");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function offerHelp(id: string) {
+    setBusy(id);
+    try {
+      const r = await fetch("/api/newsroom/collab/assist", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ draftId: id }),
+      });
+      const d = await r.json();
+      if (!r.ok) throw new Error(d?.error || "Failed");
+      alert("Offer sent to the author.");
+    } catch (e: any) {
+      alert(e.message || "Failed");
+    } finally {
+      setBusy(null);
+    }
+  }
+
   return (
-    <NewsroomLayout>
-      <h1 className="text-2xl font-semibold mb-4">Collaboration</h1>
-      <div className="text-sm text-gray-600 mb-3">Share a draft from the Publisher to invite help. Network-visible drafts appear here.</div>
-      <div className="flex items-center gap-2 mb-3">
-        <button className={`px-3 py-1 rounded border ${tab==='network'?'bg-gray-50':''}`} onClick={()=>setTab('network')}>Network drafts</button>
-        <button className={`px-3 py-1 rounded border ${tab==='mine'?'bg-gray-50':''}`} onClick={()=>setTab('mine')}>My shared drafts</button>
+    <Page
+      title="Collaboration"
+      subtitle="Invite help or offer to collaborate on works-in-progress"
+    >
+      <div className="grid gap-6">
+        <Callout variant="info">
+          Toggle visibility to let other authors discover and offer help on your draft.
+        </Callout>
+        <div className="grid gap-6 lg:grid-cols-2">
+          <SectionCard title="My drafts (visibility)">
+            {loading ? (
+              <div>Loading…</div>
+            ) : mine.length === 0 ? (
+              <div>No drafts yet.</div>
+            ) : (
+              <ul className="divide-y">
+                {mine.map((d) => (
+                  <li key={d._id} className="py-3 flex items-center justify-between">
+                    <div className="min-w-0">
+                      <div className="font-medium truncate">
+                        {d.title || "Untitled"}
+                      </div>
+                      <div className="text-xs text-gray-500">
+                        Updated {new Date(d.updatedAt || Date.now()).toLocaleString()}
+                      </div>
+                    </div>
+                    <div className="shrink-0 flex items-center gap-3">
+                      <label className="text-sm flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          checked={!!d.collabVisible}
+                          onChange={(e) => toggle(d._id, e.target.checked)}
+                          disabled={busy === d._id}
+                        />
+                        Visible to network
+                      </label>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </SectionCard>
+          <SectionCard title="Network drafts">
+            {loading ? (
+              <div>Loading…</div>
+            ) : network.length === 0 ? (
+              <div>No network drafts yet.</div>
+            ) : (
+              <ul className="divide-y">
+                {network.map((d) => (
+                  <li key={d._id} className="py-3">
+                    <div className="font-medium">{d.title || "Untitled"}</div>
+                    <div className="text-xs text-gray-500">
+                      by {d.author?.name || "Author"}
+                    </div>
+                    <div className="mt-2">
+                      <button
+                        className="text-sm px-3 py-2 rounded-md border hover:bg-gray-50"
+                        onClick={() => offerHelp(d._id)}
+                        disabled={busy === d._id}
+                      >
+                        {busy === d._id ? "Sending…" : "Offer help"}
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </SectionCard>
+        </div>
       </div>
-      <ul className="divide-y rounded-xl border">
-        {(tab==='network' ? network : mine).map((it:any, i:number)=>(
-          <li key={i} className="p-4">
-            <div className="font-medium">{it.title || 'Untitled'}</div>
-            <div className="text-xs text-gray-500">
-              {it.authorEmail ? <span className="mr-2">{it.authorEmail}</span> : null}
-              updated {new Date(it.updatedAt).toLocaleString()}
-            </div>
-          </li>
-        ))}
-      </ul>
-    </NewsroomLayout>
+    </Page>
   );
 }
 

--- a/frontend/pages/newsroom/dashboard.tsx
+++ b/frontend/pages/newsroom/dashboard.tsx
@@ -1,67 +1,91 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Link from "next/link";
 import Page from "@/components/UX/Page";
 import SectionCard from "@/components/UX/SectionCard";
+import KPI from "@/components/UX/KPI";
 
 export default function Dashboard() {
-  return (
-    <Page
-      title="Newsroom"
-      subtitle="Your writing hub — drafts, schedules, and activity."
-      actions={
-        <div className="flex gap-2">
-          <Link href="/newsroom" className="px-3 py-2 rounded-md bg-black text-white hover:bg-gray-900">
-            Write
-          </Link>
-          <Link href="/newsroom/notice-board" className="px-3 py-2 rounded-md border hover:bg-gray-50">
-            New notice
-          </Link>
-        </div>
+  const [stats, setStats] = useState<any | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const r = await fetch("/api/newsroom/stats");
+        const d = await r.json();
+        if (!alive) return;
+        setStats(d || {});
+      } catch {
+        if (!alive) return;
+        setStats({});
+      } finally {
+        if (alive) setLoading(false);
       }
-    >
-      <div className="grid gap-6 sm:grid-cols-2">
-        <SectionCard title="At a glance">
-          <ul className="text-sm text-gray-700 space-y-1">
-            <li>
-              Drafts in progress: <span className="font-medium">—</span>
-            </li>
-            <li>
-              Scheduled for publish: <span className="font-medium">—</span>
-            </li>
-            <li>
-              Last 7 days views: <span className="font-medium">—</span>
-            </li>
-          </ul>
-        </SectionCard>
-        <SectionCard title="Shortcuts">
-          <div className="flex flex-wrap gap-2">
-            <Link href="/newsroom" className="px-3 py-2 rounded-md border hover:bg-gray-50">
-              Open Publisher
-            </Link>
-            <Link href="/newsroom/media" className="px-3 py-2 rounded-md border hover:bg-gray-50">
-              Browse Media
-            </Link>
-            <Link href="/newsroom/collab" className="px-3 py-2 rounded-md border hover:bg-gray-50">
-              Collaboration
-            </Link>
-            <Link href="/newsroom/profile" className="px-3 py-2 rounded-md border hover:bg-gray-50">
-              Profile & Settings
-            </Link>
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return (
+    <Page title="Newsroom" subtitle="Your writer dashboard">
+      <div className="grid gap-6">
+        <SectionCard>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            <KPI title="Drafts" value={stats?.drafts ?? 0} data={stats?.spark?.drafts ?? []} />
+            <KPI title="Scheduled" value={stats?.scheduled ?? 0} data={stats?.spark?.scheduled ?? []} />
+            <KPI title="Published" value={stats?.published ?? 0} data={stats?.spark?.published ?? []} />
+            <KPI
+              title="Views (7d)"
+              value={stats?.views7d ?? 0}
+              delta={stats?.viewsDelta ?? 0}
+              data={stats?.spark?.views ?? []}
+            />
           </div>
         </SectionCard>
-      </div>
-      <div className="mt-6 grid gap-6 sm:grid-cols-2">
-        <SectionCard title="Recent activity">
-          <p className="text-gray-600 text-sm">Your latest edits, comments, and approvals will appear here.</p>
-        </SectionCard>
-        <SectionCard title="Tips">
-          <ul className="text-sm text-gray-700 list-disc pl-5 space-y-1">
-            <li>Use the Media Library to re-use newsroom assets.</li>
-            <li>Submit for review early; you can keep editing.</li>
-            <li>Try the AI Assistant to outline complex explainers.</li>
-          </ul>
-        </SectionCard>
+        <div className="grid lg:grid-cols-2 gap-6">
+          <SectionCard title="Quick actions">
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/newsroom"
+                className="px-4 py-2 rounded-md bg-black text-white hover:bg-gray-900"
+              >
+                New draft
+              </Link>
+              <Link
+                href="/newsroom/posts"
+                className="px-4 py-2 rounded-md border hover:bg-gray-50"
+              >
+                My posts
+              </Link>
+              <Link
+                href="/newsroom/notice-board#new"
+                className="px-4 py-2 rounded-md border hover:bg-gray-50"
+              >
+                New notice
+              </Link>
+              <Link
+                href="/newsroom/media"
+                className="px-4 py-2 rounded-md border hover:bg-gray-50"
+              >
+                Media library
+              </Link>
+            </div>
+          </SectionCard>
+          <SectionCard title="Tips">
+            <ul className="list-disc list-inside text-sm text-gray-700">
+              <li>
+                Attach media directly from the editor via <em>/</em> menu or drag-drop.
+              </li>
+              <li>
+                Use “Submit for review” to notify editors; scheduling auto-publishes.
+              </li>
+            </ul>
+          </SectionCard>
+        </div>
       </div>
     </Page>
   );
 }
+

--- a/frontend/pages/newsroom/help.tsx
+++ b/frontend/pages/newsroom/help.tsx
@@ -1,31 +1,30 @@
-import NewsroomLayout from '@/components/Newsroom/NewsroomLayout';
-import type { GetServerSideProps } from 'next';
-import { requireAuthSSR } from '@/lib/user-guard';
+import React from "react";
+import Page from "@/components/UX/Page";
+import SectionCard from "@/components/UX/SectionCard";
+import Callout from "@/components/UX/Callout";
 
-export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ctx as any);
-
-export default function HelpPage(){
+export default function NewsroomHelp() {
   return (
-    <NewsroomLayout>
-      <h1 className="text-2xl font-semibold mb-4">Help for Members</h1>
-      <div className="grid md:grid-cols-2 gap-4">
-        <section className="border rounded-xl p-4">
-          <div className="font-medium mb-1">Getting started</div>
-          <p className="text-sm text-gray-600">Use Publisher to create drafts, insert media, and submit for review. The Dashboard shows your stats and quick actions.</p>
-        </section>
-        <section className="border rounded-xl p-4">
-          <div className="font-medium mb-1">Editorial workflow</div>
-          <p className="text-sm text-gray-600">Submit for review when ready. Editors will approve or request changes; you’ll receive email notifications.</p>
-        </section>
-        <section className="border rounded-xl p-4">
-          <div className="font-medium mb-1">Media tips</div>
-          <p className="text-sm text-gray-600">Open Media from the draft to insert images/videos. Uploads live in Cloudinary and can be reused across drafts.</p>
-        </section>
-        <section className="border rounded-xl p-4">
-          <div className="font-medium mb-1">Policies</div>
-          <p className="text-sm text-gray-600">Review our <a className="text-blue-600 underline" href="/editorial-standards">Editorial Standards</a> and <a className="text-blue-600 underline" href="/privacy">Privacy</a>.</p>
-        </section>
+    <Page title="Help" subtitle="Guides, best practices, and shortcuts">
+      <div className="grid gap-6">
+        <Callout title="TL;DR">
+          Draft → Add media → Submit for review → (optional) Schedule → Publish
+        </Callout>
+        <SectionCard title="Writing">
+          <ul className="list-disc list-inside text-sm text-gray-700">
+            <li>Use headings and short paragraphs for scannability.</li>
+            <li>Add captions and alt text for accessibility.</li>
+            <li>Link sources — we encourage transparent citations.</li>
+          </ul>
+        </SectionCard>
+        <SectionCard title="Media">
+          <ul className="list-disc list-inside text-sm text-gray-700">
+            <li>Prefer horizontal images ≥ 1600px on the long edge.</li>
+            <li>Use the library to reuse approved assets.</li>
+          </ul>
+        </SectionCard>
       </div>
-    </NewsroomLayout>
+    </Page>
   );
 }
+

--- a/frontend/pages/newsroom/notice-board.tsx
+++ b/frontend/pages/newsroom/notice-board.tsx
@@ -1,49 +1,189 @@
 import React, { useEffect, useState } from "react";
-import Link from "next/link";
 import Page from "@/components/UX/Page";
 import SectionCard from "@/components/UX/SectionCard";
+import Callout from "@/components/UX/Callout";
+
+type Notice = {
+  _id?: string;
+  title?: string;
+  body?: string;
+  createdAt?: string;
+  comments?: any[];
+};
 
 export default function NoticeBoard() {
-  const [items, setItems] = useState<any[]>([]);
+  const [items, setItems] = useState<Notice[]>([]);
   const [loading, setLoading] = useState(true);
+  const [posting, setPosting] = useState(false);
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+
   useEffect(() => {
-    let mounted = true;
+    let alive = true;
     (async () => {
       try {
         const r = await fetch("/api/newsroom/notice");
         const d = await r.json();
-        if (mounted) setItems(d?.items || []);
+        if (!alive) return;
+        setItems(Array.isArray(d?.items) ? d.items : []);
+        // mark seen to clear unread badge
+        fetch("/api/newsroom/notice/seen", { method: "POST" }).catch(() => {});
+      } catch {
+        if (!alive) return;
+        setItems([]);
       } finally {
-        if (mounted) setLoading(false);
+        if (alive) setLoading(false);
       }
     })();
     return () => {
-      mounted = false;
+      alive = false;
     };
   }, []);
 
+  async function onPost(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim() || !body.trim()) return;
+    setPosting(true);
+    try {
+      const r = await fetch("/api/newsroom/notice", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title, body }),
+      });
+      const d = await r.json();
+      if (!r.ok) throw new Error(d?.error || "Failed");
+      setItems((prev) => [
+        { ...(d?.item || { title, body, createdAt: new Date().toISOString() }) },
+        ...prev,
+      ]);
+      setTitle("");
+      setBody("");
+    } catch (e: any) {
+      alert(e.message || "Failed");
+    } finally {
+      setPosting(false);
+    }
+  }
+
+  async function onComment(id: string, text: string) {
+    if (!text.trim()) return;
+    try {
+      const r = await fetch("/api/newsroom/notice/comments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id, text }),
+      });
+      const d = await r.json();
+      if (!r.ok) throw new Error(d?.error || "Failed");
+      setItems((prev) =>
+        prev.map((n) =>
+          n._id === id ? { ...n, comments: [...(n.comments || []), d.comment] } : n
+        )
+      );
+    } catch (e: any) {
+      alert(e.message || "Failed");
+    }
+  }
+
   return (
-    <Page
-      title="Notice Board"
-      subtitle="Internal posts for authors and editors."
-      actions={<Link href="/newsroom" className="px-3 py-2 rounded-md border hover:bg-gray-50">Back to Publisher</Link>}
-    >
-      <SectionCard>
-        {loading ? (
-          <p className="text-gray-600">Loading…</p>
-        ) : items.length === 0 ? (
-          <p className="text-gray-600">No notices yet.</p>
-        ) : (
-          <ul className="divide-y">
-            {items.map((n) => (
-              <li key={n._id} className="py-3">
-                <div className="font-medium">{n.title || "Notice"}</div>
-                <p className="text-sm text-gray-700 mt-1">{n.body}</p>
-              </li>
-            ))}
-          </ul>
-        )}
-      </SectionCard>
+    <Page title="Notice Board" subtitle="Newsroom updates, suggestions, and discussion">
+      <div className="grid gap-6">
+        <Callout variant="info">
+          Use this space for platform notes, suggestions, and coordination.
+        </Callout>
+        <div id="new">
+          <SectionCard title="Post a notice">
+            <form onSubmit={onPost} className="space-y-3">
+              <input
+                className="w-full border px-3 py-2 rounded"
+                placeholder="Title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+              />
+              <textarea
+                className="w-full border px-3 py-2 rounded"
+                placeholder="Write your notice…"
+                rows={4}
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+              />
+              <button
+                className="px-4 py-2 rounded-md bg-black text-white hover:bg-gray-900"
+                disabled={posting}
+              >
+                {posting ? "Posting…" : "Publish notice"}
+              </button>
+            </form>
+          </SectionCard>
+        </div>
+        <SectionCard title="All notices">
+          {loading ? (
+            <div>Loading…</div>
+          ) : items.length === 0 ? (
+            <div>No notices yet.</div>
+          ) : (
+            <ul className="space-y-4">
+              {items.map((n) => (
+                <li
+                  key={n._id || n.title}
+                  className="rounded-xl ring-1 ring-gray-200 p-3"
+                >
+                  <div className="font-medium">{n.title || "Notice"}</div>
+                  <div className="text-sm text-gray-700 whitespace-pre-line mt-1">
+                    {n.body}
+                  </div>
+                  <CommentsMini
+                    noticeId={String(n._id || "")}
+                    items={n.comments || []}
+                    onAdd={onComment}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </SectionCard>
+      </div>
     </Page>
   );
 }
+
+function CommentsMini({
+  noticeId,
+  items,
+  onAdd,
+}: {
+  noticeId: string;
+  items: any[];
+  onAdd: (id: string, text: string) => void;
+}) {
+  const [text, setText] = React.useState("");
+  return (
+    <div className="mt-3">
+      <ul className="space-y-2">
+        {items.map((c, i) => (
+          <li key={c._id || i} className="text-sm text-gray-700">
+            <span className="font-medium">{c.author?.name || "Member"}:</span> {c.text}
+          </li>
+        ))}
+      </ul>
+      <div className="mt-2 flex gap-2">
+        <input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Add a comment…"
+          className="flex-1 border px-3 py-2 rounded"
+        />
+        <button
+          onClick={() => {
+            onAdd(noticeId, text);
+            setText("");
+          }}
+          className="px-3 py-2 rounded-md border hover:bg-gray-50"
+        >
+          Comment
+        </button>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add tiny Sparkline and KPI components for lightweight dashboard metrics
- overhaul newsroom dashboard with KPI cards, quick actions, and notice shortcut
- reskin help, notice board (with comments), and collaboration pages for clearer UX

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aa9380a2948329ab25476c92cd8955