### PR TITLE
refactor: centralize newsroom editor functionality

### DIFF
--- a/frontend/components/Newsroom/SharedEditor.tsx
+++ b/frontend/components/Newsroom/SharedEditor.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import MarkdownEditor from "@/components/Newsroom/MarkdownEditor";
+import ModerationNotesDrawer from "@/components/Newsroom/ModerationNotesDrawer";
+
+type SharedEditorProps = {
+  value: string;
+  onChange: (v: string) => void;
+  status: string;
+  onStatusChange: (s: string) => void;
+  statusOptions?: string[];
+  draftId?: string;
+  onSave?: () => void;
+  showModerationNotes?: boolean;
+  rightPanel?: React.ReactNode;
+  children?: React.ReactNode;
+};
+
+export default function SharedEditor({
+  value,
+  onChange,
+  status,
+  onStatusChange,
+  statusOptions,
+  draftId,
+  onSave,
+  showModerationNotes,
+  rightPanel,
+  children,
+}: SharedEditorProps) {
+  const statuses = statusOptions || [
+    "draft",
+    "in-review",
+    "ready",
+    "scheduled",
+    "published",
+    "archived",
+  ];
+
+  const main = (
+    <div className="max-w-4xl">
+      <div className="mb-3">
+        <label className="block text-sm font-medium text-gray-700 mb-1">Status</label>
+        <select
+          className="border rounded px-2 py-1"
+          value={status}
+          onChange={(e) => onStatusChange(e.target.value)}
+        >
+          {statuses.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+      <MarkdownEditor value={value} onChange={onChange} onSave={onSave} draftId={draftId} />
+      {children}
+    </div>
+  );
+
+  return (
+    <section className="mt-6">
+      {rightPanel ? (
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr,320px] gap-4">
+          {main}
+          {rightPanel}
+        </div>
+      ) : (
+        main
+      )}
+      {showModerationNotes && <ModerationNotesDrawer targetId={draftId} />}
+    </section>
+  );
+}

