### PR TITLE
feat: centralize design tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # WaterNews
+
+## Brand Tokens
+
+Shared design tokens live in `frontend/lib/brand-tokens.ts`. Import these
+tokens instead of hard-coding values to keep the interface consistent.
+
+```ts
+import { colors } from "@/lib/brand-tokens";
+
+<a
+  style={{ "--brand": colors.primary }}
+  className="text-[var(--brand)]"
+>
+  Link text
+</a>
+```
+
+The file also exports fonts, spacing units, and logo paths for reuse across
+components.

--- a/frontend/lib/brand-tokens.ts
+++ b/frontend/lib/brand-tokens.ts
@@ -1,0 +1,49 @@
+export const colors = {
+  /** Core brand blue */
+  primary: '#1583c2',
+  /** Lighter border/hover shade */
+  primaryLight: '#cfe6f7',
+  /** Lightest background shade */
+  primaryLighter: '#eff7fd',
+  /** Soft gradient start */
+  primarySoftFrom: '#e8f4fd',
+  /** Soft gradient end */
+  primarySoftTo: '#f7fbff',
+  /** Tag background */
+  primaryTagBg: '#e6f2fb',
+  /** Tag text */
+  primaryTagText: '#0f6cad',
+  /** Darker blues for gradients */
+  brandBlue: '#0f6cad',
+  brandBlueDark: '#0b5d95',
+  brandBlueDarker: '#0a4f7f',
+  /** Accent gold used in logo */
+  gold: '#F2A300',
+};
+
+export const fonts = {
+  sans: "'Inter', sans-serif",
+  serif: "'Merriweather', serif",
+};
+
+export const spacing = {
+  xs: '4px',
+  sm: '8px',
+  md: '16px',
+  lg: '24px',
+  xl: '32px',
+};
+
+import { LOGO_FULL, LOGO_MINI } from './brand';
+
+export const logos = {
+  full: LOGO_FULL,
+  mini: LOGO_MINI,
+};
+
+export default {
+  colors,
+  fonts,
+  spacing,
+  logos,
+};

--- a/frontend/pages/about/index.jsx
+++ b/frontend/pages/about/index.jsx
@@ -2,6 +2,7 @@ import Head from "next/head";
 import Image from "next/image";
 import Link from "next/link";
 import { withCloudinaryAuto } from "@/lib/media";
