### PR TITLE
Replace Cloudinary logo PNGs with local SVGs

### DIFF
--- a/frontend/components/UX/Page.tsx
+++ b/frontend/components/UX/Page.tsx
@@ -1,12 +1,8 @@
 import Image from "next/image";
 import { withCloudinaryAuto } from "@/lib/media";
 
-const MINI_LOGO = withCloudinaryAuto(
-  "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755962658/logo-mini_uhsj21.png"
-);
-const FULL_LOGO = withCloudinaryAuto(
-  "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755961127/WN_Logo_Full_JPG_s1tkic_0238af.png"
-);
+const MINI_LOGO = withCloudinaryAuto("/logo-mini.svg");
+const FULL_LOGO = withCloudinaryAuto("/logo-waternews.svg");
 
 export default function Page({
   title,

--- a/frontend/pages/about/index.jsx
+++ b/frontend/pages/about/index.jsx
@@ -33,12 +33,8 @@ const COMMUNITY_PHOTOS = [
   ),
 ];
 
-const MINI_LOGO = withCloudinaryAuto(
-  "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755962658/logo-mini_uhsj21.png"
-);
-const FULL_LOGO = withCloudinaryAuto(
-  "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755961127/WN_Logo_Full_JPG_s1tkic_0238af.png"
-);
+const MINI_LOGO = withCloudinaryAuto("/logo-mini.svg");
+const FULL_LOGO = withCloudinaryAuto("/logo-waternews.svg");
 
 export default function AboutPage() {
   return (

--- a/frontend/pages/about/masthead.jsx
+++ b/frontend/pages/about/masthead.jsx
@@ -77,9 +77,7 @@ export default function MastheadPage() {
             "@type": "NewsMediaOrganization",
             name: "WaterNews",
             url: "https://waternews.onrender.com",
-            logo: withCloudinaryAuto(
-              "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755961127/WN_Logo_Full_JPG_s1tkic_0238af.png"
-            ),
+            logo: withCloudinaryAuto("/logo-waternews.svg"),
             slogan: "Dive Into Current Stories",
             foundingLocation: "Georgetown, Guyana",
             contactPoint: [

--- a/frontend/pages/suggest-story.jsx
+++ b/frontend/pages/suggest-story.jsx
@@ -5,12 +5,8 @@ import { SUBJECTS } from "@/lib/cms-routing";
 import Toast from "@/components/Toast";
 import { withCloudinaryAuto } from "@/lib/media";
 
-const MINI_LOGO = withCloudinaryAuto(
-  "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755962658/logo-mini_uhsj21.png"
-);
-const FULL_LOGO = withCloudinaryAuto(
-  "https://res.cloudinary.com/dpdhi4joq/image/upload/v1755961127/WN_Logo_Full_JPG_s1tkic_0238af.png"
-);
+const MINI_LOGO = withCloudinaryAuto("/logo-mini.svg");
+const FULL_LOGO = withCloudinaryAuto("/logo-waternews.svg");
 
 export default function SuggestStory() {
   const [anonymous, setAnonymous] = useState(false);


### PR DESCRIPTION
## Summary
- Use local SVG logo files in About page, Suggest a Story page, shared Page header, and Masthead JSON-LD
- Ensure SVG versions load via withCloudinaryAuto for consistent delivery

## Testing
- `npm test`
- `node -e function withCloudinaryAuto(url){ if(!url) return url; if(/^https?:\/\/res\.cloudinary\.com\//.test(url) && !/\/upload\/.*f_auto/.test(url)){ return url.replace(/\/upload\/(?!.*f_auto)/, '/upload/f_auto,q_auto/'); } return url;} console.log('local:', withCloudinaryAuto('/logo-mini.svg')); console.log('cloudinary:', withCloudinaryAuto('https://res.cloudinary.com/demo/image/upload/v1/sample.png'));`


------
https://chatgpt.com/codex/tasks/task_e_68aaa82bf05083298479118639e95161