### PR TITLE
Add reusable SEO meta tags

### DIFF
--- a/frontend/components/ArticleView.tsx
+++ b/frontend/components/ArticleView.tsx
@@ -8,7 +8,13 @@ import Image from "next/image";
 import ImageLightbox from "@/components/ImageLightbox";
 import { readingTime } from "@/lib/readingTime";
 import { slugify } from "@/lib/slugify";
-import { buildBreadcrumbsJsonLd, buildNewsArticleJsonLd, jsonLdScript, ogImageForPost } from "@/lib/seo";
+import {
+  buildBreadcrumbsJsonLd,
+  buildNewsArticleJsonLd,
+  jsonLdScript,
+  ogImageForPost,
+  seoMetaTags,
+} from "@/lib/seo";
 
 const RelatedRail = dynamic(() => import("@/components/RelatedRail"), {
   ssr: false,
@@ -114,11 +120,13 @@ export default function ArticleView({
   return (
     <>
       <Head>
-        <title>{post.title} — WaterNewsGY</title>
+        {seoMetaTags({
+          title: `${post.title} — WaterNewsGY`,
+          description: post.excerpt || post.description || undefined,
+          image: ogImage,
+        })}
         {!isPreview && <link rel="canonical" href={`${origin}${canonicalPath}`} />}
         {isPreview && <meta name="robots" content="noindex" />}
-        <meta property="og:image" content={ogImage} />
-        <meta name="twitter:image" content={ogImage} />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
         <script

--- a/frontend/lib/seo.tsx
+++ b/frontend/lib/seo.tsx
@@ -3,13 +3,15 @@
 
 import { absoluteUrl, BRAND_NAME } from "@/lib/brand";
 import { LOGO_FULL, OG_DEFAULT } from "@/lib/brand-tokens";
-import { buildOgForPost } from "@/lib/og";
+
+export const DEFAULT_TWITTER_SITE = "@WaterNewsGY";
 
 export const DEFAULT_OG_IMAGE = OG_DEFAULT;
 
 export function ogImageForPost(post: any | null) {
-  const maybe = post?.ogImageUrl || (post ? buildOgForPost(post) : null);
-  return maybe || absoluteUrl(OG_DEFAULT);
+  if (!post) return absoluteUrl("/api/og/site");
+  const maybe = post.ogImageUrl || (post.slug ? `/api/og/${post.slug}` : null);
+  return absoluteUrl(maybe || "/api/og/site");
 }
 
 type Publisher = {
@@ -184,5 +186,28 @@ export function buildPersonJsonLd(params: {
 
 export function jsonLdScript(objOrArray: unknown) {
   return JSON.stringify(objOrArray, null, 0);
+}
+
+export function seoMetaTags(params: {
+  title: string;
+  description?: string;
+  image?: string;
+  slug?: string;
+  twitterSite?: string;
+}) {
+  const { title, description, image, slug, twitterSite = DEFAULT_TWITTER_SITE } = params;
+  const img = absoluteUrl(image || (slug ? `/api/og/${slug}` : "/api/og/site"));
+  return (
+    <>
+      <title>{title}</title>
+      {description ? <meta name="description" content={description} /> : null}
+      <meta property="og:title" content={title} />
+      {description ? <meta property="og:description" content={description} /> : null}
+      <meta property="og:image" content={img} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:site" content={twitterSite} />
+      <meta name="twitter:image" content={img} />
+    </>
+  );
 }
 

--- a/frontend/pages/about/index.tsx
+++ b/frontend/pages/about/index.tsx
@@ -4,11 +4,9 @@ import Image from "next/image";
 import Script from "next/script";
 import SectionCard from "@/components/UX/SectionCard";
 import { colors } from "@/lib/brand-tokens";
-import { aboutPageJsonLd, jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
+import { aboutPageJsonLd, jsonLdScript, pageBreadcrumbsJsonLd, seoMetaTags } from "@/lib/seo";
 import aboutCopy from "@/lib/copy/about";
-import type { CSSProperties } from "react";
-
-type BrandVars = CSSProperties & Record<string, string>;
+type BrandVars = Record<string, string>;
 
 export default function AboutPage() {
   const brandVars: BrandVars = {
@@ -43,11 +41,11 @@ export default function AboutPage() {
   return (
     <>
       <Head>
-        <title>About Us — WaterNews</title>
-        <meta
-          name="description"
-          content="WaterNews gives Guyanese, Caribbean, and diaspora voices a modern platform for verified news, opinion, and lifestyle stories."
-        />
+        {seoMetaTags({
+          title: "About Us — WaterNews",
+          description:
+            "WaterNews gives Guyanese, Caribbean, and diaspora voices a modern platform for verified news, opinion, and lifestyle stories.",
+        })}
       </Head>
       <Script
         id="about-jsonld"

--- a/frontend/pages/about/leadership.tsx
+++ b/frontend/pages/about/leadership.tsx
@@ -4,10 +4,8 @@ import Image from "next/image";
 import SectionCard from "@/components/UX/SectionCard";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
-import { jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
-import type { CSSProperties } from "react";
-
-type BrandVars = CSSProperties & Record<string, string>;
+import { jsonLdScript, pageBreadcrumbsJsonLd, seoMetaTags } from "@/lib/seo";
+type BrandVars = Record<string, string>;
 
 const leaders = [
   {
@@ -54,8 +52,10 @@ export default function LeadershipPage() {
   return (
     <>
       <Head>
-        <title>Leadership Team — WaterNews</title>
-        <meta name="description" content="Meet the executives guiding WaterNews." />
+        {seoMetaTags({
+          title: "Leadership Team — WaterNews",
+          description: "Meet the executives guiding WaterNews.",
+        })}
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: jsonLdScript(breadcrumbs) }}

--- a/frontend/pages/about/masthead.tsx
+++ b/frontend/pages/about/masthead.tsx
@@ -4,10 +4,8 @@ import { useState } from "react";
 import ProfilePhoto from "@/components/User/ProfilePhoto";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
-import { jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
-import type { CSSProperties } from "react";
-
-type BrandVars = CSSProperties & Record<string, string>;
+import { jsonLdScript, pageBreadcrumbsJsonLd, seoMetaTags } from "@/lib/seo";
+type BrandVars = Record<string, string>;
 
 const team = [
   {
@@ -57,8 +55,10 @@ export default function MastheadPage() {
   return (
     <>
       <Head>
-        <title>Masthead & News Team — WaterNews</title>
-        <meta name="description" content="WaterNews masthead and newsroom staff." />
+        {seoMetaTags({
+          title: "Masthead & News Team — WaterNews",
+          description: "WaterNews masthead and newsroom staff.",
+        })}
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: jsonLdScript(breadcrumbs) }}

--- a/frontend/pages/careers.tsx
+++ b/frontend/pages/careers.tsx
@@ -2,13 +2,16 @@ import Head from "next/head";
 import Link from "next/link";
 import SectionCard from "@/components/UX/SectionCard";
 import { colors } from "@/lib/brand-tokens";
+import { seoMetaTags } from "@/lib/seo";
 
 export default function CareersPage() {
   return (
     <>
       <Head>
-        <title>Careers — WaterNews</title>
-        <meta name="description" content="Join the WaterNews team." />
+        {seoMetaTags({
+          title: "Careers — WaterNews",
+          description: "Join the WaterNews team.",
+        })}
       </Head>
       <header
         className="relative grid min-h-[40vh] place-items-center overflow-hidden px-4 pt-16 text-center text-white"

--- a/frontend/pages/contact.tsx
+++ b/frontend/pages/contact.tsx
@@ -6,7 +6,7 @@ import Page from "@/components/UX/Page";
 import Toast from "@/components/Toast";
 import { SUBJECTS } from "@/lib/cms-routing";
 import contactCopy from "@/lib/copy/contact";
-import { jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
+import { jsonLdScript, pageBreadcrumbsJsonLd, seoMetaTags } from "@/lib/seo";
 
 type ToastState = { type: "success" | "error"; message: string } | null;
 interface Fields {
@@ -71,8 +71,10 @@ export default function ContactPage() {
   return (
     <>
       <Head>
-        <title>{current.hero.title} — WaterNews</title>
-        <meta name="description" content={current.hero.subtitle} />
+        {seoMetaTags({
+          title: `${current.hero.title} — WaterNews`,
+          description: current.hero.subtitle,
+        })}
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: jsonLdScript(breadcrumbs) }}

--- a/frontend/pages/credits.tsx
+++ b/frontend/pages/credits.tsx
@@ -1,5 +1,6 @@
 import Head from "next/head";
 import SectionCard from "@/components/UX/SectionCard";
+import { seoMetaTags } from "@/lib/seo";
 
 interface CreditItem {
   name: string;
@@ -41,11 +42,11 @@ export default function CreditsPage() {
   return (
     <>
       <Head>
-        <title>Credits — WaterNews</title>
-        <meta
-          name="description"
-          content="Credits for technologies, photography, and news organizations used by WaterNews."
-        />
+        {seoMetaTags({
+          title: "Credits — WaterNews",
+          description:
+            "Credits for technologies, photography, and news organizations used by WaterNews.",
+        })}
       </Head>
       <main className="mx-auto max-w-4xl px-4 py-16">
         <h1 className="mb-8 text-4xl font-bold">Credits</h1>

--- a/frontend/pages/faq.tsx
+++ b/frontend/pages/faq.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import Page from "@/components/UX/Page";
 import SectionCard from "@/components/UX/SectionCard";
 import { colors } from "@/lib/brand-tokens";
+import { seoMetaTags } from "@/lib/seo";
 
 export default function FAQ() {
   const brandVars = {
@@ -12,8 +13,10 @@ export default function FAQ() {
   return (
     <>
       <Head>
-        <title>FAQ — WaterNews</title>
-        <meta name="description" content="Answers for readers and visitors." />
+        {seoMetaTags({
+          title: "FAQ — WaterNews",
+          description: "Answers for readers and visitors.",
+        })}
       </Head>
       <Page
         title="FAQ"

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,3 +1,4 @@
+import Head from 'next/head'
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import axios from 'axios'
@@ -5,6 +6,7 @@ import Hero from '../components/Hero'
 import MasonryFeed from '../components/MasonryFeed'
 import dynamic from 'next/dynamic'
 import RecircSkeleton from '@/components/Recirculation/RecircSkeleton'
+import { seoMetaTags } from '@/lib/seo'
 import { getFollowedAuthors, getFollowedTags, toggleFollowAuthor, toggleFollowTag, syncFollowsIfAuthed, pushServerFollows } from '../utils/follow'
 
 const RecircWidget = dynamic(() => import('@/components/Recirculation/RecircWidget'), { ssr: false, loading: () => <RecircSkeleton /> })
@@ -149,7 +151,14 @@ export default function HomePage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <>
+      <Head>
+        {seoMetaTags({
+          title: 'WaterNewsGY — Home',
+          description: 'Latest stories from WaterNewsGY.',
+        })}
+      </Head>
+      <div className="min-h-screen bg-gray-50">
       <div className="px-3 py-4 md:px-4 max-w-7xl mx-auto">
         {/* Contextual hero */}
           <Hero
@@ -183,5 +192,6 @@ export default function HomePage() {
         }
       </div>
     </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- create `seoMetaTags` helper for Open Graph and Twitter metadata
- default article and site pages to dynamic og images
- use helper across ArticleView and static pages for titles and descriptions

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ad096e16f08329bb04ba801d767c2e