### PR TITLE
feat: add canonical URLs and lazy recirc

### DIFF
--- a/frontend/components/ArticleView.tsx
+++ b/frontend/components/ArticleView.tsx
@@ -6,6 +6,7 @@ import dynamic from "next/dynamic";
 import ShareRow from "@/components/ShareRow";
 import Image from "next/image";
 import ImageLightbox from "@/components/ImageLightbox";
+import RecircSkeleton from "@/components/Recirculation/RecircSkeleton";
 import { readingTime } from "@/lib/readingTime";
 import { slugify } from "@/lib/slugify";
 import {
@@ -14,16 +15,12 @@ import {
   jsonLdScript,
   ogImageForPost,
   seoMetaTags,
+  absoluteCanonical,
 } from "@/lib/seo";
 
 const RelatedRail = dynamic(() => import("@/components/RelatedRail"), {
   ssr: false,
-  loading: () => (
-    <div className="space-y-4 animate-pulse">
-      <div className="h-24 bg-gray-200 rounded" />
-      <div className="h-24 bg-gray-200 rounded" />
-    </div>
-  ),
+  loading: () => <RecircSkeleton />,
 });
 
 const PrevNext = dynamic(() => import("@/components/PrevNext"), {
@@ -125,7 +122,9 @@ export default function ArticleView({
           description: post.excerpt || post.description || undefined,
           image: ogImage,
         })}
-        {!isPreview && <link rel="canonical" href={`${origin}${canonicalPath}`} />}
+        {!isPreview && (
+          <link rel="canonical" href={absoluteCanonical(canonicalPath)} />
+        )}
         {isPreview && <meta name="robots" content="noindex" />}
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />

--- a/frontend/lib/seo.tsx
+++ b/frontend/lib/seo.tsx
@@ -8,6 +8,11 @@ export const DEFAULT_TWITTER_SITE = "@WaterNewsGY";
 
 export const DEFAULT_OG_IMAGE = OG_DEFAULT;
 
+// Build an absolute canonical URL for a given path.
+export function absoluteCanonical(path: string) {
+  return absoluteUrl(path || "/");
+}
+
 export function ogImageForPost(post: any | null) {
   if (!post) return absoluteUrl("/api/og/site");
   const maybe = post.ogImageUrl || (post.slug ? `/api/og/${post.slug}` : null);

--- a/frontend/pages/about/index.tsx
+++ b/frontend/pages/about/index.tsx
@@ -4,7 +4,13 @@ import Image from "next/image";
 import Script from "next/script";
 import SectionCard from "@/components/UX/SectionCard";
 import { colors } from "@/lib/brand-tokens";
-import { aboutPageJsonLd, jsonLdScript, pageBreadcrumbsJsonLd, seoMetaTags } from "@/lib/seo";
+import {
+  aboutPageJsonLd,
+  buildBreadcrumbsJsonLd,
+  jsonLdScript,
+  seoMetaTags,
+  absoluteCanonical,
+} from "@/lib/seo";
 import aboutCopy from "@/lib/copy/about";
 type BrandVars = Record<string, string>;
 
@@ -23,7 +29,10 @@ export default function AboutPage() {
     typeof window === "undefined"
       ? process.env.NEXT_PUBLIC_SITE_URL || "https://www.waternewsgy.com"
       : window.location.origin;
-  const breadcrumbs = pageBreadcrumbsJsonLd(origin, { name: "About", url: "/about" });
+  const breadcrumbs = buildBreadcrumbsJsonLd(origin, [
+    { name: "Home", url: "/" },
+    { name: "About", url: "/about" },
+  ]);
 
   const {
     hero,
@@ -46,12 +55,12 @@ export default function AboutPage() {
           description:
             "WaterNews gives Guyanese, Caribbean, and diaspora voices a modern platform for verified news, opinion, and lifestyle stories.",
         })}
+        <link rel="canonical" href={absoluteCanonical("/about")} />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: jsonLdScript([aboutPageJsonLd(), breadcrumbs]) }}
+        />
       </Head>
-      <Script
-        id="about-jsonld"
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: jsonLdScript([aboutPageJsonLd(), breadcrumbs]) }}
-      />
       <header
         className="relative grid min-h-[58vh] place-items-center overflow-hidden px-4 pt-16 text-center text-white"
         style={{

--- a/frontend/pages/about/leadership.tsx
+++ b/frontend/pages/about/leadership.tsx
@@ -4,7 +4,12 @@ import Image from "next/image";
 import SectionCard from "@/components/UX/SectionCard";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
-import { jsonLdScript, pageBreadcrumbsJsonLd, seoMetaTags } from "@/lib/seo";
+import {
+  buildBreadcrumbsJsonLd,
+  jsonLdScript,
+  seoMetaTags,
+  absoluteCanonical,
+} from "@/lib/seo";
 type BrandVars = Record<string, string>;
 
 const leaders = [
@@ -47,7 +52,11 @@ export default function LeadershipPage() {
     typeof window === "undefined"
       ? process.env.NEXT_PUBLIC_SITE_URL || "https://www.waternewsgy.com"
       : window.location.origin;
-  const breadcrumbs = pageBreadcrumbsJsonLd(origin, { name: "About", url: "/about" }, { name: "Leadership Team", url: "/about/leadership" });
+  const breadcrumbs = buildBreadcrumbsJsonLd(origin, [
+    { name: "Home", url: "/" },
+    { name: "About", url: "/about" },
+    { name: "Leadership Team", url: "/about/leadership" },
+  ]);
 
   return (
     <>
@@ -56,6 +65,7 @@ export default function LeadershipPage() {
           title: "Leadership Team — WaterNews",
           description: "Meet the executives guiding WaterNews.",
         })}
+        <link rel="canonical" href={absoluteCanonical("/about/leadership")} />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: jsonLdScript(breadcrumbs) }}

--- a/frontend/pages/about/masthead.tsx
+++ b/frontend/pages/about/masthead.tsx
@@ -4,7 +4,12 @@ import { useState } from "react";
 import ProfilePhoto from "@/components/User/ProfilePhoto";
 import { withCloudinaryAuto } from "@/lib/media";
 import { colors } from "@/lib/brand-tokens";
-import { jsonLdScript, pageBreadcrumbsJsonLd, seoMetaTags } from "@/lib/seo";
+import {
+  buildBreadcrumbsJsonLd,
+  jsonLdScript,
+  seoMetaTags,
+  absoluteCanonical,
+} from "@/lib/seo";
 type BrandVars = Record<string, string>;
 
 const team = [
@@ -51,7 +56,11 @@ export default function MastheadPage() {
     typeof window === "undefined"
       ? process.env.NEXT_PUBLIC_SITE_URL || "https://www.waternewsgy.com"
       : window.location.origin;
-  const breadcrumbs = pageBreadcrumbsJsonLd(origin, { name: "About", url: "/about" }, { name: "Masthead & News Team", url: "/about/masthead" });
+  const breadcrumbs = buildBreadcrumbsJsonLd(origin, [
+    { name: "Home", url: "/" },
+    { name: "About", url: "/about" },
+    { name: "Masthead & News Team", url: "/about/masthead" },
+  ]);
   return (
     <>
       <Head>
@@ -59,6 +68,7 @@ export default function MastheadPage() {
           title: "Masthead & News Team — WaterNews",
           description: "WaterNews masthead and newsroom staff.",
         })}
+        <link rel="canonical" href={absoluteCanonical("/about/masthead")} />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: jsonLdScript(breadcrumbs) }}

