### PR TITLE
refactor: consolidate draft list component

### DIFF
--- a/frontend/components/Newsroom/DraftList.tsx
+++ b/frontend/components/Newsroom/DraftList.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from "react";
+
+export type Column = {
+  key: string;
+  label: string;
+  render?: (item: any) => React.ReactNode;
+};
+
+interface DraftListProps {
+  fetchUrl: string;
+  columns: Column[];
+  actions?: (item: any) => React.ReactNode;
+  showSearch?: boolean;
+  showStatusFilter?: boolean;
+  refreshDeps?: any[];
+}
+
+export default function DraftList({
+  fetchUrl,
+  columns,
+  actions,
+  showSearch = false,
+  showStatusFilter = false,
+  refreshDeps = [],
+}: DraftListProps) {
+  const [items, setItems] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [q, setQ] = useState("");
+  const [status, setStatus] = useState("all");
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (showSearch && q) params.set("q", q);
+    if (showStatusFilter && status && status !== "all") params.set("status", status);
+    setLoading(true);
+    fetch(`${fetchUrl}${params.toString() ? `?${params.toString()}` : ""}`)
+      .then((r) => r.json())
+      .then((d) => setItems(d.items || d.rows || []))
+      .finally(() => setLoading(false));
+  }, [fetchUrl, q, status, showSearch, showStatusFilter, ...refreshDeps]);
+
+  return (
+    <div>
+      {(showSearch || showStatusFilter) && (
+        <div className="flex items-center gap-2 mb-4">
+          {showSearch && (
+            <input
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+              placeholder="Search title..."
+              className="rounded-xl border px-3 py-2"
+            />
+          )}
+          {showStatusFilter && (
+            <select
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+              className="rounded-xl border px-3 py-2"
+            >
+              {["all", "draft", "in-review", "ready", "scheduled", "published", "archived"].map((s) => (
+                <option key={s}>{s}</option>
+              ))}
+            </select>
+          )}
+        </div>
+      )}
+
+      <div className="overflow-auto rounded-2xl border">
+        <table className="min-w-[680px] w-full">
+          <thead className="bg-neutral-50 text-left text-sm">
+            <tr>
+              {columns.map((col) => (
+                <th key={col.key} className="p-3">
+                  {col.label}
+                </th>
+              ))}
+              {actions && <th className="p-3" />}
+            </tr>
+          </thead>
+          <tbody className="text-sm">
+            {items.map((item) => (
+              <tr key={item._id || item.id} className="border-t">
+                {columns.map((col) => (
+                  <td key={col.key} className="p-3">
+                    {col.render ? col.render(item) : item[col.key]}
+                  </td>
+                ))}
+                {actions && <td className="p-3 text-right">{actions(item)}</td>}
+              </tr>
+            ))}
+            {!loading && items.length === 0 && (
+              <tr>
+                <td
+                  className="p-6 text-neutral-600"
+                  colSpan={columns.length + (actions ? 1 : 0)}
+                >
+                  No drafts yet.
+                </td>
+              </tr>
+            )}
+            {loading && (
+              <tr>
+                <td
+                  className="p-6 text-neutral-600"
+                  colSpan={columns.length + (actions ? 1 : 0)}
+                >
+                  Loading…
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/pages/admin/drafts/index.jsx
+++ b/frontend/pages/admin/drafts/index.jsx
@@ -1,66 +1,63 @@
-import { useEffect, useState } from "react";
 import Link from "next/link";
+import DraftList from "@/components/Newsroom/DraftList";
 
 export default function DraftsList() {
-  const [q, setQ] = useState("");
-  const [status, setStatus] = useState("all");
-  const [items, setItems] = useState([]);
-
-  useEffect(() => {
-    const params = new URLSearchParams();
-    if (q) params.set("q", q);
-    if (status) params.set("status", status);
-    fetch(`/api/drafts/list?${params}`).then(r=>r.json()).then(d=>setItems(d.items||[]));
-  }, [q, status]);
-
   async function createDraft() {
-    const r = await fetch("/api/drafts/create", { method:"POST", headers:{ "Content-Type":"application/json"}, body: JSON.stringify({}) });
+    const r = await fetch("/api/drafts/create", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
     const d = await r.json();
     if (d.id) location.href = `/admin/drafts/${d.id}`;
   }
+
+  const columns = [
+    {
+      key: "updatedAt",
+      label: "Updated",
+      render: (x) => new Date(x.updatedAt).toLocaleString(),
+    },
+    { key: "title", label: "Title" },
+    { key: "status", label: "Status", render: (x) => x.status },
+    {
+      key: "assignedTo",
+      label: "Assigned",
+      render: (x) => x.assignedTo?.name || x.assignedTo?.email || "—",
+    },
+    {
+      key: "scheduledAt",
+      label: "Scheduled",
+      render: (x) => (x.scheduledAt ? new Date(x.scheduledAt).toLocaleString() : "—"),
+    },
+  ];
 
   return (
     <div className="p-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold">Drafts</h1>
-        <button onClick={createDraft} className="px-4 py-2 bg-blue-600 text-white rounded-lg">New Draft</button>
+        <button
+          onClick={createDraft}
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg"
+        >
+          New Draft
+        </button>
       </div>
 
-      <div className="mt-4 flex gap-3">
-        <input className="border rounded px-3 py-2" placeholder="Search…" value={q} onChange={e=>setQ(e.target.value)} />
-        <select className="border rounded px-3 py-2" value={status} onChange={e=>setStatus(e.target.value)}>
-          {["all","draft","in-review","ready","scheduled","published","archived"].map(s=><option key={s}>{s}</option>)}
-        </select>
-      </div>
-
-      <div className="mt-6 bg-white rounded-xl shadow overflow-hidden">
-        <table className="min-w-full">
-          <thead className="bg-gray-50 text-left text-sm">
-            <tr>
-              <th className="px-4 py-2">Updated</th>
-              <th className="px-4 py-2">Title</th>
-              <th className="px-4 py-2">Status</th>
-              <th className="px-4 py-2">Assigned</th>
-              <th className="px-4 py-2">Scheduled</th>
-              <th className="px-4 py-2"></th>
-            </tr>
-          </thead>
-          <tbody className="text-sm">
-            {items.map(x=>(
-              <tr key={x._id} className="border-t">
-                <td className="px-4 py-2">{new Date(x.updatedAt).toLocaleString()}</td>
-                <td className="px-4 py-2">{x.title}</td>
-                <td className="px-4 py-2 capitalize">{x.status}</td>
-                <td className="px-4 py-2">{x.assignedTo?.name || x.assignedTo?.email || "—"}</td>
-                <td className="px-4 py-2">{x.scheduledAt ? new Date(x.scheduledAt).toLocaleString() : "—"}</td>
-                <td className="px-4 py-2">
-                  <Link href={`/admin/drafts/${x._id}`} className="text-blue-600 underline">Open</Link>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <DraftList
+        fetchUrl="/api/drafts/list"
+        columns={columns}
+        actions={(x) => (
+          <Link
+            href={`/admin/drafts/${x._id}`}
+            className="text-blue-600 underline"
+          >
+            Open
+          </Link>
+        )}
+        showSearch
+        showStatusFilter
+      />
     </div>
   );
 }

--- a/frontend/pages/admin/newsroom/index.tsx
+++ b/frontend/pages/admin/newsroom/index.tsx
@@ -1,78 +1,43 @@
 import Link from "next/link";
-import { useEffect, useState } from "react";
-import { api } from "@/lib/api";
+import DraftList, { Column } from "@/components/Newsroom/DraftList";
 
-type Row = {
-  _id: string;
-  title: string;
-  slug: string;
-  status: "draft" | "scheduled" | "published";
-  updatedAt: string;
-  type: "news" | "vip" | "post" | "ads";
-};
+const columns: Column[] = [
+  { key: "title", label: "Title" },
+  { key: "type", label: "Type" },
+  { key: "status", label: "Status" },
+  {
+    key: "updatedAt",
+    label: "Updated",
+    render: (r) => new Date(r.updatedAt).toLocaleString(),
+  },
+];
 
 export default function NewsroomListPage() {
-  const [rows, setRows] = useState<Row[]>([]);
-  const [q, setQ] = useState("");
-
-  useEffect(() => {
-    refresh();
-  }, []);
-
-  async function refresh() {
-    const res = await api<{ rows: Row[] }>("/api/newsroom/drafts");
-    setRows(res.rows);
-  }
-
-  async function search() {
-    const res = await api<{ rows: Row[] }>(`/api/newsroom/drafts?q=${encodeURIComponent(q)}`);
-    setRows(res.rows);
-  }
-
   return (
     <main className="max-w-6xl mx-auto p-4">
       <div className="flex items-center justify-between mb-4">
         <h1 className="text-2xl font-semibold">Newsroom</h1>
-        <Link href="/admin/newsroom/editor" className="rounded-xl bg-blue-600 text-white px-4 py-2 hover:bg-blue-700">New Draft</Link>
+        <Link
+          href="/admin/newsroom/editor"
+          className="rounded-xl bg-blue-600 text-white px-4 py-2 hover:bg-blue-700"
+        >
+          New Draft
+        </Link>
       </div>
 
-      <div className="flex items-center gap-2 mb-4">
-        <input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search title..." className="rounded-xl border px-3 py-2" />
-        <button onClick={search} className="rounded-xl border px-3 py-2 hover:bg-neutral-50">Search</button>
-        <button onClick={refresh} className="rounded-xl border px-3 py-2 hover:bg-neutral-50">Reset</button>
-      </div>
-
-      <div className="overflow-auto rounded-2xl border">
-        <table className="min-w-[680px] w-full">
-          <thead className="bg-neutral-50 text-left text-sm">
-            <tr>
-              <th className="p-3">Title</th>
-              <th className="p-3">Type</th>
-              <th className="p-3">Status</th>
-              <th className="p-3">Updated</th>
-              <th className="p-3"></th>
-            </tr>
-          </thead>
-          <tbody className="text-sm">
-            {rows.map((r) => (
-              <tr key={r._id} className="border-t">
-                <td className="p-3">{r.title}</td>
-                <td className="p-3">{r.type}</td>
-                <td className="p-3">{r.status}</td>
-                <td className="p-3">{new Date(r.updatedAt).toLocaleString()}</td>
-                <td className="p-3 text-right">
-                  <Link href={`/admin/newsroom/editor?id=${r._id}`} className="text-blue-600 hover:underline">Edit</Link>
-                </td>
-              </tr>
-            ))}
-            {rows.length === 0 && (
-              <tr>
-                <td className="p-6 text-neutral-600" colSpan={5}>No drafts yet.</td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
+      <DraftList
+        fetchUrl="/api/newsroom/drafts"
+        columns={columns}
+        actions={(r) => (
+          <Link
+            href={`/admin/newsroom/editor?id=${r._id}`}
+            className="text-blue-600 hover:underline"
+          >
+            Edit
+          </Link>
+        )}
+        showSearch
+      />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable `DraftList` component with optional search and status filters
- reuse `DraftList` in newsroom and admin pages for draft tables

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aa9a668c0883299ab62153c15cc5d6