--- a/frontend/pages/admin/drafts/[id].jsx
+++ b/frontend/pages/admin/drafts/[id].jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/router";
+import SharedEditor from "@/components/Newsroom/SharedEditor";
 
 function useDebouncedCallback(cb, delay=600) {
   const [t, setT] = useState(null);
@@ -14,7 +15,6 @@ export default function DraftEditor() {
   const { id } = query;
   const [item, setItem] = useState(null);
   const [saving, setSaving] = useState(false);
-  const [mediaOpen, setMediaOpen] = useState(false);
   const [threadUrl, setThreadUrl] = useState(null);
   const [threadBusy, setThreadBusy] = useState(false);
 
@@ -58,172 +58,100 @@ export default function DraftEditor() {
 
   if (!item) return <div className="p-6">Loading…</div>;
 
-  function insertAtCursor(textarea, snippet) {
-    const start = textarea.selectionStart || 0;
-    const end = textarea.selectionEnd || 0;
-    const before = textarea.value.slice(0,start);
-    const after = textarea.value.slice(end);
-    const next = before + snippet + after;
-    textarea.value = next;
-    debouncedSave({ body: next });
-  }
-
   return (
-    <div className="p-6 grid gap-6 lg:grid-cols-3">
-      <div className="lg:col-span-2 bg-white rounded-xl shadow p-6">
-        <div className="flex items-center gap-3">
-          <input
-            className="w-full text-xl font-semibold border-b focus:outline-none"
-            defaultValue={item.title}
-            onChange={(e)=>debouncedSave({ title: e.target.value })}
-            placeholder="Title…"
-          />
-          <span className="text-xs text-gray-500">{saving ? "Saving…" : "Saved"}</span>
-        </div>
-
-        <div className="mt-4">
-          <textarea
-            id="editor"
-            className="w-full h-[420px] border rounded-lg p-3 font-mono"
-            defaultValue={item.body}
-            onChange={(e)=>debouncedSave({ body: e.target.value })}
-            placeholder="Write in Markdown…"
-          />
-          <div className="mt-3 flex gap-2">
-            <button onClick={()=>setMediaOpen(true)} className="px-3 py-2 rounded border">Insert Media</button>
-          </div>
-        </div>
+    <div className="p-6">
+      <div className="flex items-center gap-3 max-w-4xl">
+        <input
+          className="w-full text-xl font-semibold border-b focus:outline-none"
+          defaultValue={item.title}
+          onChange={(e)=>debouncedSave({ title: e.target.value })}
+          placeholder="Title…"
+        />
+        <span className="text-xs text-gray-500">{saving ? "Saving…" : "Saved"}</span>
       </div>
 
-      <div className="bg-white rounded-xl shadow p-6 space-y-4">
-        <div>
-          <div className="text-sm font-medium text-gray-700">Status</div>
-          <div className="mt-2 flex flex-wrap gap-2">
-            {["draft","in-review","ready","scheduled","published","archived"].map(s=>(
-              <button key={s} onClick={()=>debouncedSave({ status: s })} className={`px-3 py-1 rounded border ${item.status===s?"bg-blue-600 text-white":"bg-white"}`}>{s}</button>
-            ))}
-          </div>
-        </div>
-
-        <div>
-          <div className="text-sm font-medium text-gray-700">Schedule</div>
-          <input
-            type="datetime-local"
-            className="mt-2 w-full border rounded px-3 py-2"
-            value={scheduleStr}
-            onChange={(e)=>debouncedSave({ scheduledAt: e.target.value || null })}
-          />
-        </div>
-
-        <div>
-          <div className="text-sm font-medium text-gray-700">Assignment</div>
-          <input className="mt-2 w-full border rounded px-3 py-2" placeholder="Assignee email"
-            defaultValue={item.assignedTo?.email || ""}
-            onBlur={(e)=>debouncedSave({ assignedTo: e.target.value ? { email: e.target.value } : null })}
-          />
-        </div>
-
-        <div>
-          <div className="text-sm font-medium text-gray-700">Reviewers</div>
-          <textarea className="mt-2 w-full border rounded px-3 py-2" placeholder="Comma-separated reviewer emails"
-            defaultValue={(item.reviewers||[]).map(r=>r.email).join(",")}
-            onBlur={(e)=>{
-              const list = e.target.value.split(",").map(s=>s.trim()).filter(Boolean).map(email=>({ email }));
-              debouncedSave({ reviewers: list });
-            }}
-          />
-          <label className="mt-2 flex items-center gap-2 text-sm">
-            <input type="checkbox" defaultChecked={!!item.secondReviewRequired}
-              onChange={(e)=>debouncedSave({ secondReviewRequired: e.target.checked })}/>
-            Second review required
-          </label>
-        </div>
-
-        {item?.slug ? (
-          <div className="border rounded-xl p-4">
-            <div className="flex items-center justify-between">
-              <div className="font-medium">Discussion Thread (Patwua)</div>
-              {threadUrl ? (
-                <a href={threadUrl} target="_blank" rel="noreferrer" className="text-sm underline">Open thread →</a>
-              ) : null}
+      <SharedEditor
+        value={item.body}
+        onChange={(v)=>debouncedSave({ body: v })}
+        status={item.status}
+        onStatusChange={(s)=>debouncedSave({ status: s })}
+        draftId={id}
+        showModerationNotes
+        rightPanel={
+          <div className="bg-white rounded-xl shadow p-6 space-y-4">
+            <div>
+              <div className="text-sm font-medium text-gray-700">Schedule</div>
+              <input
+                type="datetime-local"
+                className="mt-2 w-full border rounded px-3 py-2"
+                value={scheduleStr}
+                onChange={(e)=>debouncedSave({ scheduledAt: e.target.value || null })}
+              />
             </div>
-            {!threadUrl ? (
-              <div className="mt-2">
-                <button
-                  disabled={threadBusy}
-                  onClick={async ()=>{
-                    setThreadBusy(true);
-                    try {
-                      const r = await fetch(`/api/admin/posts/${encodeURIComponent(item.slug)}/create-thread`, { method: 'POST' });
-                      const d = await r.json();
-                      if (!r.ok) return alert(d?.error || 'Failed to create thread');
-                      setThreadUrl(d.threadUrl);
-                    } finally { setThreadBusy(false); }
-                  }}
-                  className="px-3 py-2 rounded bg-black text-white text-sm disabled:opacity-50"
-                >
-                  {threadBusy ? 'Creating…' : 'Create Patwua Thread'}
-                </button>
-                <div className="text-xs text-gray-500 mt-2">Creates a discussion thread on Patwua and links this post to it.</div>
+
+            <div>
+              <div className="text-sm font-medium text-gray-700">Assignment</div>
+              <input className="mt-2 w-full border rounded px-3 py-2" placeholder="Assignee email"
+                defaultValue={item.assignedTo?.email || ""}
+                onBlur={(e)=>debouncedSave({ assignedTo: e.target.value ? { email: e.target.value } : null })}
+              />
+            </div>
+
+            <div>
+              <div className="text-sm font-medium text-gray-700">Reviewers</div>
+              <textarea className="mt-2 w-full border rounded px-3 py-2" placeholder="Comma-separated reviewer emails"
+                defaultValue={(item.reviewers||[]).map(r=>r.email).join(",")}
+                onBlur={(e)=>{
+                  const list = e.target.value.split(",").map(s=>s.trim()).filter(Boolean).map(email=>({ email }));
+                  debouncedSave({ reviewers: list });
+                }}
+              />
+              <label className="mt-2 flex items-center gap-2 text-sm">
+                <input type="checkbox" defaultChecked={!!item.secondReviewRequired}
+                  onChange={(e)=>debouncedSave({ secondReviewRequired: e.target.checked })}/>
+                Second review required
+              </label>
+            </div>
+
+            {item?.slug ? (
+              <div className="border rounded-xl p-4">
+                <div className="flex items-center justify-between">
+                  <div className="font-medium">Discussion Thread (Patwua)</div>
+                  {threadUrl ? (
+                    <a href={threadUrl} target="_blank" rel="noreferrer" className="text-sm underline">Open thread →</a>
+                  ) : null}
+                </div>
+                {!threadUrl ? (
+                  <div className="mt-2">
+                    <button
+                      disabled={threadBusy}
+                      onClick={async ()=>{
+                        setThreadBusy(true);
+                        try {
+                          const r = await fetch(`/api/admin/posts/${encodeURIComponent(item.slug)}/create-thread`, { method: 'POST' });
+                          const d = await r.json();
+                          if (!r.ok) return alert(d?.error || 'Failed to create thread');
+                          setThreadUrl(d.threadUrl);
+                        } finally { setThreadBusy(false); }
+                      }}
+                      className="px-3 py-2 rounded bg-black text-white text-sm disabled:opacity-50"
+                    >
+                      {threadBusy ? 'Creating…' : 'Create Patwua Thread'}
+                    </button>
+                    <div className="text-xs text-gray-500 mt-2">Creates a discussion thread on Patwua and links this post to it.</div>
+                  </div>
+                ) : (
+                  <div className="text-sm text-gray-600 mt-2">Thread linked.</div>
+                )}
               </div>
-            ) : (
-              <div className="text-sm text-gray-600 mt-2">Thread linked.</div>
+            ) : null}
+
+            {item.ticketId && (
+              <div className="text-xs text-gray-500">Linked Ticket: {String(item.ticketId)}</div>
             )}
           </div>
-        ) : null}
-
-        {item.ticketId && (
-          <div className="text-xs text-gray-500">Linked Ticket: {String(item.ticketId)}</div>
-        )}
-      </div>
-
-      {/* Media Library Modal */}
-      {mediaOpen && <MediaModal onClose={()=>setMediaOpen(false)} onPick={(m)=>{
-        setMediaOpen(false);
-        const ta = document.getElementById("editor");
-        if (!ta) return;
-        const snippet = `\n![media](${m.url})\n`;
-        insertAtCursor(ta, snippet);
-      }} />}
-    </div>
-  );
-}
-
-function MediaModal({ onClose, onPick }) {
-  const [items, setItems] = useState([]);
-  const [cursor, setCursor] = useState(null);
-  useEffect(()=>{
-    fetch(`/api/media/list`).then(r=>r.json()).then(d=>{
-      setItems(d.resources || []);
-      setCursor(d.next_cursor || null);
-    });
-  },[]);
-  async function loadMore() {
-    const r = await fetch(`/api/media/list?cursor=${encodeURIComponent(cursor)}`);
-    const d = await r.json();
-    setItems(prev => [...prev, ...(d.resources||[])]);
-    setCursor(d.next_cursor || null);
-  }
-  return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-xl shadow-xl max-w-4xl w-full p-6">
-        <div className="flex items-center justify-between">
-          <h3 className="text-lg font-semibold">Media Library</h3>
-          <button onClick={onClose} className="text-gray-500">Close</button>
-        </div>
-        <div className="mt-4 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 max-h-[60vh] overflow-auto">
-          {items.map((r)=>(
-            <button key={r.public_id} className="border rounded-lg overflow-hidden hover:shadow"
-              onClick={()=>onPick({ url: r.secure_url || r.url, public_id: r.public_id, resource_type: r.resource_type })}>
-              <img src={r.secure_url || r.url} alt={r.public_id} className="w-full h-32 object-cover" />
-              <div className="p-2 text-xs truncate">{r.public_id}</div>
-            </button>
-          ))}
-        </div>
-        <div className="mt-4 flex justify-end">
-          {cursor && <button onClick={loadMore} className="px-4 py-2 rounded border">Load more</button>}
-        </div>
-      </div>
+        }
+      />
     </div>
   );
 }

--- a/frontend/pages/admin/newsroom/editor.tsx
+++ b/frontend/pages/admin/newsroom/editor.tsx
@@ -2,9 +2,8 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/router";
 import { api } from "@/lib/api";
 import { LegacyEditorBar } from "@/components/Newsroom/EditorBar";
-import MarkdownEditor from "@/components/Newsroom/MarkdownEditor";
 import EditorSidePanel from "@/components/Newsroom/EditorSidePanel";
-import ModerationNotesDrawer from "@/components/Newsroom/ModerationNotesDrawer";
+import SharedEditor from "@/components/Newsroom/SharedEditor";
 import LinkCheckerPanel from "@/components/Newsroom/LinkCheckerPanel";
 import SimilarityDrawer from "@/components/Newsroom/SimilarityDrawer";
 import SummaryPanel from "@/components/Newsroom/SummaryPanel";
@@ -124,28 +123,31 @@ export default function EditorPage() {
         </div>
       ) : null}
 
-      <section className="mt-6 grid grid-cols-1 lg:grid-cols-[1fr,320px] gap-4">
-        <div className="max-w-4xl">
-          <MarkdownEditor value={body} onChange={setBody} onSave={save} draftId={draftId || undefined} />
-          <div className="mt-4 flex gap-3">
-            <button onClick={save} className="rounded-xl border px-4 py-2 hover:bg-neutral-50">Save Draft</button>
-            <button onClick={publish} className="rounded-xl bg-blue-600 text-white px-4 py-2 hover:bg-blue-700">Publish</button>
-          </div>
+      <SharedEditor
+        value={body}
+        onChange={setBody}
+        status={status}
+        onStatusChange={(s) => setStatus(s as any)}
+        draftId={draftId || undefined}
+        onSave={save}
+        showModerationNotes
+        rightPanel={
+          <EditorSidePanel
+            title={title}
+            tags={tags}
+            onInsertReferences={(items) => {
+              if (!items?.length) return;
+              const bullets = items.map(it => `- [${it.title}](/news/${it.slug})`).join("\n");
+              setBody(prev => prev ? `${prev}\n\n### Related\n${bullets}\n` : `### Related\n${bullets}\n`);
+            }}
+          />
+        }
+      >
+        <div className="mt-4 flex gap-3">
+          <button onClick={save} className="rounded-xl border px-4 py-2 hover:bg-neutral-50">Save Draft</button>
+          <button onClick={publish} className="rounded-xl bg-blue-600 text-white px-4 py-2 hover:bg-blue-700">Publish</button>
         </div>
-
-        <EditorSidePanel
-          title={title}
-          tags={tags}
-          onInsertReferences={(items) => {
-            if (!items?.length) return;
-            const bullets = items.map(it => `- [${it.title}](/news/${it.slug})`).join("\n");
-            setBody(prev => prev ? `${prev}\n\n### Related\n${bullets}\n` : `### Related\n${bullets}\n`);
-          }}
-        />
-      </section>
-
-      {/* Moderation notes (internal) */}
-      <ModerationNotesDrawer targetId={draftId} />
+      </SharedEditor>
 
       {linkOpen ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center">

--- a/frontend/pages/newsroom/drafts/[id].tsx
+++ b/frontend/pages/newsroom/drafts/[id].tsx
@@ -3,8 +3,7 @@ import type { GetServerSideProps } from "next";
 import { useRouter } from "next/router";
 import { requireAuthSSR } from "@/lib/user-guard";
 import Page from "@/components/UX/Page";
-import SectionCard from "@/components/UX/SectionCard";
-import MarkdownEditor from "@/components/Newsroom/MarkdownEditor";
+import SharedEditor from "@/components/Newsroom/SharedEditor";
 import StatusPill from "@/components/StatusPill";
 import EditorBar from "@/components/Newsroom/EditorBar";
 
@@ -80,9 +79,17 @@ export default function DraftEditor() {
         onBack={() => router.push("/newsroom/dashboard")}
         rightExtra={draft?.status ? <StatusPill status={draft.status} /> : null}
       />
-      <SectionCard className="mt-4">
-        <MarkdownEditor value={draft?.body || ""} onChange={onChange} />
-      </SectionCard>
+      <SharedEditor
+        value={draft?.body || ""}
+        onChange={onChange}
+        status={draft?.status || "draft"}
+        onStatusChange={(s) => {
+          const next = { ...draft, status: s };
+          setDraft(next);
+          save(next);
+        }}
+        draftId={draft?._id}
+      />
     </Page>
   );
 }


### PR DESCRIPTION
## Summary
- add SharedEditor component for markdown editing, status control, and optional moderation notes
- refactor draft editor pages to configure SharedEditor

## Testing
- `npm test`
- `npm run typecheck` *(fails: tsc not found; npm install 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9a6b4edc8329a1a538c4237e53d5