### PR TITLE
Remove BrandLogo from hero sections

### DIFF
--- a/frontend/components/UX/Page.tsx
+++ b/frontend/components/UX/Page.tsx
@@ -1,4 +1,3 @@
-import BrandLogo from "@/components/BrandLogo";
 import { colors } from "@/lib/brand-tokens";
 
 export default function Page({
@@ -15,14 +14,11 @@ export default function Page({
   return (
     <>
       <header
-        className="relative grid min-h-[40vh] place-items-center overflow-hidden px-4 text-center text-white"
+        className="relative grid min-h-[40vh] place-items-center overflow-hidden px-4 pt-16 text-center text-white"
         style={{
           backgroundImage: `linear-gradient(to bottom, ${colors.brandBlue}, ${colors.brandBlueDark}, ${colors.brandBlueDarker})`,
         }}
       >
-        <div className="mb-4 flex items-center justify-center">
-          <BrandLogo variant="mark" width={48} height={48} />
-        </div>
         <h1 className="m-0 text-3xl font-extrabold leading-tight md:text-5xl">{title}</h1>
         {subtitle && (
           <p className="mt-2 font-serif text-base opacity-95 md:text-lg">{subtitle}</p>

--- a/frontend/pages/about/index.jsx
+++ b/frontend/pages/about/index.jsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import Image from "next/image";
 import Script from "next/script";
 import SectionCard from "@/components/UX/SectionCard";
-import BrandLogo from "@/components/BrandLogo";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
 import { aboutPageJsonLd } from "@/lib/seo";
@@ -101,13 +100,12 @@ export default function AboutPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(aboutPageJsonLd()) }}
       />
       <header
-        className="relative grid min-h-[58vh] place-items-center overflow-hidden px-4 text-center text-white"
+        className="relative grid min-h-[58vh] place-items-center overflow-hidden px-4 pt-16 text-center text-white"
         style={{
           backgroundImage: `linear-gradient(to bottom, ${colors.brandBlue}, ${colors.brandBlueDark}, ${colors.brandBlueDarker})`,
         }}
       >
-        <BrandLogo variant="mark" width={56} height={56} />
-        <h1 className="mt-4 text-4xl font-extrabold">About WaterNews</h1>
+        <h1 className="text-4xl font-extrabold">About WaterNews</h1>
         <p className="mt-2 font-serif text-base opacity-95 md:text-lg">
           Dive Into Current Stories — giving Guyanese, Caribbean, and diaspora voices a modern platform.
         </p>
@@ -295,9 +293,8 @@ export default function AboutPage() {
           </SectionCard>
         </div>
       </main>
-      <footer className="px-4 pb-16 text-center text-slate-500">
-        <BrandLogo variant="mark" width={36} height={36} className="mx-auto rounded-full" />
-        <div className="mt-2">&copy; {new Date().getFullYear()} WaterNews — All rights reserved.</div>
+      <footer className="px-4 py-16 text-center text-slate-500">
+        <div>&copy; {new Date().getFullYear()} WaterNews — All rights reserved.</div>
       </footer>
     </>
   );

--- a/frontend/pages/about/leadership.jsx
+++ b/frontend/pages/about/leadership.jsx
@@ -2,7 +2,6 @@ import Head from "next/head";
 import Link from "next/link";
 import Image from "next/image";
 import SectionCard from "@/components/UX/SectionCard";
-import BrandLogo from "@/components/BrandLogo";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
 
@@ -49,11 +48,10 @@ export default function LeadershipPage() {
         <meta name="description" content="Meet the executives guiding WaterNews." />
       </Head>
       <header
-        className="relative grid min-h-[40vh] place-items-center overflow-hidden px-4 text-center text-white"
+        className="relative grid min-h-[40vh] place-items-center overflow-hidden px-4 pt-16 text-center text-white"
         style={{ backgroundImage: `linear-gradient(to bottom, ${colors.brandBlue}, ${colors.brandBlueDark}, ${colors.brandBlueDarker})` }}
       >
-        <BrandLogo variant="mark" width={56} height={56} />
-        <h1 className="mt-4 text-4xl font-extrabold">Leadership Team</h1>
+        <h1 className="text-4xl font-extrabold">Leadership Team</h1>
       </header>
       <main style={brandVars} className="mx-auto -mt-12 mb-16 max-w-5xl px-4">
         <SectionCard>
@@ -87,9 +85,8 @@ export default function LeadershipPage() {
           </div>
         </SectionCard>
       </main>
-      <footer className="px-4 pb-16 text-center text-slate-500">
-        <BrandLogo variant="mark" width={36} height={36} className="mx-auto rounded-full" />
-        <div className="mt-2">&copy; {new Date().getFullYear()} WaterNews — All rights reserved.</div>
+      <footer className="px-4 py-16 text-center text-slate-500">
+        <div>&copy; {new Date().getFullYear()} WaterNews — All rights reserved.</div>
       </footer>
     </>
   );

--- a/frontend/pages/about/masthead.jsx
+++ b/frontend/pages/about/masthead.jsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import ProfilePhoto from "@/components/User/ProfilePhoto";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
-import BrandLogo from "@/components/BrandLogo";
 
 const team = [
   {
@@ -58,13 +57,8 @@ export default function MastheadPage() {
         className="bg-gradient-to-b from-[var(--brand-blue)] via-[var(--brand-blue-dark)] to-[var(--brand-blue-darker)] px-4 py-14 text-white"
       >
         <div className="mx-auto max-w-5xl">
-          <div className="mb-5 flex items-center gap-3">
-            <BrandLogo variant="mark" width={40} height={40} className="rounded-full bg-white/95 p-1" />
-            <h1 className="m-0 text-3xl font-extrabold leading-tight md:text-5xl">
-              Masthead &amp; News Team
-            </h1>
-          </div>
-          <p className="max-w-3xl text-sm md:text-base opacity-95">
+          <h1 className="mb-5 text-3xl font-extrabold leading-tight md:text-5xl">Masthead &amp; News Team</h1>
+          <p className="max-w-3xl text-sm opacity-95 md:text-base">
             Meet the journalists and staff behind WaterNews.
           </p>
         </div>
@@ -73,10 +67,7 @@ export default function MastheadPage() {
       <main style={brandVars} className="mx-auto my-10 max-w-5xl px-4">
         {/* News Team */}
         <section className="mb-10">
-          <div className="mb-3 flex items-center gap-3">
-            <BrandLogo variant="mark" width={28} height={28} />
-            <h2 className="m-0 text-xl font-bold">News Team</h2>
-          </div>
+          <h2 className="mb-3 text-xl font-bold">News Team</h2>
 
           <input
             placeholder="Search by name"
@@ -170,9 +161,8 @@ export default function MastheadPage() {
         </section>
       </main>
 
-      <footer className="px-4 pb-16 text-center text-slate-500">
-        <BrandLogo variant="mark" width={36} height={36} className="mx-auto rounded-full" />
-        <div className="mt-2">&copy; {new Date().getFullYear()} WaterNews — All rights reserved.</div>
+      <footer className="px-4 py-16 text-center text-slate-500">
+        <div>&copy; {new Date().getFullYear()} WaterNews — All rights reserved.</div>
       </footer>
     </>
   );

--- a/frontend/pages/careers.jsx
+++ b/frontend/pages/careers.jsx
@@ -1,7 +1,6 @@
 import Head from "next/head";
 import Link from "next/link";
 import SectionCard from "@/components/UX/SectionCard";
-import BrandLogo from "@/components/BrandLogo";
 import { colors } from "@/lib/brand-tokens";
 
 export default function CareersPage() {
@@ -12,11 +11,10 @@ export default function CareersPage() {
         <meta name="description" content="Join the WaterNews team." />
       </Head>
       <header
-        className="relative grid min-h-[40vh] place-items-center overflow-hidden px-4 text-center text-white"
+        className="relative grid min-h-[40vh] place-items-center overflow-hidden px-4 pt-16 text-center text-white"
         style={{ backgroundImage: `linear-gradient(to bottom, ${colors.brandBlue}, ${colors.brandBlueDark}, ${colors.brandBlueDarker})` }}
       >
-        <BrandLogo variant="mark" width={56} height={56} />
-        <h1 className="mt-4 text-4xl font-extrabold">Careers</h1>
+        <h1 className="text-4xl font-extrabold">Careers</h1>
       </header>
       <main className="mx-auto -mt-12 mb-16 max-w-4xl px-4">
         <SectionCard className="mb-8">
@@ -38,9 +36,8 @@ export default function CareersPage() {
           </Link>
         </SectionCard>
       </main>
-      <footer className="px-4 pb-16 text-center text-slate-500">
-        <BrandLogo variant="mark" width={36} height={36} className="mx-auto rounded-full" />
-        <div className="mt-2">&copy; {new Date().getFullYear()} WaterNews — All rights reserved.</div>
+      <footer className="px-4 py-16 text-center text-slate-500">
+        <div>&copy; {new Date().getFullYear()} WaterNews — All rights reserved.</div>
       </footer>
     </>
   );


### PR DESCRIPTION
## Summary
- remove `BrandLogo` from shared hero Page component
- strip logos from About, Leadership, Masthead and Careers pages and adjust spacing

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68abd899053c8329a1fdaf0fa0624a9a