### PR TITLE
Rev.4 — Dynamic Open Graph images (Cloudinary overlays)

### DIFF
--- a/frontend/components/ArticleView.tsx
+++ b/frontend/components/ArticleView.tsx
@@ -7,7 +7,7 @@ import PrevNext from "@/components/PrevNext";
 import ImageLightbox from "@/components/ImageLightbox";
 import { readingTime } from "@/lib/readingTime";
 import { slugify } from "@/lib/slugify";
-import { buildBreadcrumbsJsonLd, buildNewsArticleJsonLd, jsonLdScript } from "@/lib/seo";
+import { buildBreadcrumbsJsonLd, buildNewsArticleJsonLd, jsonLdScript, ogImageForPost } from "@/lib/seo";
 
 export type ArticleViewProps = {
   post: any | null;
@@ -43,6 +43,7 @@ export default function ArticleView({
       ? process.env.NEXT_PUBLIC_SITE_URL || "https://www.waternewsgy.com"
       : window.location.origin;
   const canonicalPath = `/${basePath}/${post.slug}`;
+  const ogImage = ogImageForPost(post);
   const breadcrumbs = buildBreadcrumbsJsonLd(origin, [
     { name: "Home", url: "/" },
     { name: sectionLabel, url: `/${basePath}` },
@@ -53,7 +54,7 @@ export default function ArticleView({
     url: canonicalPath,
     headline: post.title,
     description: post.excerpt || post.description || undefined,
-    image: post.coverImage || post.image || undefined,
+    image: post.coverImage || ogImage || undefined,
     datePublished: post.publishedAt || post.createdAt,
     dateModified: post.updatedAt || undefined,
     section: post.category || post.section || undefined,
@@ -90,6 +91,10 @@ export default function ArticleView({
       <Head>
         <title>{post.title} — WaterNewsGY</title>
         <link rel="canonical" href={`${origin}${canonicalPath}`} />
+        <meta property="og:image" content={ogImage} />
+        <meta name="twitter:image" content={ogImage} />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: jsonLdScript([breadcrumbs, articleLd]) }}

--- a/frontend/lib/og.ts
+++ b/frontend/lib/og.ts
@@ -1,0 +1,59 @@
+import { absoluteUrl } from "@/lib/brand";
+import { OG_DEFAULT, colors } from "@/lib/brand-tokens";
+
+export interface BuildOgParams {
+  title: string;
+  section?: string;
+  author?: string;
+  slug?: string;
+}
+
+function getCloudName(): string | null {
+  const cloudinaryUrl = process.env.CLOUDINARY_URL;
+  if (cloudinaryUrl) {
+    const match = cloudinaryUrl.match(/cloudinary:\/\/[^@]+@([^/]+)/);
+    if (match) return match[1];
+  }
+  return process.env.CLOUDINARY_CLOUD_NAME || null;
+}
+
+const BASE_PUBLIC_ID = process.env.CLOUDINARY_OG_BASE_ID || "waternewsgy/og/base";
+const LOGO_PUBLIC_ID = process.env.CLOUDINARY_LOGO_MARK_ID || "waternewsgy/brand/logo-mark";
+
+function escapeColor(hex: string) {
+  return hex.replace('#', '');
+}
+
+export function buildOgUrl(params: BuildOgParams): string {
+  const generator = process.env.OG_GENERATOR || 'cloudinary';
+  const cloud = getCloudName();
+  if (generator !== 'cloudinary' || !cloud) {
+    return absoluteUrl(OG_DEFAULT);
+  }
+  const { title, section, author } = params;
+  const trunc = title.length > 100 ? `${title.slice(0, 100)}…` : title;
+  const encTitle = encodeURIComponent(trunc);
+  const transforms = [
+    'f_auto,q_auto,w_1200,h_630,c_fill',
+    `l_text:Arial_64_bold:${encTitle},co_rgb:${escapeColor(colors.brandBlueDarker)},g_south_west,x_60,y_140,w_1020,c_fit`,
+  ];
+  if (section) {
+    const encSection = encodeURIComponent(section);
+    transforms.push(`l_text:Arial_32_bold:${encSection},co_rgb:${escapeColor(colors.brandBlue)},g_south_west,x_60,y_220`);
+  }
+  if (author) {
+    const encAuthor = encodeURIComponent(author);
+    transforms.push(`l_text:Arial_28:${encAuthor},co_rgb:666666,g_south_west,x_60,y_80`);
+  }
+  transforms.push(`l_${LOGO_PUBLIC_ID},g_north_east,x_48,y_48,w_120`);
+  const base = `https://res.cloudinary.com/${cloud}/image/upload`;
+  return `${base}/${transforms.join('/')}/${BASE_PUBLIC_ID}`;
+}
+
+export function buildOgForPost(post: any): string {
+  if (!post) return absoluteUrl(OG_DEFAULT);
+  const section = post.section || post.category || (Array.isArray(post.tags) ? post.tags[0] : undefined);
+  const author = post.authorDisplay || post.author || post.byline || post.authorName;
+  return buildOgUrl({ title: post.title || '', section, author, slug: post.slug });
+}
+

--- a/frontend/lib/seo.ts
+++ b/frontend/lib/seo.ts
@@ -3,8 +3,14 @@
 
 import { absoluteUrl, BRAND_NAME } from "@/lib/brand";
 import { LOGO_FULL, OG_DEFAULT } from "@/lib/brand-tokens";
+import { buildOgForPost } from "@/lib/og";
 
 export const DEFAULT_OG_IMAGE = OG_DEFAULT;
+
+export function ogImageForPost(post: any | null) {
+  const maybe = post?.ogImageUrl || (post ? buildOgForPost(post) : null);
+  return maybe || absoluteUrl(OG_DEFAULT);
+}
 
 type Publisher = {
   name: string;

--- a/frontend/models/Post.ts
+++ b/frontend/models/Post.ts
@@ -13,6 +13,7 @@ export interface PostDoc {
   authorId?: string | null;
   engagementScore?: number;
   isBreaking?: boolean;
+  ogImageUrl?: string;
 }
 
 const PostSchema = new Schema<PostDoc>(
@@ -28,6 +29,7 @@ const PostSchema = new Schema<PostDoc>(
     authorId: { type: String, default: null },
     engagementScore: { type: Number, default: 0 },
     isBreaking: { type: Boolean, default: false, index: true },
+    ogImageUrl: { type: String },
   },
   { timestamps: true }
 );

--- a/frontend/pages/api/newsroom/drafts/[id]/publish.js
+++ b/frontend/pages/api/newsroom/drafts/[id]/publish.js
@@ -3,6 +3,7 @@ import { getDb } from '@/lib/db';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/pages/api/auth/[...nextauth]';
 import { slugify } from '@/lib/slugify';
+import { buildOgForPost } from '@/lib/og';
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') return res.status(405).end();
@@ -33,8 +34,9 @@ export default async function handler(req, res) {
     coverImage: draft.coverImage || null,
     status: 'published',
   };
+  post.ogImageUrl = buildOgForPost(post);
   await posts.updateOne({ slug }, { $set: post }, { upsert: true });
   await drafts.updateOne({ _id: draft._id }, { $set: { status: 'published', publishedAt: post.publishedAt, slug } });
-  res.json({ ok: true, slug, url: `/news/${slug}` });
+  res.json({ ok: true, slug, url: `/news/${slug}`, ogImageUrl: post.ogImageUrl });
 }
 

--- a/frontend/pages/api/og/[slug].ts
+++ b/frontend/pages/api/og/[slug].ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { dbConnect } from '@/lib/server/db';
+import Post from '@/models/Post';
+import { buildOgForPost } from '@/lib/og';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.status(405).end();
+    return;
+  }
+  const { slug } = req.query;
+  if (!slug || Array.isArray(slug)) {
+    res.status(400).json({ error: 'Invalid slug' });
+    return;
+  }
+  await dbConnect();
+  const post = await Post.findOne({ slug }).lean();
+  if (!post) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  const url = buildOgForPost(post);
+  res.setHeader('Cache-Control', 'public, s-maxage=86400, stale-while-revalidate=86400');
+  res.status(302).setHeader('Location', url);
+  res.end();
+}


### PR DESCRIPTION
## Summary
- introduce Cloudinary-based `buildOgUrl` helper and `buildOgForPost` convenience for article OG images
- add `/api/og/[slug]` endpoint that redirects to computed Cloudinary image
- wire articles and publishing flow to use/persist dynamic OG images with fallback to default

## Testing
- `npm test --prefix frontend`
- `npm run typecheck --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68aabad6e04883299768425d8bd939a3