### PR TITLE
feat: add noindex meta for preview pages

### DIFF
--- a/frontend/components/ArticleView.tsx
+++ b/frontend/components/ArticleView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import Head from "next/head";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import RelatedRail from "@/components/RelatedRail";
 import ShareRow from "@/components/ShareRow";
 import PrevNext from "@/components/PrevNext";
@@ -24,6 +25,7 @@ export default function ArticleView({
   basePath = "news",
   sectionLabel = "News",
 }: ArticleViewProps) {
+  const router = useRouter();
   const [zoomSrc, setZoomSrc] = useState<string | null>(null);
 
   if (!post) {
@@ -44,6 +46,7 @@ export default function ArticleView({
       : window.location.origin;
   const canonicalPath = `/${basePath}/${post.slug}`;
   const ogImage = ogImageForPost(post);
+  const isPreview = router.query.preview !== undefined;
   const breadcrumbs = buildBreadcrumbsJsonLd(origin, [
     { name: "Home", url: "/" },
     { name: sectionLabel, url: `/${basePath}` },
@@ -90,7 +93,8 @@ export default function ArticleView({
     <>
       <Head>
         <title>{post.title} — WaterNewsGY</title>
-        <link rel="canonical" href={`${origin}${canonicalPath}`} />
+        {!isPreview && <link rel="canonical" href={`${origin}${canonicalPath}`} />}
+        {isPreview && <meta name="robots" content="noindex" />}
         <meta property="og:image" content={ogImage} />
         <meta name="twitter:image" content={ogImage} />
         <meta property="og:image:width" content="1200" />

--- a/frontend/pages/admin/drafts/[id].jsx
+++ b/frontend/pages/admin/drafts/[id].jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import Head from "next/head";
 import { useRouter } from "next/router";
 import SharedEditor from "@/components/Newsroom/SharedEditor";
 
@@ -13,6 +14,7 @@ function useDebouncedCallback(cb, delay=600) {
 export default function DraftEditor() {
   const { query } = useRouter();
   const { id } = query;
+  const isPreview = query.preview !== undefined;
   const [item, setItem] = useState(null);
   const [saving, setSaving] = useState(false);
   const [threadUrl, setThreadUrl] = useState(null);
@@ -56,10 +58,19 @@ export default function DraftEditor() {
     setSaving(false);
   }, 600);
 
-  if (!item) return <div className="p-6">Loading…</div>;
+  if (!item) {
+    return (
+      <>
+        <Head>{isPreview && <meta name="robots" content="noindex" />}</Head>
+        <div className="p-6">Loading…</div>
+      </>
+    );
+  }
 
   return (
-    <div className="p-6">
+    <>
+      <Head>{isPreview && <meta name="robots" content="noindex" />}</Head>
+      <div className="p-6">
       <div className="flex items-center gap-3 max-w-4xl">
         <input
           className="w-full text-xl font-semibold border-b focus:outline-none"
@@ -153,5 +164,6 @@ export default function DraftEditor() {
         }
       />
     </div>
+    </>
   );
 }

--- a/frontend/pages/newsroom/drafts/[id].tsx
+++ b/frontend/pages/newsroom/drafts/[id].tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import type { GetServerSideProps } from "next";
+import Head from "next/head";
 import { useRouter } from "next/router";
 import { requireAuthSSR } from "@/lib/user-guard";
 import Page from "@/components/UX/Page";
@@ -10,6 +11,7 @@ export const getServerSideProps: GetServerSideProps = (ctx) => requireAuthSSR(ct
 export default function DraftEditor() {
   const router = useRouter();
   const { id } = router.query as { id?: string };
+  const isPreview = router.query.preview !== undefined;
   const [draft, setDraft] = useState<any>(null);
 
   useEffect(() => {
@@ -66,23 +68,26 @@ export default function DraftEditor() {
   }
 
   return (
-    <Page title="Editor" subtitle="Write, attach media, and publish">
+    <>
+      <Head>{isPreview && <meta name="robots" content="noindex" />}</Head>
+      <Page title="Editor" subtitle="Write, attach media, and publish">
       <SharedEditor
         title={draft?.title}
         value={draft?.body || ""}
         onChange={onChange}
         status={draft?.status || "draft"}
-        onStatusChange={(s) => {
-          const next = { ...draft, status: s };
-          setDraft(next);
-          save(next);
-        }}
-        draftId={draft?._id}
+          onStatusChange={(s) => {
+            const next = { ...draft, status: s };
+            setDraft(next);
+            save(next);
+          }}
+          draftId={draft?._id}
         scheduleAt={draft?.publishAt || draft?.scheduledFor || null}
         onPreview={onPreview}
         onSubmit={onSubmit}
         onPublish={onPublish}
       />
     </Page>
+  </>
   );
 }


### PR DESCRIPTION
## Summary
- prevent search engines indexing preview pages with `meta name="robots" content="noindex"`
- gate canonical links during article previews to reduce SEO confusion

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68abf62badc88329b5ac323fc27bdd44