### PR TITLE
Add canonical URL helper and tags

### DIFF
--- a/frontend/components/ArticleView.tsx
+++ b/frontend/components/ArticleView.tsx
@@ -7,7 +7,13 @@ import PrevNext from "@/components/PrevNext";
 import ImageLightbox from "@/components/ImageLightbox";
 import { readingTime } from "@/lib/readingTime";
 import { slugify } from "@/lib/slugify";
-import { buildBreadcrumbsJsonLd, buildNewsArticleJsonLd, jsonLdScript, ogImageForPost } from "@/lib/seo";
+import {
+  buildBreadcrumbsJsonLd,
+  buildNewsArticleJsonLd,
+  canonicalHref,
+  jsonLdScript,
+  ogImageForPost,
+} from "@/lib/seo";
 
 export type ArticleViewProps = {
   post: any | null;
@@ -90,7 +96,7 @@ export default function ArticleView({
     <>
       <Head>
         <title>{post.title} — WaterNewsGY</title>
-        <link rel="canonical" href={`${origin}${canonicalPath}`} />
+        <link rel="canonical" href={canonicalHref(canonicalPath)} />
         <meta property="og:image" content={ogImage} />
         <meta name="twitter:image" content={ogImage} />
         <meta property="og:image:width" content="1200" />

--- a/frontend/lib/seo.ts
+++ b/frontend/lib/seo.ts
@@ -12,6 +12,11 @@ export function ogImageForPost(post: any | null) {
   return maybe || absoluteUrl(OG_DEFAULT);
 }
 
+// Build an absolute URL for use in canonical link tags
+export function canonicalHref(path: string) {
+  return absoluteUrl(path || "/");
+}
+
 type Publisher = {
   name: string;
   logoUrl: string;

--- a/frontend/pages/about/index.jsx
+++ b/frontend/pages/about/index.jsx
@@ -5,7 +5,7 @@ import Script from "next/script";
 import SectionCard from "@/components/UX/SectionCard";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
-import { aboutPageJsonLd } from "@/lib/seo";
+import { aboutPageJsonLd, canonicalHref } from "@/lib/seo";
 
 const leaders = [
   {
@@ -127,6 +127,7 @@ export default function AboutPage() {
           name="description"
           content="WaterNews gives Guyanese, Caribbean, and diaspora voices a modern platform for verified news, opinion, and lifestyle stories."
         />
+        <link rel="canonical" href={canonicalHref("/about")} />
       </Head>
       <Script
         id="about-jsonld"

--- a/frontend/pages/about/leadership.jsx
+++ b/frontend/pages/about/leadership.jsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import SectionCard from "@/components/UX/SectionCard";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
+import { canonicalHref } from "@/lib/seo";
 
 const leaders = [
   {
@@ -46,6 +47,7 @@ export default function LeadershipPage() {
       <Head>
         <title>Leadership Team — WaterNews</title>
         <meta name="description" content="Meet the executives guiding WaterNews." />
+        <link rel="canonical" href={canonicalHref("/about/leadership")} />
       </Head>
       <header
         className="relative grid min-h-[40vh] place-items-center overflow-hidden px-4 pt-16 text-center text-white"

--- a/frontend/pages/about/masthead.jsx
+++ b/frontend/pages/about/masthead.jsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import ProfilePhoto from "@/components/User/ProfilePhoto";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
+import { canonicalHref } from "@/lib/seo";
 
 const team = [
   {
@@ -50,6 +51,7 @@ export default function MastheadPage() {
       <Head>
         <title>Masthead & News Team — WaterNews</title>
         <meta name="description" content="WaterNews masthead and newsroom staff." />
+        <link rel="canonical" href={canonicalHref("/about/masthead")} />
       </Head>
 
       <header

--- a/frontend/pages/contact.jsx
+++ b/frontend/pages/contact.jsx
@@ -6,6 +6,7 @@ import Page from "@/components/UX/Page";
 import Toast from "@/components/Toast";
 import { SUBJECTS } from "@/lib/cms-routing";
 import contactCopy from "@/lib/copy/contact";
+import { canonicalHref } from "@/lib/seo";
 
 export default function ContactPage() {
   const router = useRouter();
@@ -58,6 +59,7 @@ export default function ContactPage() {
       <Head>
         <title>{current.hero.title} — WaterNews</title>
         <meta name="description" content={current.hero.subtitle} />
+        <link rel="canonical" href={canonicalHref("/contact")} />
       </Head>
       <Page title={current.hero.title} subtitle={current.hero.subtitle} style={{ minHeight: "70vh" }}>
         <SectionCard>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import Head from 'next/head'
 import { useRouter } from 'next/router'
 import axios from 'axios'
 import Hero from '../components/Hero'
@@ -6,6 +7,7 @@ import MasonryFeed from '../components/MasonryFeed'
 import dynamic from 'next/dynamic'
 import RecircSkeleton from '@/components/Recirculation/RecircSkeleton'
 import { getFollowedAuthors, getFollowedTags, toggleFollowAuthor, toggleFollowTag, syncFollowsIfAuthed, pushServerFollows } from '../utils/follow'
+import { canonicalHref } from '@/lib/seo'
 
 const RecircWidget = dynamic(() => import('@/components/Recirculation/RecircWidget'), { ssr: false, loading: () => <RecircSkeleton /> })
 const TrendingRail = dynamic(() => import('@/components/Recirculation/TrendingRail'), { ssr: false, loading: () => <RecircSkeleton /> })
@@ -149,8 +151,12 @@ export default function HomePage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="px-3 py-4 md:px-4 max-w-7xl mx-auto">
+    <>
+      <Head>
+        <link rel="canonical" href={canonicalHref('/')} />
+      </Head>
+      <div className="min-h-screen bg-gray-50">
+        <div className="px-3 py-4 md:px-4 max-w-7xl mx-auto">
         {/* Contextual hero */}
           <Hero
             category={activeCategory}
@@ -181,7 +187,8 @@ export default function HomePage() {
               <MasonryFeed items={articles} />
             </div>
         }
+        </div>
       </div>
-    </div>
+    </>
   )
 }

--- a/frontend/pages/privacy.tsx
+++ b/frontend/pages/privacy.tsx
@@ -1,15 +1,22 @@
 import React from "react";
+import Head from "next/head";
 import Page from "@/components/UX/Page";
 import SectionCard from "@/components/UX/SectionCard";
 import Callout from "@/components/UX/Callout";
+import { canonicalHref } from "@/lib/seo";
 
 export default function Privacy() {
   return (
-    <Page title="Privacy Policy" subtitle="How we collect, use, and protect your data.">
-      <div className="grid gap-6">
-        <Callout variant="info">
-          We keep things simple: only what’s necessary to run the site and improve your experience.
-        </Callout>
+    <>
+      <Head>
+        <title>Privacy Policy — WaterNews</title>
+        <link rel="canonical" href={canonicalHref("/privacy")} />
+      </Head>
+      <Page title="Privacy Policy" subtitle="How we collect, use, and protect your data.">
+        <div className="grid gap-6">
+          <Callout variant="info">
+            We keep things simple: only what’s necessary to run the site and improve your experience.
+          </Callout>
         <SectionCard>
           <div className="prose max-w-none">
             <h3>What we collect</h3>
@@ -50,6 +57,7 @@ export default function Privacy() {
           </div>
         </SectionCard>
       </div>
-    </Page>
+      </Page>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add `canonicalHref` helper for absolute URLs
- include canonical `<link>` tags on static pages
- use helper in article view to keep slug-based canonical URLs

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68abf62e01b483299e0466c9c9ad9cc0