+import { colors } from "@/lib/brand-tokens";
 
 const EIC = {
   name: "Tatiana Chow",
@@ -41,6 +42,16 @@ const FULL_LOGO = withCloudinaryAuto(
 );
 
 export default function AboutPage() {
+  const brandVars = {
+    "--brand": colors.primary,
+    "--brand-light": colors.primaryLight,
+    "--brand-lighter": colors.primaryLighter,
+    "--brand-tag-bg": colors.primaryTagBg,
+    "--brand-tag-text": colors.primaryTagText,
+    "--brand-soft-from": colors.primarySoftFrom,
+    "--brand-soft-to": colors.primarySoftTo,
+  };
+
   return (
     <>
       <Head>
@@ -54,7 +65,7 @@ export default function AboutPage() {
       {/* HERO */}
       <header
         className="relative grid min-h-[58vh] place-items-center overflow-hidden px-4 text-center text-white"
-        style={{ backgroundImage: "linear-gradient(to bottom, #0f6cad, #0b5d95, #0a4f7f)" }}
+        style={{ backgroundImage: `linear-gradient(to bottom, ${colors.brandBlue}, ${colors.brandBlueDark}, ${colors.brandBlueDarker})` }}
       >
         <div className="mb-4 flex items-center justify-center gap-4">
           <Image src={MINI_LOGO} alt="WaterNews mini logo" width={48} height={48} />
@@ -84,11 +95,11 @@ export default function AboutPage() {
       </header>
 
       {/* BODY */}
-      <main className="mx-auto -mt-14 mb-16 max-w-5xl px-4">
+      <main style={brandVars} className="mx-auto -mt-14 mb-16 max-w-5xl px-4">
         {/* Mission */}
         <section className="mb-12 grid gap-6 rounded-2xl bg-white p-6 shadow-lg md:grid-cols-[1.1fr,0.9fr]">
           <div>
-            <span className="inline-flex items-center gap-2 rounded-full bg-[#e6f2fb] px-3 py-1 text-xs font-semibold text-[#0f6cad]">
+            <span className="inline-flex items-center gap-2 rounded-full bg-[var(--brand-tag-bg)] px-3 py-1 text-xs font-semibold text-[var(--brand-tag-text)]">
               Our Mission
             </span>
             <h2 className="mt-2 text-2xl font-bold">
@@ -105,18 +116,18 @@ export default function AboutPage() {
               <li>✅ Lifestyle features celebrating culture, food, and everyday life</li>
             </ul>
             <div className="mt-4 flex flex-wrap gap-2">
-              <a className="rounded-xl bg-[#1583c2] px-4 py-2 font-semibold text-white" href="#join">
+              <a className="rounded-xl bg-[var(--brand)] px-4 py-2 font-semibold text-white" href="#join">
                 Join Our Team
               </a>
-              <a className="rounded-xl border border-[#cfe6f7] bg-[#eff7fd] px-4 py-2 font-semibold text-[#1583c2]" href="#suggest">
+              <a className="rounded-xl border border-[var(--brand-light)] bg-[var(--brand-lighter)] px-4 py-2 font-semibold text-[var(--brand)]" href="#suggest">
                 Suggest a Story
               </a>
-              <a className="rounded-xl border border-[#cfe6f7] bg-[#eff7fd] px-4 py-2 font-semibold text-[#1583c2]" href="#follow">
+              <a className="rounded-xl border border-[var(--brand-light)] bg-[var(--brand-lighter)] px-4 py-2 font-semibold text-[var(--brand)]" href="#follow">
                 Follow for Updates
               </a>
             </div>
           </div>
-          <div className="grid gap-2 rounded-xl border border-slate-200 bg-gradient-to-br from-[#e8f4fd] to-[#f7fbff] p-4 sm:grid-cols-2">
+          <div className="grid gap-2 rounded-xl border border-slate-200 bg-gradient-to-br from-[var(--brand-soft-from)] to-[var(--brand-soft-to)] p-4 sm:grid-cols-2">
             {COMMUNITY_PHOTOS.map((src, i) => (
               <div key={i} className="relative aspect-video w-full overflow-hidden rounded-md">
                 <Image
@@ -323,10 +334,10 @@ export default function AboutPage() {
               <h4 className="mt-4 text-lg font-semibold">Corrections</h4>
               <p className="text-[15px] text-slate-700">
                 If we publish an error, we will correct it promptly and add a note indicating
-                what changed. Email <a className="text-[#1583c2]" href="mailto:corrections@waternewsgy.com">corrections@waternewsgy.com</a>.
+                what changed. Email <a className="text-[var(--brand)]" href="mailto:corrections@waternewsgy.com">corrections@waternewsgy.com</a>.
               </p>
               <div className="mt-3">
-                <Link href="/about/masthead" className="inline-flex items-center gap-2 rounded-lg border border-[#cfe6f7] bg-[#eff7fd] px-3 py-2 text-sm font-semibold text-[#1583c2]">
+                <Link href="/about/masthead" className="inline-flex items-center gap-2 rounded-lg border border-[var(--brand-light)] bg-[var(--brand-lighter)] px-3 py-2 text-sm font-semibold text-[var(--brand)]">
                   View Masthead &amp; Contacts
                 </Link>
               </div>
@@ -342,10 +353,10 @@ export default function AboutPage() {
             regional storytelling.
           </p>
           <div className="mt-3 flex flex-wrap gap-2">
-            <a className="rounded-xl bg-[#1583c2] px-4 py-2 font-semibold text-white" href="/apply">
+            <a className="rounded-xl bg-[var(--brand)] px-4 py-2 font-semibold text-white" href="/apply">
               Become an Author
             </a>
-            <a className="rounded-xl border border-[#cfe6f7] bg-[#eff7fd] px-4 py-2 font-semibold text-[#1583c2]" href="#suggest">
+            <a className="rounded-xl border border-[var(--brand-light)] bg-[var(--brand-lighter)] px-4 py-2 font-semibold text-[var(--brand)]" href="#suggest">
               Suggest a Story
             </a>
           </div>
@@ -358,7 +369,7 @@ export default function AboutPage() {
             formed pitch.
           </p>
           <div className="mt-3">
-            <a className="rounded-xl border border-[#cfe6f7] bg-[#eff7fd] px-4 py-2 font-semibold text-[#1583c2]" href="mailto:tips@waternewsgy.com">
+            <a className="rounded-xl border border-[var(--brand-light)] bg-[var(--brand-lighter)] px-4 py-2 font-semibold text-[var(--brand)]" href="mailto:tips@waternewsgy.com">
               tips@waternewsgy.com
             </a>
           </div>
@@ -370,16 +381,16 @@ export default function AboutPage() {
             Get the latest headlines and features as they publish.
           </p>
           <div className="mt-3 flex flex-wrap gap-2">
-            <a className="rounded-xl border border-[#cfe6f7] bg-[#eff7fd] px-4 py-2 font-semibold text-[#1583c2]" href="#">
+            <a className="rounded-xl border border-[var(--brand-light)] bg-[var(--brand-lighter)] px-4 py-2 font-semibold text-[var(--brand)]" href="#">
               @WaterNewsGY
             </a>
-            <a className="rounded-xl border border-[#cfe6f7] bg-[#eff7fd] px-4 py-2 font-semibold text-[#1583c2]" href="#">
+            <a className="rounded-xl border border-[var(--brand-light)] bg-[var(--brand-lighter)] px-4 py-2 font-semibold text-[var(--brand)]" href="#">
               Facebook
             </a>
-            <a className="rounded-xl border border-[#cfe6f7] bg-[#eff7fd] px-4 py-2 font-semibold text-[#1583c2]" href="#">
+            <a className="rounded-xl border border-[var(--brand-light)] bg-[var(--brand-lighter)] px-4 py-2 font-semibold text-[var(--brand)]" href="#">
               Instagram
             </a>
-            <a className="rounded-xl border border-[#cfe6f7] bg-[#eff7fd] px-4 py-2 font-semibold text-[#1583c2]" href="#">
+            <a className="rounded-xl border border-[var(--brand-light)] bg-[var(--brand-lighter)] px-4 py-2 font-semibold text-[var(--brand)]" href="#">
               X (Twitter)
             </a>
           </div>

--- a/frontend/pages/about/masthead.jsx
+++ b/frontend/pages/about/masthead.jsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import Script from "next/script";
 import ProfilePhoto from "@/components/User/ProfilePhoto";
 import { withCloudinaryAuto } from "@/lib/media";
+import { colors } from "@/lib/brand-tokens";
 import BrandLogo from "@/components/BrandLogo";
 
 const contacts = [
@@ -58,6 +59,16 @@ const people = [
 ];
 
 export default function MastheadPage() {
+  const brandVars = {
+    "--brand": colors.primary,
+    "--brand-light": colors.primaryLight,
+    "--brand-lighter": colors.primaryLighter,
+    "--brand-soft-from": colors.primarySoftFrom,
+    "--brand-soft-to": colors.primarySoftTo,
+    "--brand-blue": colors.brandBlue,
+    "--brand-blue-dark": colors.brandBlueDark,
+    "--brand-blue-darker": colors.brandBlueDarker,
+  };
   return (
     <>
       <Head>
@@ -99,7 +110,7 @@ export default function MastheadPage() {
         }}
       />
 
-      <header className="bg-gradient-to-b from-[#0f6cad] via-[#0b5d95] to-[#0a4f7f] px-4 py-14 text-white">
+      <header style={brandVars} className="bg-gradient-to-b from-[var(--brand-blue)] via-[var(--brand-blue-dark)] to-[var(--brand-blue-darker)] px-4 py-14 text-white">
         <div className="mx-auto max-w-5xl">
           <div className="mb-5 flex items-center gap-3">
             <BrandLogo variant="mini" onDark size={40} className="rounded-full bg-white/95 p-1" />
@@ -113,7 +124,7 @@ export default function MastheadPage() {
         </div>
       </header>
 
-      <main className="mx-auto my-10 max-w-5xl px-4">
+      <main style={brandVars} className="mx-auto my-10 max-w-5xl px-4">
         {/* Contacts */}
         <section className="mb-10 rounded-2xl bg-white p-6 shadow">
           <h2 className="text-xl font-bold">Contact</h2>
@@ -123,7 +134,7 @@ export default function MastheadPage() {
                 <p className="m-0 text-sm font-semibold">{c.label}</p>
                 <p className="m-0 text-[13px] text-slate-600">{c.description}</p>
                 <a
-                  className="mt-2 inline-block rounded-lg border border-[#cfe6f7] bg-[#eff7fd] px-3 py-1.5 text-sm font-semibold text-[#1583c2]"
+                  className="mt-2 inline-block rounded-lg border border-[var(--brand-light)] bg-[var(--brand-lighter)] px-3 py-1.5 text-sm font-semibold text-[var(--brand)]"
                   href={`mailto:${c.email}`}
                 >
                   {c.email}
@@ -143,7 +154,7 @@ export default function MastheadPage() {
           <div className="grid gap-4 md:grid-cols-3">
             {people.map((p) => (
               <article key={p.name} className="rounded-2xl bg-white p-5 shadow">
-                <div className="grid min-h-[120px] place-items-center rounded-md border border-slate-200 bg-gradient-to-br from-[#e8f4fd] to-[#f7fbff]">
+                <div className="grid min-h-[120px] place-items-center rounded-md border border-slate-200 bg-gradient-to-br from-[var(--brand-soft-from)] to-[var(--brand-soft-to)]">
                   <ProfilePhoto
                     name={p.name}
                     url={p.headshot}
@@ -157,7 +168,7 @@ export default function MastheadPage() {
                 <p className="mt-2 text-[14px] text-slate-700">{p.bio}</p>
                 {p.email && (
                   <a
-                    className="mt-2 inline-block rounded-lg border border-[#cfe6f7] bg-[#eff7fd] px-3 py-1.5 text-sm font-semibold text-[#1583c2]"
+                    className="mt-2 inline-block rounded-lg border border-[var(--brand-light)] bg-[var(--brand-lighter)] px-3 py-1.5 text-sm font-semibold text-[var(--brand)]"
                     href={`mailto:${p.email}`}
                   >
                     {p.email}
@@ -171,18 +182,18 @@ export default function MastheadPage() {
         <section className="rounded-2xl bg-white p-6 shadow">
           <h2 className="text-xl font-bold">Policies &amp; Standards</h2>
           <p className="mt-2 text-[15px] text-slate-700">
-            Read our <Link className="text-[#1583c2]" href="/about#editorial-standards">Editorial Standards &amp; Fact-Check Policy</Link> and how to request corrections.
+            Read our <Link className="text-[var(--brand)]" href="/about#editorial-standards">Editorial Standards &amp; Fact-Check Policy</Link> and how to request corrections.
           </p>
           <div className="mt-3">
             <Link
               href="/about"
-              className="inline-flex items-center gap-2 rounded-lg border border-[#cfe6f7] bg-[#eff7fd] px-3 py-2 text-sm font-semibold text-[#1583c2]"
+              className="inline-flex items-center gap-2 rounded-lg border border-[var(--brand-light)] bg-[var(--brand-lighter)] px-3 py-2 text-sm font-semibold text-[var(--brand)]"
             >
               Back to About WaterNews
             </Link>
             <Link
               href="/contact"
-              className="ml-2 inline-flex items-center gap-2 rounded-lg border border-[#cfe6f7] bg-[#eff7fd] px-3 py-2 text-sm font-semibold text-[#1583c2]"
+              className="ml-2 inline-flex items-center gap-2 rounded-lg border border-[var(--brand-light)] bg-[var(--brand-lighter)] px-3 py-2 text-sm font-semibold text-[var(--brand)]"
             >
               Contact Us
             </Link>

--- a/frontend/pages/contact.jsx
+++ b/frontend/pages/contact.jsx
@@ -5,11 +5,20 @@ import { SUBJECTS } from "@/lib/cms-routing";
 import Toast from "@/components/Toast";
 import Page from "@/components/UX/Page";
 import SectionCard from "@/components/UX/SectionCard";
+import { colors } from "@/lib/brand-tokens";
 
 export default function ContactPage() {
   const [state, setState] = useState({ name: "", email: "", subject: "general", message: "" });
   const [submitting, setSubmitting] = useState(false);
   const [toast, setToast] = useState(null);
+
+  const brandVars = {
+    "--brand": colors.primary,
+    "--brand-light": colors.primaryLight,
+    "--brand-lighter": colors.primaryLighter,
+    "--brand-soft-from": colors.primarySoftFrom,
+    "--brand-soft-to": colors.primarySoftTo,
+  };
 
   async function onSubmit(e) {
     e.preventDefault();
@@ -47,46 +56,49 @@ export default function ContactPage() {
         subtitle="We read every message. For sensitive tips, email and request a secure channel."
       >
         <div className="grid gap-6">
-          <SectionCard className="grid gap-4 md:grid-cols-3">
-            {[
-              {
-                label: "News Tips",
-                email: "tips@waternewsgy.com",
-                desc: "Story ideas, documents, eyewitness info.",
-              },
-              {
-                label: "Corrections",
-                email: "corrections@waternewsgy.com",
-                desc: "Tell us what needs fixing.",
-              },
-              {
-                label: "Partnerships",
-                email: "hello@waternewsgy.com",
-                desc: "Press, events, advertising.",
-              },
-            ].map((c) => (
-              <a
-                key={c.label}
-                href={`mailto:${c.email}`}
-                className="rounded-xl border border-slate-200 bg-white p-5 shadow transition hover:shadow-md"
-              >
-                <p className="m-0 text-sm font-semibold">{c.label}</p>
-                <p className="m-0 text-[13px] text-slate-600">{c.desc}</p>
-                <span className="mt-2 inline-block rounded-lg border border-[#cfe6f7] bg-[#eff7fd] px-3 py-1.5 text-xs font-semibold text-[#1583c2]">
-                  {c.email}
-                </span>
-              </a>
-            ))}
+          <SectionCard>
+            <div style={brandVars} className="grid gap-4 md:grid-cols-3">
+              {[
+                {
+                  label: "News Tips",
+                  email: "tips@waternewsgy.com",
+                  desc: "Story ideas, documents, eyewitness info.",
+                },
+                {
+                  label: "Corrections",
+                  email: "corrections@waternewsgy.com",
+                  desc: "Tell us what needs fixing.",
+                },
+                {
+                  label: "Partnerships",
+                  email: "hello@waternewsgy.com",
+                  desc: "Press, events, advertising.",
+                },
+              ].map((c) => (
+                <a
+                  key={c.label}
+                  href={`mailto:${c.email}`}
+                  className="rounded-xl border border-slate-200 bg-white p-5 shadow transition hover:shadow-md"
+                >
+                  <p className="m-0 text-sm font-semibold">{c.label}</p>
+                  <p className="m-0 text-[13px] text-slate-600">{c.desc}</p>
+                  <span className="mt-2 inline-block rounded-lg border border-[var(--brand-light)] bg-[var(--brand-lighter)] px-3 py-1.5 text-xs font-semibold text-[var(--brand)]">
+                    {c.email}
+                  </span>
+                </a>
+              ))}
+            </div>
           </SectionCard>
 
-          <SectionCard className="grid gap-6 md:grid-cols-[1.1fr,0.9fr]">
+          <SectionCard>
+            <div style={brandVars} className="grid gap-6 md:grid-cols-[1.1fr,0.9fr]">
             <form onSubmit={onSubmit} className="grid gap-3">
               <h2 className="text-xl font-bold">Send us a message</h2>
               <label className="block">
                 <span className="text-sm font-medium">Your name</span>
                 <input
                   required
-                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[var(--brand)] focus:ring-2 focus:ring-[var(--brand-light)]"
                   value={state.name}
                   onChange={(e) => setState((s) => ({ ...s, name: e.target.value }))}
                 />
@@ -96,7 +108,7 @@ export default function ContactPage() {
                 <input
                   required
                   type="email"
-                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[var(--brand)] focus:ring-2 focus:ring-[var(--brand-light)]"
                   value={state.email}
                   onChange={(e) => setState((s) => ({ ...s, email: e.target.value }))}
                 />
@@ -104,7 +116,7 @@ export default function ContactPage() {
               <label className="block">
                 <span className="text-sm font-medium">Subject</span>
                 <select
-                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[var(--brand)] focus:ring-2 focus:ring-[var(--brand-light)]"
                   value={state.subject}
                   onChange={(e) => setState((s) => ({ ...s, subject: e.target.value }))}
                   name="subject"
@@ -121,7 +133,7 @@ export default function ContactPage() {
                 <textarea
                   required
                   rows={6}
-                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[var(--brand)] focus:ring-2 focus:ring-[var(--brand-light)]"
                   value={state.message}
                   onChange={(e) => setState((s) => ({ ...s, message: e.target.value }))}
                 />
@@ -135,18 +147,19 @@ export default function ContactPage() {
               </button>
             </form>
 
-            <aside className="grid place-items-center rounded-xl border border-slate-200 bg-gradient-to-br from-[#e8f4fd] to-[#f7fbff] p-4 text-slate-600">
+            <aside className="grid place-items-center rounded-xl border border-slate-200 bg-gradient-to-br from-[var(--brand-soft-from)] to-[var(--brand-soft-to)] p-4 text-slate-600">
               <div className="text-center">
                 <Image src="/placeholders/community-1.svg" alt="" width={320} height={180} />
                 <p className="mt-3 text-sm">
-                  Prefer social? Follow {" "}
-                  <a className="font-semibold text-[#1583c2]" href="#">
+                  Prefer social? Follow{" "}
+                  <a className="font-semibold text-[var(--brand)]" href="#">
                     @WaterNewsGY
                   </a>{" "}
-                  for headlines & highlights.
+                  for headlines &amp; highlights.
                 </p>
               </div>
             </aside>
+            </div>
           </SectionCard>
         </div>
       </Page>

--- a/frontend/pages/corrections.jsx
+++ b/frontend/pages/corrections.jsx
@@ -5,11 +5,20 @@ import { SUBJECTS } from "@/lib/cms-routing";
 import Toast from "@/components/Toast";
 import Page from "@/components/UX/Page";
 import SectionCard from "@/components/UX/SectionCard";
+import { colors } from "@/lib/brand-tokens";
 
 export default function CorrectionsPage() {
   const [state, setState] = useState({ name: "", email: "", url: "", correction: "", subject: "correction" });
   const [submitting, setSubmitting] = useState(false);
   const [toast, setToast] = useState(null);
+
+  const brandVars = {
+    "--brand": colors.primary,
+    "--brand-light": colors.primaryLight,
+    "--brand-lighter": colors.primaryLighter,
+    "--brand-soft-from": colors.primarySoftFrom,
+    "--brand-soft-to": colors.primarySoftTo,
+  };
 
   async function onSubmit(e) {
     e.preventDefault();
@@ -43,14 +52,15 @@ export default function CorrectionsPage() {
         title="Request a Correction"
         subtitle="We correct the record. Share the link and what needs fixing."
       >
-        <SectionCard className="grid gap-6 md:grid-cols-[1.1fr,0.9fr]">
+        <SectionCard>
+          <div style={brandVars} className="grid gap-6 md:grid-cols-[1.1fr,0.9fr]">
           <form onSubmit={onSubmit} className="grid gap-3">
             <h2 className="text-xl font-bold">Submit a correction</h2>
             <label className="block">
               <span className="text-sm font-medium">Your name</span>
               <input
                 required
-                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[var(--brand)] focus:ring-2 focus:ring-[var(--brand-light)]"
                 value={state.name}
                 onChange={(e) => setState((s) => ({ ...s, name: e.target.value }))}
               />
@@ -60,7 +70,7 @@ export default function CorrectionsPage() {
               <input
                 required
                 type="email"
-                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[var(--brand)] focus:ring-2 focus:ring-[var(--brand-light)]"
                 value={state.email}
                 onChange={(e) => setState((s) => ({ ...s, email: e.target.value }))}
               />
@@ -68,7 +78,7 @@ export default function CorrectionsPage() {
             <label className="block">
               <span className="text-sm font-medium">Subject</span>
               <select
-                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[var(--brand)] focus:ring-2 focus:ring-[var(--brand-light)]"
                 value={state.subject}
                 onChange={(e) => setState((s) => ({ ...s, subject: e.target.value }))}
                 name="subject"
@@ -86,7 +96,7 @@ export default function CorrectionsPage() {
                 required
                 type="url"
                 placeholder="https://waternews…"
-                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[var(--brand)] focus:ring-2 focus:ring-[var(--brand-light)]"
                 value={state.url}
                 onChange={(e) => setState((s) => ({ ...s, url: e.target.value }))}
               />
@@ -96,7 +106,7 @@ export default function CorrectionsPage() {
               <textarea
                 required
                 rows={6}
-                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[#1583c2] focus:ring-2 focus:ring-[#cfe6f7]"
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 outline-none focus:border-[var(--brand)] focus:ring-2 focus:ring-[var(--brand-light)]"
                 value={state.correction}
                 onChange={(e) => setState((s) => ({ ...s, correction: e.target.value }))}
               />
@@ -112,17 +122,18 @@ export default function CorrectionsPage() {
             </div>
           </form>
 
-          <aside className="grid place-items-center rounded-xl border border-slate-200 bg-gradient-to-br from-[#e8f4fd] to-[#f7fbff] p-4 text-slate-600">
+          <aside className="grid place-items-center rounded-xl border border-slate-200 bg-gradient-to-br from-[var(--brand-soft-from)] to-[var(--brand-soft-to)] p-4 text-slate-600">
             <div className="text-center">
               <Image src="/placeholders/newsroom.svg" alt="" width={320} height={180} />
               <p className="mt-3 text-sm">
-                Prefer email? Write {" "}
-                <a className="font-semibold text-[#1583c2]" href="mailto:corrections@waternewsgy.com">
+                Prefer email? Write{" "}
+                <a className="font-semibold text-[var(--brand)]" href="mailto:corrections@waternewsgy.com">
                   corrections@waternewsgy.com
                 </a>
               </p>
             </div>
           </aside>
+          </div>
         </SectionCard>
       </Page>
       {toast && <Toast {...toast} onDone={() => setToast(null)} />}

--- a/frontend/pages/faq.tsx
+++ b/frontend/pages/faq.tsx
@@ -2,8 +2,13 @@ import Head from "next/head";
 import Link from "next/link";
 import Page from "@/components/UX/Page";
 import SectionCard from "@/components/UX/SectionCard";
+import { colors } from "@/lib/brand-tokens";
 
 export default function FAQ() {
+  const brandVars = {
+    "--brand": colors.primary,
+  } as Record<string, string>;
+
   return (
     <>
       <Head>
@@ -15,12 +20,12 @@ export default function FAQ() {
         subtitle="Answers for readers and visitors. For member help, see the NewsRoom dashboard."
       >
         <SectionCard>
-          <div className="space-y-6">
+          <div style={brandVars} className="space-y-6">
             <section>
               <h2 className="font-medium">How do I submit a story tip?</h2>
               <p>
                 Use the{" "}
-                <Link className="font-semibold text-[#1583c2]" href="/suggest-story">
+                <Link className="font-semibold text-[var(--brand)]" href="/suggest-story">
                   Suggest a Story
                 </Link>{" "}
                 page.
@@ -30,7 +35,7 @@ export default function FAQ() {
               <h2 className="font-medium">How do I contact the newsroom?</h2>
               <p>
                 Visit{" "}
-                <Link className="font-semibold text-[#1583c2]" href="/contact">
+                <Link className="font-semibold text-[var(--brand)]" href="/contact">
                   Contact
                 </Link>{" "}
                 for email and forms.
@@ -40,11 +45,11 @@ export default function FAQ() {
               <h2 className="font-medium">Corrections policy?</h2>
               <p>
                 See{" "}
-                <Link className="font-semibold text-[#1583c2]" href="/corrections">
+                <Link className="font-semibold text-[var(--brand)]" href="/corrections">
                   Corrections
                 </Link>{" "}
                 and our{" "}
-                <Link className="font-semibold text-[#1583c2]" href="/editorial-standards">
+                <Link className="font-semibold text-[var(--brand)]" href="/editorial-standards">
                   Editorial Standards
                 </Link>
                 .


### PR DESCRIPTION
## Summary
- add `brand-tokens` module with shared colors, fonts, spacing and logos
- use brand tokens instead of hard-coded hex colors across pages
- document brand token usage in README

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aaa82f8ff08329b004b54c10b36e99