### PR TITLE
Use Next.js Link for footer navigation

### DIFF
--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -8,11 +8,21 @@ export default function Footer() {
       <div className="max-w-6xl mx-auto px-4 py-10 flex flex-col sm:flex-row sm:items-center gap-6 sm:gap-8">
         <BrandLogo variant="mark" tone="dark" width={28} height={28} className="opacity-95" />
         <nav className="text-sm flex-1 flex flex-wrap gap-x-6 gap-y-2">
-          <a href="/about" className="hover:underline">About</a>
-          <a href="/about#standards" className="hover:underline">Editorial Standards</a>
-          <a href="/contact" className="hover:underline">Contact</a>
-          <a href="/faq" className="hover:underline">FAQ</a>
-          <a href="/privacy" className="hover:underline">Privacy</a>
+          <Link href="/about" className="hover:underline">
+            About
+          </Link>
+          <Link href="/about#standards" className="hover:underline">
+            Editorial Standards
+          </Link>
+          <Link href="/contact" className="hover:underline">
+            Contact
+          </Link>
+          <Link href="/faq" className="hover:underline">
+            FAQ
+          </Link>
+          <Link href="/privacy" className="hover:underline">
+            Privacy
+          </Link>
         </nav>
         <div className="text-xs text-gray-300">© {new Date().getFullYear()} WaterNewsGY</div>
       </div>


### PR DESCRIPTION
## Summary
- replace footer anchor tags with `next/link` components for internal pages
## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad15fd3af883299f66b6c2ed61075a