### PR TITLE
Expand tap targets for newsroom buttons

### DIFF
--- a/frontend/components/Newsroom/GlobalShell.tsx
+++ b/frontend/components/Newsroom/GlobalShell.tsx
@@ -160,7 +160,7 @@ function MobileTopBar() {
         </button>
         <button
           onClick={openMobile}
-          className="ml-auto inline-flex items-center justify-center w-9 h-9 rounded-md border bg-white hover:bg-gray-50"
+          className="ml-auto inline-flex items-center justify-center w-11 h-11 p-3 rounded-md border bg-white hover:bg-gray-50"
           aria-label="Open Newsroom menu"
           title="Open menu"
         >
@@ -272,7 +272,7 @@ function MobileDrawer({ children }: { children: React.ReactNode }) {
           <span className="font-semibold">NewsRoom</span>
           <button
             onClick={closeMobile}
-            className="inline-flex items-center justify-center w-9 h-9 rounded-md border bg-white hover:bg-gray-50"
+            className="inline-flex items-center justify-center w-11 h-11 p-3 rounded-md border bg-white hover:bg-gray-50"
             aria-label="Close Newsroom menu"
             title="Close"
             ref={setInitialButton as any}

--- a/frontend/components/Newsroom/SharedEditor.tsx
+++ b/frontend/components/Newsroom/SharedEditor.tsx
@@ -136,7 +136,7 @@ export default function SharedEditor({
           <div className="flex items-center gap-3 min-w-0">
             <button
               onClick={() => router.push("/newsroom/writer-dashboard")}
-              className="shrink-0 inline-flex items-center justify-center w-8 h-8 rounded-md border hover:bg-gray-50"
+              className="shrink-0 inline-flex items-center justify-center w-11 h-11 p-2.5 rounded-md border hover:bg-gray-50"
               aria-label="Back to Newsroom"
               title="Back to Newsroom"
             >


### PR DESCRIPTION
## Summary
- enlarge editor back button to 44px and add padding for tap-friendly size
- increase mobile menu buttons to 44px square with extra padding for accessibility

## Testing
- `npm test`
- `npm run typecheck`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abf826999c8329b0ea753fe70c46d0