### PR TITLE
Fix TypeScript custom property errors on about pages

### DIFF
--- a/frontend/pages/about/index.tsx
+++ b/frontend/pages/about/index.tsx
@@ -6,9 +6,10 @@ import SectionCard from "@/components/UX/SectionCard";
 import { colors } from "@/lib/brand-tokens";
 import { aboutPageJsonLd, jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
 import aboutCopy from "@/lib/copy/about";
+import type { CSSProperties } from "react";
 
 export default function AboutPage() {
-  const brandVars = {
+  const brandVars: CSSProperties = {
     "--brand": colors.primary,
     "--brand-light": colors.primaryLight,
     "--brand-lighter": colors.primaryLighter,

--- a/frontend/pages/about/leadership.tsx
+++ b/frontend/pages/about/leadership.tsx
@@ -5,6 +5,7 @@ import SectionCard from "@/components/UX/SectionCard";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
 import { jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
+import type { CSSProperties } from "react";
 
 const leaders = [
   {
@@ -35,7 +36,7 @@ const leaders = [
 ];
 
 export default function LeadershipPage() {
-  const brandVars = {
+  const brandVars: CSSProperties = {
     "--brand": colors.primary,
     "--brand-light": colors.primaryLight,
     "--brand-lighter": colors.primaryLighter,

--- a/frontend/pages/about/masthead.tsx
+++ b/frontend/pages/about/masthead.tsx
@@ -5,6 +5,7 @@ import ProfilePhoto from "@/components/User/ProfilePhoto";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
 import { jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
+import type { CSSProperties } from "react";
 
 const team = [
   {
@@ -35,7 +36,7 @@ const team = [
 export default function MastheadPage() {
   const [query, setQuery] = useState<string>("");
   const [show, setShow] = useState<number>(6);
-  const brandVars = {
+  const brandVars: CSSProperties = {
     "--brand": colors.primary,
     "--brand-light": colors.primaryLight,
     "--brand-lighter": colors.primaryLighter,


### PR DESCRIPTION
## Summary
- type CSS variables objects as `CSSProperties` on About pages to satisfy React style typings

## Testing
- `npm run typecheck` *(fails: Module '"react"' has no exported member 'CSSProperties')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abfca935cc832994d577cc8a2d6ed6