### PR TITLE
feat: unify dashboard layouts and KPI cards

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -24,7 +24,7 @@ export default function Header() {
       {/* Top row: logo • SmartMenu • actions */}
       <div className="mx-auto flex h-16 max-w-7xl items-center gap-4 px-4">
         <Link
-          href={me?.email ? "/newsroom/dashboard" : "/"}
+          href={me?.email ? "/newsroom/writer-dashboard" : "/"}
           aria-label="WaterNews — Home"
           className="shrink-0 inline-flex items-center"
         >

--- a/frontend/components/Newsroom/GlobalShell.tsx
+++ b/frontend/components/Newsroom/GlobalShell.tsx
@@ -77,8 +77,8 @@ function RailContents() {
       <div className="p-4 border-b flex items-center gap-3">
         <button
           className="flex items-center gap-3 text-left group"
-          onClick={() => router.push("/newsroom/dashboard")}
-          title="Go to Newsroom dashboard"
+          onClick={() => router.push("/newsroom/writer-dashboard")}
+          title="Go to Writer dashboard"
         >
           <ProfilePhoto
             name={user?.displayName || user?.name || "You"}
@@ -109,7 +109,7 @@ function RailContents() {
         {!isCollapsed && (
           <div className="text-xs uppercase tracking-wide text-gray-500 px-2 mb-2">NewsRoom</div>
         )}
-        <SectionLink href="/newsroom/dashboard" label={isCollapsed ? "Home" : "Dashboard"} />
+        <SectionLink href="/newsroom/writer-dashboard" label={isCollapsed ? "Home" : "Dashboard"} />
         <SectionLink href="/newsroom" label={isCollapsed ? "Write" : "Publisher"} />
         <SectionLink href="/newsroom/collab" label={isCollapsed ? "Collab" : "Collaboration"} />
         <SectionLink href="/newsroom/media" label="Media" />
@@ -139,9 +139,9 @@ function MobileTopBar() {
     <div className="md:hidden sticky top-0 z-50 bg-white/85 backdrop-blur border-b">
       <div className="h-14 px-3 flex items-center gap-3">
         <button
-          onClick={() => router.push("/newsroom/dashboard")}
+          onClick={() => router.push("/newsroom/writer-dashboard")}
           className="flex items-center gap-2 min-w-0"
-          title="Go to Newsroom dashboard"
+          title="Go to Writer dashboard"
         >
           <ProfilePhoto
             name={user?.displayName || user?.name || "You"}

--- a/frontend/components/UX/DashboardLayout.tsx
+++ b/frontend/components/UX/DashboardLayout.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+interface Props {
+  title: string;
+  subtitle?: string;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export default function DashboardLayout({ title, subtitle, actions, children }: Props) {
+  return (
+    <main className="max-w-6xl mx-auto p-6 space-y-6">
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">{title}</h1>
+          {subtitle && <p className="text-gray-600">{subtitle}</p>}
+        </div>
+        {actions && <div className="shrink-0">{actions}</div>}
+      </header>
+      {children}
+    </main>
+  );
+}
+

--- a/frontend/pages/admin/moderation/dashboard.tsx
+++ b/frontend/pages/admin/moderation/dashboard.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import type { GetServerSideProps } from 'next';
 import { requireAdminSSR } from '@/lib/admin-guard';
+import DashboardLayout from '@/components/UX/DashboardLayout';
+import KPI from '@/components/UX/KPI';
 
 export const getServerSideProps: GetServerSideProps = (ctx) => requireAdminSSR(ctx as any);
 
@@ -31,17 +33,15 @@ export default function ModerationDashboard() {
   if (err) return <div className="p-6 text-red-600">{err}</div>;
 
   return (
-    <div className="max-w-6xl mx-auto p-6 space-y-6">
-      <h1 className="text-2xl font-semibold">Moderation Dashboard</h1>
-
+    <DashboardLayout title="Moderation Dashboard">
       {/* KPI cards */}
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
-        <Kpi title="Pending" value={stats?.pending ?? 0} />
-        <Kpi title="Ready" value={stats?.ready ?? 0} />
-        <Kpi title="Needs 2nd" value={stats?.needs_second_review ?? 0} />
-        <Kpi title="Changes" value={stats?.changes_requested ?? 0} />
-        <Kpi title="Scheduled" value={stats?.scheduled ?? 0} />
-        <Kpi title="Published (24h)" value={stats?.published_24h ?? 0} />
+        <KPI title="Pending" value={stats?.pending ?? 0} />
+        <KPI title="Ready" value={stats?.ready ?? 0} />
+        <KPI title="Needs 2nd" value={stats?.needs_second_review ?? 0} />
+        <KPI title="Changes" value={stats?.changes_requested ?? 0} />
+        <KPI title="Scheduled" value={stats?.scheduled ?? 0} />
+        <KPI title="Published (24h)" value={stats?.published_24h ?? 0} />
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div className="border rounded-xl p-4">
@@ -58,16 +58,7 @@ export default function ModerationDashboard() {
         <div className="font-medium mb-2">Editor workload</div>
         <SimpleTable rows={work?.editor || []} />
       </div>
-    </div>
-  );
-}
-
-function Kpi({ title, value }: { title: string; value: number }) {
-  return (
-    <div className="border rounded-xl p-4">
-      <div className="text-xs uppercase tracking-wide text-gray-500">{title}</div>
-      <div className="text-3xl font-semibold">{value}</div>
-    </div>
+    </DashboardLayout>
   );
 }
 

--- a/frontend/pages/newsroom/drafts/[id].tsx
+++ b/frontend/pages/newsroom/drafts/[id].tsx
@@ -77,7 +77,7 @@ export default function DraftEditor() {
         onPreview={onPreview}
         onSubmit={onSubmit}
         onPublish={onPublish}
-        onBack={() => router.push("/newsroom/dashboard")}
+        onBack={() => router.push("/newsroom/writer-dashboard")}
         rightExtra={draft?.status ? <StatusPill status={draft.status} /> : null}
       />
       <SectionCard className="mt-4">

--- a/frontend/pages/newsroom/writer-dashboard.tsx
+++ b/frontend/pages/newsroom/writer-dashboard.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react";
 import Link from "next/link";
-import Page from "@/components/UX/Page";
+import DashboardLayout from "@/components/UX/DashboardLayout";
 import SectionCard from "@/components/UX/SectionCard";
 import KPI from "@/components/UX/KPI";
 
-export default function Dashboard() {
+export default function WriterDashboard() {
   const [stats, setStats] = useState<any | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -29,7 +29,7 @@ export default function Dashboard() {
   }, []);
 
   return (
-    <Page title="Newsroom" subtitle="Your writer dashboard">
+    <DashboardLayout title="Writer Dashboard" subtitle="Your newsroom overview">
       <div className="grid gap-6">
         <SectionCard>
           <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
@@ -85,7 +85,7 @@ export default function Dashboard() {
           </SectionCard>
         </div>
       </div>
-    </Page>
+    </DashboardLayout>
   );
 }
 


### PR DESCRIPTION
## Summary
- add reusable DashboardLayout component
- rename writer dashboard route and update links
- share KPI card component across writer and moderation dashboards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa9a743950832996d3da43251e118a