### PR TITLE
Add structured JSON-LD for site, pages and articles

### DIFF
--- a/frontend/components/ArticleView.tsx
+++ b/frontend/components/ArticleView.tsx
@@ -38,6 +38,7 @@ export default function ArticleView({
   const read = readingTime(post?.content || "").minutes;
   const authorName: string | undefined = post?.author || post?.byline;
   const authorSlug = authorName ? slugify(authorName) : null;
+  const authorUrl = authorSlug ? `/author/${authorSlug}` : undefined;
   const origin =
     typeof window === "undefined"
       ? process.env.NEXT_PUBLIC_SITE_URL || "https://www.waternewsgy.com"
@@ -60,6 +61,7 @@ export default function ArticleView({
     section: post.category || post.section || undefined,
     keywords: Array.isArray(post.tags) ? post.tags : undefined,
     authorName,
+    authorUrl,
   });
 
   // Attach click-to-zoom on images inside the article body

--- a/frontend/lib/seo.ts
+++ b/frontend/lib/seo.ts
@@ -28,12 +28,25 @@ export function getPublisher(origin: string): Publisher {
 }
 
 // Organization JSON-LD with a square logo (>=112x112).
-export function orgJsonLd() {
+export function orgJsonLd(origin: string) {
+  const url = origin || "https://www.waternewsgy.com";
   return {
     "@context": "https://schema.org",
     "@type": "Organization",
     name: BRAND_NAME,
+    url,
     logo: absoluteUrl(LOGO_FULL),
+  };
+}
+
+// WebSite JSON-LD for global site identity.
+export function webSiteJsonLd(origin: string) {
+  const url = origin || "https://www.waternewsgy.com";
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: BRAND_NAME,
+    url,
   };
 }
 
@@ -78,6 +91,17 @@ export function buildBreadcrumbsJsonLd(origin: string, items: Array<{ name: stri
   };
 }
 
+// Convenience builder for common page-level breadcrumbs: Home → section → page.
+export function pageBreadcrumbsJsonLd(
+  origin: string,
+  section: { name: string; url: string },
+  page?: { name: string; url: string }
+) {
+  const items = [{ name: "Home", url: "/" }, section];
+  if (page) items.push(page);
+  return buildBreadcrumbsJsonLd(origin, items);
+}
+
 export function buildNewsArticleJsonLd(params: {
   origin: string;
   url: string;
@@ -89,6 +113,7 @@ export function buildNewsArticleJsonLd(params: {
   section?: string;
   keywords?: string[];
   authorName?: string;
+  authorUrl?: string;
 }) {
   const {
     origin,
@@ -101,6 +126,7 @@ export function buildNewsArticleJsonLd(params: {
     section,
     keywords,
     authorName,
+    authorUrl,
   } = params;
   const publisher = getPublisher(origin);
   const canonical = url.startsWith("http") ? url : `${origin}${url}`;
@@ -116,7 +142,15 @@ export function buildNewsArticleJsonLd(params: {
     ...(dateModified ? { dateModified } : {}),
     ...(section ? { articleSection: section } : {}),
     ...(keywords && keywords.length ? { keywords: keywords.join(", ") } : {}),
-    author: authorName ? { "@type": "Person", name: authorName } : undefined,
+    author: authorName
+      ? {
+          "@type": "Person",
+          name: authorName,
+          ...(authorUrl
+            ? { url: authorUrl.startsWith("http") ? authorUrl : `${origin}${authorUrl}` }
+            : {}),
+        }
+      : undefined,
     publisher: {
       "@type": "Organization",
       name: publisher.name,

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -6,8 +6,15 @@ import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import ShellProvider from '@/components/Newsroom/ShellContext';
 import GlobalShell from '@/components/Newsroom/GlobalShell';
+import { jsonLdScript, orgJsonLd, webSiteJsonLd } from '@/lib/seo';
 
 export default function App({ Component, pageProps: { session, ...pageProps } }: AppProps) {
+  const origin =
+    typeof window === 'undefined'
+      ? process.env.NEXT_PUBLIC_SITE_URL || 'https://www.waternewsgy.com'
+      : window.location.origin;
+  const orgLd = orgJsonLd(origin);
+  const siteLd = webSiteJsonLd(origin);
   return (
     <>
       <Head>
@@ -15,6 +22,10 @@ export default function App({ Component, pageProps: { session, ...pageProps } }:
         <link rel="preconnect" href="https://waternews.onrender.com" />
         {/* Example: if you serve images or fonts from a CDN, add it here */}
         {/* <link rel="preconnect" href="https://cdn.example.com" crossOrigin="anonymous" /> */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: jsonLdScript([orgLd, siteLd]) }}
+        />
       </Head>
       <SessionProvider session={session}>
         <ShellProvider>

--- a/frontend/pages/about/index.jsx
+++ b/frontend/pages/about/index.jsx
@@ -5,7 +5,7 @@ import Script from "next/script";
 import SectionCard from "@/components/UX/SectionCard";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
-import { aboutPageJsonLd } from "@/lib/seo";
+import { aboutPageJsonLd, jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
 
 const leaders = [
   {
@@ -119,6 +119,12 @@ export default function AboutPage() {
     "--brand-tag-text": colors.primaryTagText,
   };
 
+  const origin =
+    typeof window === "undefined"
+      ? process.env.NEXT_PUBLIC_SITE_URL || "https://www.waternewsgy.com"
+      : window.location.origin;
+  const breadcrumbs = pageBreadcrumbsJsonLd(origin, { name: "About", url: "/about" });
+
   return (
     <>
       <Head>
@@ -131,7 +137,7 @@ export default function AboutPage() {
       <Script
         id="about-jsonld"
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(aboutPageJsonLd()) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdScript([aboutPageJsonLd(), breadcrumbs]) }}
       />
       <header
         className="relative grid min-h-[58vh] place-items-center overflow-hidden px-4 pt-16 text-center text-white"

--- a/frontend/pages/about/leadership.jsx
+++ b/frontend/pages/about/leadership.jsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import SectionCard from "@/components/UX/SectionCard";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
+import { jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
 
 const leaders = [
   {
@@ -41,11 +42,21 @@ export default function LeadershipPage() {
     "--brand-soft-from": colors.primarySoftFrom,
     "--brand-soft-to": colors.primarySoftTo,
   };
+  const origin =
+    typeof window === "undefined"
+      ? process.env.NEXT_PUBLIC_SITE_URL || "https://www.waternewsgy.com"
+      : window.location.origin;
+  const breadcrumbs = pageBreadcrumbsJsonLd(origin, { name: "About", url: "/about" }, { name: "Leadership Team", url: "/about/leadership" });
+
   return (
     <>
       <Head>
         <title>Leadership Team — WaterNews</title>
         <meta name="description" content="Meet the executives guiding WaterNews." />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: jsonLdScript(breadcrumbs) }}
+        />
       </Head>
       <header
         className="relative grid min-h-[40vh] place-items-center overflow-hidden px-4 pt-16 text-center text-white"

--- a/frontend/pages/about/masthead.jsx
+++ b/frontend/pages/about/masthead.jsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import ProfilePhoto from "@/components/User/ProfilePhoto";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
+import { jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
 
 const team = [
   {
@@ -45,11 +46,20 @@ export default function MastheadPage() {
     "--brand-blue-darker": colors.brandBlueDarker,
   };
   const filtered = team.filter((p) => p.name.toLowerCase().includes(query.toLowerCase()));
+  const origin =
+    typeof window === "undefined"
+      ? process.env.NEXT_PUBLIC_SITE_URL || "https://www.waternewsgy.com"
+      : window.location.origin;
+  const breadcrumbs = pageBreadcrumbsJsonLd(origin, { name: "About", url: "/about" }, { name: "Masthead & News Team", url: "/about/masthead" });
   return (
     <>
       <Head>
         <title>Masthead & News Team — WaterNews</title>
         <meta name="description" content="WaterNews masthead and newsroom staff." />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: jsonLdScript(breadcrumbs) }}
+        />
       </Head>
 
       <header

--- a/frontend/pages/contact.jsx
+++ b/frontend/pages/contact.jsx
@@ -6,6 +6,7 @@ import Page from "@/components/UX/Page";
 import Toast from "@/components/Toast";
 import { SUBJECTS } from "@/lib/cms-routing";
 import contactCopy from "@/lib/copy/contact";
+import { jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
 
 export default function ContactPage() {
   const router = useRouter();
@@ -53,11 +54,21 @@ export default function ContactPage() {
     }
   }
 
+  const origin =
+    typeof window === "undefined"
+      ? process.env.NEXT_PUBLIC_SITE_URL || "https://www.waternewsgy.com"
+      : window.location.origin;
+  const breadcrumbs = pageBreadcrumbsJsonLd(origin, { name: "Contact", url: "/contact" });
+
   return (
     <>
       <Head>
         <title>{current.hero.title} — WaterNews</title>
         <meta name="description" content={current.hero.subtitle} />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: jsonLdScript(breadcrumbs) }}
+        />
       </Head>
       <Page title={current.hero.title} subtitle={current.hero.subtitle} style={{ minHeight: "70vh" }}>
         <SectionCard>


### PR DESCRIPTION
## Summary
- add WebSite and page breadcrumb builders and extend article JSON-LD
- embed Organization/WebSite structured data globally
- output breadcrumb JSON-LD on About, Leadership, Masthead and Contact pages

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68abf62c519c8329810e625720dd47ba