--- a/frontend/pages/careers.tsx
+++ b/frontend/pages/careers.tsx
@@ -2,7 +2,7 @@ import Head from "next/head";
 import Link from "next/link";
 import SectionCard from "@/components/UX/SectionCard";
 import { colors } from "@/lib/brand-tokens";
-import { seoMetaTags } from "@/lib/seo";
+import { seoMetaTags, absoluteCanonical } from "@/lib/seo";
 
 export default function CareersPage() {
   return (
@@ -12,6 +12,7 @@ export default function CareersPage() {
           title: "Careers — WaterNews",
           description: "Join the WaterNews team.",
         })}
+        <link rel="canonical" href={absoluteCanonical("/careers")} />
       </Head>
       <header
         className="relative grid min-h-[40vh] place-items-center overflow-hidden px-4 pt-16 text-center text-white"

--- a/frontend/pages/contact.tsx
+++ b/frontend/pages/contact.tsx
@@ -6,7 +6,12 @@ import Page from "@/components/UX/Page";
 import Toast from "@/components/Toast";
 import { SUBJECTS } from "@/lib/cms-routing";
 import contactCopy from "@/lib/copy/contact";
-import { jsonLdScript, pageBreadcrumbsJsonLd, seoMetaTags } from "@/lib/seo";
+import {
+  buildBreadcrumbsJsonLd,
+  jsonLdScript,
+  seoMetaTags,
+  absoluteCanonical,
+} from "@/lib/seo";
 
 type ToastState = { type: "success" | "error"; message: string } | null;
 interface Fields {
@@ -66,7 +71,10 @@ export default function ContactPage() {
     typeof window === "undefined"
       ? process.env.NEXT_PUBLIC_SITE_URL || "https://www.waternewsgy.com"
       : window.location.origin;
-  const breadcrumbs = pageBreadcrumbsJsonLd(origin, { name: "Contact", url: "/contact" });
+  const breadcrumbs = buildBreadcrumbsJsonLd(origin, [
+    { name: "Home", url: "/" },
+    { name: "Contact", url: "/contact" },
+  ]);
 
   return (
     <>
@@ -75,6 +83,7 @@ export default function ContactPage() {
           title: `${current.hero.title} — WaterNews`,
           description: current.hero.subtitle,
         })}
+        <link rel="canonical" href={absoluteCanonical("/contact")} />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: jsonLdScript(breadcrumbs) }}

