### PR TITLE
feat: add skip links and enlarge button targets

### DIFF
--- a/frontend/components/Newsroom/EditorBar.tsx
+++ b/frontend/components/Newsroom/EditorBar.tsx
@@ -111,7 +111,7 @@ export default function EditorBar({
         <div className="flex items-center gap-3 min-w-0">
           <button
             onClick={onBack}
-            className="shrink-0 inline-flex items-center justify-center w-8 h-8 rounded-md border hover:bg-gray-50"
+            className="shrink-0 inline-flex items-center justify-center w-11 h-11 rounded-md border hover:bg-gray-50"
             aria-label="Back to Newsroom"
             title="Back to Newsroom"
           >

--- a/frontend/components/Newsroom/GlobalShell.tsx
+++ b/frontend/components/Newsroom/GlobalShell.tsx
@@ -296,6 +296,12 @@ function ResponsiveShell({ children }: { children: React.ReactNode }) {
   const railW = isCollapsed ? RAIL_W_COLLAPSED : RAIL_W;
   return (
     <div className="min-h-screen bg-gray-50">
+      <a
+        href="#main"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 bg-black text-white px-3 py-2 rounded"
+      >
+        Skip to content
+      </a>
       {/* Mobile sticky bar */}
       <MobileTopBar />
       <div className="flex">

--- a/frontend/components/NotificationsBellMenu.tsx
+++ b/frontend/components/NotificationsBellMenu.tsx
@@ -52,7 +52,7 @@ export default function NotificationsBellMenu({
         aria-label="Open notifications"
         aria-expanded={open}
         onClick={onToggle}
-        className="relative inline-flex h-9 w-9 items-center justify-center rounded-full hover:bg-slate-100 dark:hover:bg-slate-800"
+        className="relative inline-flex h-11 w-11 items-center justify-center rounded-full hover:bg-slate-100 dark:hover:bg-slate-800"
       >
         {/* Modern outline bell */}
         <svg width="22" height="22" viewBox="0 0 24 24" className="text-slate-700 dark:text-slate-200" aria-hidden="true">

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -4,7 +4,7 @@ import '@/styles/globals.css';
 import Head from 'next/head';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
-import ShellProvider from '@/components/Newsroom/ShellContext';
+import ShellProvider, { useShell } from '@/components/Newsroom/ShellContext';
 import GlobalShell from '@/components/Newsroom/GlobalShell';
 import { jsonLdScript, orgJsonLd, webSiteJsonLd } from '@/lib/seo';
 
@@ -29,27 +29,35 @@ export default function App({ Component, pageProps: { session, ...pageProps } }:
       </Head>
       <SessionProvider session={session}>
         <ShellProvider>
-          {/* GlobalShell renders only for logged-in users; add top padding on mobile for sticky bar */}
-          <GlobalShell>
-            <a
-              href="#main-content"
-              className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 bg-black text-white px-3 py-2 rounded"
-            >
-              Skip to main content
-            </a>
-            <div className="md:pt-0 pt-14">
-              <Header />
-              <main
-                id="main-content"
-                className="min-h-screen bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-100"
-              >
-                <Component {...pageProps} />
-              </main>
-              <Footer />
-            </div>
-          </GlobalShell>
+          <AppContent Component={Component} pageProps={pageProps} />
         </ShellProvider>
       </SessionProvider>
     </>
+  );
+}
+
+function AppContent({ Component, pageProps }: { Component: any; pageProps: any }) {
+  const { user } = useShell();
+  return (
+    <GlobalShell>
+      {!user && (
+        <a
+          href="#main"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 bg-black text-white px-3 py-2 rounded"
+        >
+          Skip to content
+        </a>
+      )}
+      <div className="md:pt-0 pt-14">
+        <Header />
+        <main
+          id="main"
+          className="min-h-screen bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-100"
+        >
+          <Component {...pageProps} />
+        </main>
+        <Footer />
+      </div>
+    </GlobalShell>
   );
 }


### PR DESCRIPTION
## Summary
- add skip-to-content link in newsroom GlobalShell
- provide skip link and main anchor in public layout
- enlarge small buttons to 44px for better touch targets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad0a66fb9883298a29dd55f4953cf9