### PR TITLE
Add site-wide JSON-LD and breadcrumbs for about pages

### DIFF
--- a/frontend/lib/seo.ts
+++ b/frontend/lib/seo.ts
@@ -2,7 +2,7 @@
 // Keep objects small, avoid undefineds, and emit a single script per page.
 
 import { absoluteUrl, BRAND_NAME } from "@/lib/brand";
-import { LOGO_FULL, OG_DEFAULT } from "@/lib/brand-tokens";
+import { LOGO_FULL, LOGO_MARK, OG_DEFAULT } from "@/lib/brand-tokens";
 import { buildOgForPost } from "@/lib/og";
 
 export const DEFAULT_OG_IMAGE = OG_DEFAULT;
@@ -40,14 +40,17 @@ export function orgJsonLd(origin: string) {
 }
 
 // WebSite JSON-LD for global site identity.
-export function webSiteJsonLd(origin: string) {
+export function webSiteJsonLd(origin: string, sameAs?: string[]) {
   const url = origin || "https://www.waternewsgy.com";
-  return {
+  const obj: any = {
     "@context": "https://schema.org",
     "@type": "WebSite",
     name: BRAND_NAME,
     url,
+    image: absoluteUrl(LOGO_MARK),
   };
+  if (sameAs && sameAs.length) obj.sameAs = sameAs;
+  return obj;
 }
 
 export function aboutPageJsonLd() {

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -14,7 +14,10 @@ export default function App({ Component, pageProps: { session, ...pageProps } }:
       ? process.env.NEXT_PUBLIC_SITE_URL || 'https://www.waternewsgy.com'
       : window.location.origin;
   const orgLd = orgJsonLd(origin);
-  const siteLd = webSiteJsonLd(origin);
+  const siteLd = webSiteJsonLd(origin, [
+    'https://twitter.com/WaterNewsGY',
+    'https://facebook.com/WaterNewsGY',
+  ]);
   return (
     <>
       <Head>

--- a/frontend/pages/about/index.tsx
+++ b/frontend/pages/about/index.tsx
@@ -1,10 +1,9 @@
 import Head from "next/head";
 import Link from "next/link";
 import Image from "next/image";
-import Script from "next/script";
 import SectionCard from "@/components/UX/SectionCard";
 import { colors } from "@/lib/brand-tokens";
-import { aboutPageJsonLd, jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
+import { aboutPageJsonLd, jsonLdScript, buildBreadcrumbsJsonLd } from "@/lib/seo";
 import aboutCopy from "@/lib/copy/about";
 import type { CSSProperties } from "react";
 
@@ -25,7 +24,10 @@ export default function AboutPage() {
     typeof window === "undefined"
       ? process.env.NEXT_PUBLIC_SITE_URL || "https://www.waternewsgy.com"
       : window.location.origin;
-  const breadcrumbs = pageBreadcrumbsJsonLd(origin, { name: "About", url: "/about" });
+  const breadcrumbs = buildBreadcrumbsJsonLd(origin, [
+    { name: "Home", url: "/" },
+    { name: "About", url: "/about" },
+  ]);
 
   const {
     hero,
@@ -48,12 +50,13 @@ export default function AboutPage() {
           name="description"
           content="WaterNews gives Guyanese, Caribbean, and diaspora voices a modern platform for verified news, opinion, and lifestyle stories."
         />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: jsonLdScript([aboutPageJsonLd(), breadcrumbs]),
+          }}
+        />
       </Head>
-      <Script
-        id="about-jsonld"
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: jsonLdScript([aboutPageJsonLd(), breadcrumbs]) }}
-      />
       <header
         className="relative grid min-h-[58vh] place-items-center overflow-hidden px-4 pt-16 text-center text-white"
         style={{

--- a/frontend/pages/about/leadership.tsx
+++ b/frontend/pages/about/leadership.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import SectionCard from "@/components/UX/SectionCard";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
-import { jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
+import { jsonLdScript, buildBreadcrumbsJsonLd } from "@/lib/seo";
 import type { CSSProperties } from "react";
 
 type BrandVars = CSSProperties & Record<string, string>;
@@ -49,7 +49,11 @@ export default function LeadershipPage() {
     typeof window === "undefined"
       ? process.env.NEXT_PUBLIC_SITE_URL || "https://www.waternewsgy.com"
       : window.location.origin;
-  const breadcrumbs = pageBreadcrumbsJsonLd(origin, { name: "About", url: "/about" }, { name: "Leadership Team", url: "/about/leadership" });
+  const breadcrumbs = buildBreadcrumbsJsonLd(origin, [
+    { name: "Home", url: "/" },
+    { name: "About", url: "/about" },
+    { name: "Leadership Team", url: "/about/leadership" },
+  ]);
 
   return (
     <>

--- a/frontend/pages/about/masthead.tsx
+++ b/frontend/pages/about/masthead.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import ProfilePhoto from "@/components/User/ProfilePhoto";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
-import { jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
+import { jsonLdScript, buildBreadcrumbsJsonLd } from "@/lib/seo";
 import type { CSSProperties } from "react";
 
 type BrandVars = CSSProperties & Record<string, string>;
@@ -53,7 +53,11 @@ export default function MastheadPage() {
     typeof window === "undefined"
       ? process.env.NEXT_PUBLIC_SITE_URL || "https://www.waternewsgy.com"
       : window.location.origin;
-  const breadcrumbs = pageBreadcrumbsJsonLd(origin, { name: "About", url: "/about" }, { name: "Masthead & News Team", url: "/about/masthead" });
+  const breadcrumbs = buildBreadcrumbsJsonLd(origin, [
+    { name: "Home", url: "/" },
+    { name: "About", url: "/about" },
+    { name: "Masthead & News Team", url: "/about/masthead" },
+  ]);
   return (
     <>
       <Head>

--- a/frontend/pages/contact.tsx
+++ b/frontend/pages/contact.tsx
@@ -6,7 +6,7 @@ import Page from "@/components/UX/Page";
 import Toast from "@/components/Toast";
 import { SUBJECTS } from "@/lib/cms-routing";
 import contactCopy from "@/lib/copy/contact";
-import { jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
+import { jsonLdScript, buildBreadcrumbsJsonLd } from "@/lib/seo";
 
 type ToastState = { type: "success" | "error"; message: string } | null;
 interface Fields {
@@ -66,7 +66,10 @@ export default function ContactPage() {
     typeof window === "undefined"
       ? process.env.NEXT_PUBLIC_SITE_URL || "https://www.waternewsgy.com"
       : window.location.origin;
-  const breadcrumbs = pageBreadcrumbsJsonLd(origin, { name: "Contact", url: "/contact" });
+  const breadcrumbs = buildBreadcrumbsJsonLd(origin, [
+    { name: "Home", url: "/" },
+    { name: "Contact", url: "/contact" },
+  ]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- Include organization and WebSite JSON-LD globally with mini logo and social links
- Add breadcrumb JSON-LD to About, Leadership, Masthead, and Contact pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad097dba0c8329a8e736584154e7d2