--- a/frontend/pages/credits.tsx
+++ b/frontend/pages/credits.tsx
@@ -1,6 +1,6 @@
 import Head from "next/head";
 import SectionCard from "@/components/UX/SectionCard";
-import { seoMetaTags } from "@/lib/seo";
+import { seoMetaTags, absoluteCanonical } from "@/lib/seo";
 
 interface CreditItem {
   name: string;
@@ -47,6 +47,7 @@ export default function CreditsPage() {
           description:
             "Credits for technologies, photography, and news organizations used by WaterNews.",
         })}
+        <link rel="canonical" href={absoluteCanonical("/credits")} />
       </Head>
       <main className="mx-auto max-w-4xl px-4 py-16">
         <h1 className="mb-8 text-4xl font-bold">Credits</h1>

--- a/frontend/pages/faq.tsx
+++ b/frontend/pages/faq.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import Page from "@/components/UX/Page";
 import SectionCard from "@/components/UX/SectionCard";
 import { colors } from "@/lib/brand-tokens";
-import { seoMetaTags } from "@/lib/seo";
+import { seoMetaTags, absoluteCanonical } from "@/lib/seo";
 
 export default function FAQ() {
   const brandVars = {
@@ -17,6 +17,7 @@ export default function FAQ() {
           title: "FAQ — WaterNews",
           description: "Answers for readers and visitors.",
         })}
+        <link rel="canonical" href={absoluteCanonical("/faq")} />
       </Head>
       <Page
         title="FAQ"

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -6,7 +6,7 @@ import Hero from '../components/Hero'
 import MasonryFeed from '../components/MasonryFeed'
 import dynamic from 'next/dynamic'
 import RecircSkeleton from '@/components/Recirculation/RecircSkeleton'
