### PR TITLE
feat: generate edge og images

### DIFF
--- a/frontend/pages/api/og/[slug].ts
+++ b/frontend/pages/api/og/[slug].ts
@@ -1,26 +1,98 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
+import { ImageResponse } from 'next/og';
+import type { NextRequest } from 'next/server';
 import { dbConnect } from '@/lib/server/db';
 import Post from '@/models/Post';
-import { buildOgForPost } from '@/lib/og';
+import { colors, LOGO_MARK } from '@/lib/brandkits/rev2';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export const config = { runtime: 'edge' };
+
+export default async function handler(req: NextRequest) {
   if (req.method !== 'GET') {
-    res.status(405).end();
-    return;
+    return new Response('Method Not Allowed', { status: 405 });
   }
-  const { slug } = req.query;
-  if (!slug || Array.isArray(slug)) {
-    res.status(400).json({ error: 'Invalid slug' });
-    return;
+
+  const { pathname, searchParams } = req.nextUrl;
+  const slug = pathname.split('/').pop();
+  if (!slug) {
+    return new Response('Invalid slug', { status: 400 });
   }
+
   await dbConnect();
   const post = await Post.findOne({ slug }).lean();
   if (!post) {
-    res.status(404).json({ error: 'Not found' });
-    return;
+    return new Response('Not found', { status: 404 });
   }
-  const url = buildOgForPost(post);
-  res.setHeader('Cache-Control', 'public, s-maxage=86400, stale-while-revalidate=86400');
-  res.status(302).setHeader('Location', url);
-  res.end();
+
+  const isSquare = searchParams.get('square') === '1';
+  const width = isSquare ? 1080 : 1200;
+  const height = isSquare ? 1080 : 630;
+
+  const logoData = await fetch(new URL(LOGO_MARK, req.url)).then((res) =>
+    res.arrayBuffer()
+  );
+
+  const byline =
+    (post as any).authorDisplay ||
+    (post as any).author ||
+    (post as any).byline ||
+    '';
+  const date = post.publishedAt
+    ? new Date(post.publishedAt).toLocaleDateString('en-US', {
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+      })
+    : '';
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          backgroundImage: `linear-gradient(to bottom, ${colors.brandBlue}, ${colors.brandBlueDark}, ${colors.brandBlueDarker})`,
+          color: 'white',
+          padding: '80px',
+        }}
+      >
+        <div
+          style={{
+            fontSize: isSquare ? 84 : 64,
+            fontWeight: 700,
+            lineHeight: 1.2,
+            fontFamily: 'Merriweather, serif',
+            whiteSpace: 'pre-wrap',
+          }}
+        >
+          {post.title}
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-end',
+            fontSize: isSquare ? 36 : 32,
+            fontFamily: 'Inter, sans-serif',
+          }}
+        >
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            {byline && <span>{byline}</span>}
+            {date && <span>{date}</span>}
+          </div>
+          <img src={logoData} width={120} height={120} />
+        </div>
+      </div>
+    ),
+    {
+      width,
+      height,
+      headers: {
+        'Cache-Control': 's-maxage=86400, stale-while-revalidate=604800',
+      },
+    }
+  );
 }
+


### PR DESCRIPTION
## Summary
- convert `/api/og/[slug]` to Edge runtime using `next/og`'s `ImageResponse`
- render headline, byline, and date over rev2 gradient with mini mark
- add square option and long-lived cache headers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad096bcba4832991c85d511868523a