### PR TITLE
fix: support custom CSS variables

### DIFF
--- a/frontend/pages/about/index.tsx
+++ b/frontend/pages/about/index.tsx
@@ -8,8 +8,10 @@ import { aboutPageJsonLd, jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo"
 import aboutCopy from "@/lib/copy/about";
 import type { CSSProperties } from "react";
 
+type BrandVars = CSSProperties & Record<string, string>;
+
 export default function AboutPage() {
-  const brandVars: CSSProperties = {
+  const brandVars: BrandVars = {
     "--brand": colors.primary,
     "--brand-light": colors.primaryLight,
     "--brand-lighter": colors.primaryLighter,

--- a/frontend/pages/about/leadership.tsx
+++ b/frontend/pages/about/leadership.tsx
@@ -7,6 +7,8 @@ import { colors } from "@/lib/brand-tokens";
 import { jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
 import type { CSSProperties } from "react";
 
+type BrandVars = CSSProperties & Record<string, string>;
+
 const leaders = [
   {
     name: "Tatiana Chow",
@@ -36,7 +38,7 @@ const leaders = [
 ];
 
 export default function LeadershipPage() {
-  const brandVars: CSSProperties = {
+  const brandVars: BrandVars = {
     "--brand": colors.primary,
     "--brand-light": colors.primaryLight,
     "--brand-lighter": colors.primaryLighter,

--- a/frontend/pages/about/masthead.tsx
+++ b/frontend/pages/about/masthead.tsx
@@ -7,6 +7,8 @@ import { colors } from "@/lib/brand-tokens";
 import { jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
 import type { CSSProperties } from "react";
 
+type BrandVars = CSSProperties & Record<string, string>;
+
 const team = [
   {
     name: "Tatiana Chow",
@@ -36,7 +38,7 @@ const team = [
 export default function MastheadPage() {
   const [query, setQuery] = useState<string>("");
   const [show, setShow] = useState<number>(6);
-  const brandVars: CSSProperties = {
+  const brandVars: BrandVars = {
     "--brand": colors.primary,
     "--brand-light": colors.primaryLight,
     "--brand-lighter": colors.primaryLighter,


### PR DESCRIPTION
## Summary
- extend CSSProperties with string index to allow custom CSS variables
- use the new type for brand styles on about pages

## Testing
- `npm test`
- `npm run typecheck` *(fails: Module '"react"' has no exported member 'CSSProperties')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/formidable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac851f7b98832989563de7a01dc449