-import { seoMetaTags } from '@/lib/seo'
+import { seoMetaTags, absoluteCanonical } from '@/lib/seo'
 import { getFollowedAuthors, getFollowedTags, toggleFollowAuthor, toggleFollowTag, syncFollowsIfAuthed, pushServerFollows } from '../utils/follow'
 
 const RecircWidget = dynamic(() => import('@/components/Recirculation/RecircWidget'), { ssr: false, loading: () => <RecircSkeleton /> })
@@ -157,6 +157,7 @@ export default function HomePage() {
           title: 'WaterNewsGY — Home',
           description: 'Latest stories from WaterNewsGY.',
         })}
+        <link rel="canonical" href={absoluteCanonical('/')} />
       </Head>
       <div className="min-h-screen bg-gray-50">
       <div className="px-3 py-4 md:px-4 max-w-7xl mx-auto">

--- a/frontend/pages/news/[slug].tsx
+++ b/frontend/pages/news/[slug].tsx
@@ -2,6 +2,7 @@ import { GetStaticPaths, GetStaticProps } from "next";
 import { dbConnect } from "@/lib/server/db";
 import Post from "@/models/Post";
 import ArticleView from "@/components/ArticleView";
+import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
@@ -31,12 +32,17 @@ export default function NewsArticlePage({ post, prev, next }: Props) {
   return (
     <>
       {showPreview && (
-        <div className="bg-yellow-100 text-yellow-800 px-4 py-2 text-sm flex justify-between items-center">
-          <span>You’re viewing a preview of this article.</span>
-          <button onClick={viewLive} className="underline">
-            View live
-          </button>
-        </div>
+        <>
+          <Head>
+            <meta name="robots" content="noindex" />
+          </Head>
+          <div className="bg-yellow-100 text-yellow-800 px-4 py-2 text-sm flex justify-between items-center">
+            <span>You’re viewing a preview of this article.</span>
+            <button onClick={viewLive} className="underline">
+              View live
+            </button>
+          </div>
+        </>
       )}
       <ArticleView post={post} prev={prev} next={next} />
     </>

--- a/frontend/pages/privacy.tsx
+++ b/frontend/pages/privacy.tsx
@@ -1,16 +1,23 @@
 import React from "react";
+import Head from "next/head";
 import Page from "@/components/UX/Page";
 import SectionCard from "@/components/UX/SectionCard";
 import Callout from "@/components/UX/Callout";
+import { seoMetaTags, absoluteCanonical } from "@/lib/seo";
 
 export default function Privacy() {
   return (
-    <Page title="Privacy Policy" subtitle="How we collect, use, and protect your data.">
-      <div className="grid gap-6">
-        <Callout variant="info">
-          We keep things simple: only what’s necessary to run the site and improve your experience.
-        </Callout>
-        <SectionCard>
+    <>
+      <Head>
+        {seoMetaTags({ title: "Privacy Policy — WaterNews" })}
+        <link rel="canonical" href={absoluteCanonical("/privacy")} />
+      </Head>
+      <Page title="Privacy Policy" subtitle="How we collect, use, and protect your data.">
+        <div className="grid gap-6">
+          <Callout variant="info">
+            We keep things simple: only what’s necessary to run the site and improve your experience.
+          </Callout>
+          <SectionCard>
           <div className="prose max-w-none">
             <h3>What we collect</h3>
             <ul>
@@ -48,8 +55,9 @@ export default function Privacy() {
               handling of personal information.
             </p>
           </div>
-        </SectionCard>
-      </div>
-    </Page>
+          </SectionCard>
+        </div>
+      </Page>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- lazily load RelatedRail using RecircSkeleton
- add `absoluteCanonical` helper and canonical links across main pages
- include preview `noindex` handling for article pages

## Testing
- `npm test`
- `npm run typecheck` *(fails: pages/api/og/[slug].ts TS1161 Unterminated regular expression literal)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0d307a788329ac5ec0fb8db87d86