### PR TITLE
Use Next.js Image for article gallery and fix types

### DIFF
--- a/frontend/components/ArticleView.tsx
+++ b/frontend/components/ArticleView.tsx
@@ -181,16 +181,16 @@ export default function ArticleView({
                   <button
                     key={src + i}
                     type="button"
-                    className="group block rounded-lg overflow-hidden ring-1 ring-black/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-600"
+                    className="group relative block aspect-video rounded-lg overflow-hidden ring-1 ring-black/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-600"
                     onClick={() => setZoomSrc(src)}
                     aria-label="Open image"
                   >
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
+                    <Image
                       src={src}
                       alt=""
-                      className="aspect-video object-cover group-hover:opacity-90"
-                      loading="lazy"
+                      fill
+                      className="object-cover group-hover:opacity-90"
+                      sizes="(min-width: 768px) 33vw, 50vw"
                     />
                   </button>
                 ))}

--- a/frontend/pages/about/index.tsx
+++ b/frontend/pages/about/index.tsx
@@ -6,9 +6,7 @@ import SectionCard from "@/components/UX/SectionCard";
 import { colors } from "@/lib/brand-tokens";
 import { aboutPageJsonLd, jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
 import aboutCopy from "@/lib/copy/about";
-import type { CSSProperties } from "react";
-
-type BrandVars = CSSProperties & Record<string, string>;
+type BrandVars = Record<string, string>;
 
 export default function AboutPage() {
   const brandVars: BrandVars = {

--- a/frontend/pages/about/leadership.tsx
+++ b/frontend/pages/about/leadership.tsx
@@ -5,9 +5,7 @@ import SectionCard from "@/components/UX/SectionCard";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
 import { jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
-import type { CSSProperties } from "react";
-
-type BrandVars = CSSProperties & Record<string, string>;
+type BrandVars = Record<string, string>;
 
 const leaders = [
   {

--- a/frontend/pages/about/masthead.tsx
+++ b/frontend/pages/about/masthead.tsx
@@ -5,9 +5,7 @@ import ProfilePhoto from "@/components/User/ProfilePhoto";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
 import { jsonLdScript, pageBreadcrumbsJsonLd } from "@/lib/seo";
-import type { CSSProperties } from "react";
-
-type BrandVars = CSSProperties & Record<string, string>;
+type BrandVars = Record<string, string>;
 
 const team = [
   {


### PR DESCRIPTION
## Summary
- switch article gallery images to Next.js `<Image>` with responsive sizing
- simplify about page style typings to avoid React `CSSProperties` import errors

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ad0a4b63ac83298dc2ecfac3819cc7