### PR TITLE
feat: lazy load related rail with skeleton

### DIFF
--- a/frontend/components/ArticleView.tsx
+++ b/frontend/components/ArticleView.tsx
@@ -9,15 +9,11 @@ import ImageLightbox from "@/components/ImageLightbox";
 import { readingTime } from "@/lib/readingTime";
 import { slugify } from "@/lib/slugify";
 import { buildBreadcrumbsJsonLd, buildNewsArticleJsonLd, jsonLdScript, ogImageForPost } from "@/lib/seo";
+import RecircSkeleton from "@/components/Recirculation/RecircSkeleton";
 
 const RelatedRail = dynamic(() => import("@/components/RelatedRail"), {
   ssr: false,
-  loading: () => (
-    <div className="space-y-4 animate-pulse">
-      <div className="h-24 bg-gray-200 rounded" />
-      <div className="h-24 bg-gray-200 rounded" />
-    </div>
-  ),
+  loading: () => <RecircSkeleton />,
 });
 
 const PrevNext = dynamic(() => import("@/components/PrevNext"), {


### PR DESCRIPTION
## Summary
- lazy load related rail on article page with RecircSkeleton

## Testing
- `npm test`
- `npm run typecheck` *(fails: Module '"react"' has no exported member 'CSSProperties')*

------
https://chatgpt.com/codex/tasks/task_e_68ad0a51f6808329880d02190d658c7d