### PR TITLE
refactor: unify profile settings

### DIFF
--- a/frontend/components/ProfileSettings.tsx
+++ b/frontend/components/ProfileSettings.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import SectionCard from "@/components/UX/SectionCard";
+
+export default function ProfileSettings() {
+  const [revealDanger, setRevealDanger] = React.useState(false);
+  const [confirmText, setConfirmText] = React.useState("");
+  const [busy, setBusy] = React.useState(false);
+
+  async function onDelete(e: React.FormEvent) {
+    e.preventDefault();
+    if (confirmText !== "DELETE") return alert("Type DELETE to confirm.");
+    setBusy(true);
+    try {
+      const r = await fetch("/api/users/delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ confirm: "DELETE" }),
+      });
+      const d = await r.json();
+      if (!r.ok) throw new Error(d?.error || "Delete failed");
+      window.location.href = "/";
+    } catch (err: any) {
+      alert(err.message || "Delete failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <SectionCard title="Danger zone">
+      <p className="text-sm text-gray-700">
+        Delete your account (this action cannot be undone).
+      </p>
+      {!revealDanger ? (
+        <button
+          onClick={() => setRevealDanger(true)}
+          className="mt-3 text-sm px-3 py-2 rounded-md border hover:bg-gray-50"
+        >
+          Show delete options
+        </button>
+      ) : (
+        <form onSubmit={onDelete} className="mt-4 space-y-3">
+          <p className="text-sm text-red-700">
+            Type <b>DELETE</b> to confirm permanent removal.
+          </p>
+          <input
+            value={confirmText}
+            onChange={(e) => setConfirmText(e.target.value)}
+            className="w-full border px-3 py-2 rounded"
+            placeholder="DELETE"
+          />
+          <div className="flex gap-2">
+            <button
+              className="px-4 py-2 rounded-md bg-red-600 text-white hover:bg-red-700"
+              disabled={busy || confirmText !== "DELETE"}
+            >
+              {busy ? "Deleting…" : "Delete account"}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setRevealDanger(false);
+                setConfirmText("");
+              }}
+              className="px-4 py-2 rounded-md border hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+    </SectionCard>
+  );
+}
+

--- a/frontend/pages/newsroom/profile.tsx
+++ b/frontend/pages/newsroom/profile.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Page from "@/components/UX/Page";
 import SectionCard from "@/components/UX/SectionCard";
 import ProfilePhotoForm from "@/components/Settings/ProfilePhotoForm";
+import ProfileSettings from "@/components/ProfileSettings";
 
 export default function Profile() {
   return (
@@ -16,12 +17,7 @@ export default function Profile() {
         </SectionCard>
       </div>
       <div className="mt-6">
-        <SectionCard title="Danger zone">
-          <p className="text-sm text-gray-700">Delete your account (this action cannot be undone).</p>
-          <button className="mt-3 px-3 py-2 rounded-md border border-red-300 text-red-700 hover:bg-red-50">
-            Delete account
-          </button>
-        </SectionCard>
+        <ProfileSettings />
       </div>
     </Page>
   );

--- a/frontend/pages/profile.tsx
+++ b/frontend/pages/profile.tsx
@@ -1,27 +1,9 @@
 import React from "react";
 import Page from "@/components/UX/Page";
 import SectionCard from "@/components/UX/SectionCard";
+import ProfileSettings from "@/components/ProfileSettings";
 
 export default function ProfilePage() {
-  const [revealDanger, setRevealDanger] = React.useState(false);
-  const [confirmText, setConfirmText] = React.useState("");
-  const [busy, setBusy] = React.useState(false);
-
-  async function onDelete(e: React.FormEvent) {
-    e.preventDefault();
-    if (confirmText !== "DELETE") return alert('Type DELETE to confirm.');
-    setBusy(true);
-    try {
-      const r = await fetch("/api/users/delete", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ confirm: "DELETE" }) });
-      const d = await r.json();
-      if (!r.ok) throw new Error(d?.error || "Delete failed");
-      window.location.href = "/"; // back to home
-    } catch (err:any) {
-      alert(err.message || "Delete failed");
-    } finally {
-      setBusy(false);
-    }
-  }
   return (
     <Page title="Your Account" subtitle="Manage profile and settings.">
       <div className="grid gap-6">
@@ -31,35 +13,7 @@ export default function ProfilePage() {
             <li><a className="underline" href="/newsroom/posts">My Posts</a></li>
           </ul>
         </SectionCard>
-        <SectionCard title="Danger zone">
-          <p className="text-sm text-gray-700">Delete your account (this action cannot be undone).</p>
-          {!revealDanger ? (
-            <button onClick={() => setRevealDanger(true)} className="mt-3 text-sm px-3 py-2 rounded-md border hover:bg-gray-50">
-              Show delete options
-            </button>
-          ) : (
-            <form onSubmit={onDelete} className="mt-4 space-y-3">
-              <p className="text-sm text-red-700">Type <b>DELETE</b> to confirm permanent removal.</p>
-              <input
-                value={confirmText}
-                onChange={(e) => setConfirmText(e.target.value)}
-                className="w-full border px-3 py-2 rounded"
-                placeholder="DELETE"
-              />
-              <div className="flex gap-2">
-                <button
-                  className="px-4 py-2 rounded-md bg-red-600 text-white hover:bg-red-700"
-                  disabled={busy || confirmText !== "DELETE"}
-                >
-                  {busy ? "Deleting…" : "Delete account"}
-                </button>
-                <button type="button" onClick={() => { setRevealDanger(false); setConfirmText(""); }} className="px-4 py-2 rounded-md border hover:bg-gray-50">
-                  Cancel
-                </button>
-              </div>
-            </form>
-          )}
-        </SectionCard>
+        <ProfileSettings />
       </div>
     </Page>
   );


### PR DESCRIPTION
## Summary
- extract account deletion logic into reusable `ProfileSettings` component
- update public and newsroom profile pages to consume shared component

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aa9a5eea6083298e709e97055da7ad