### PR TITLE
chore: remove unused Script import from about page

### DIFF
--- a/frontend/pages/about/index.tsx
+++ b/frontend/pages/about/index.tsx
@@ -1,7 +1,6 @@
 import Head from "next/head";
 import Link from "next/link";
 import Image from "next/image";
-import Script from "next/script";
 import SectionCard from "@/components/UX/SectionCard";
 import { colors } from "@/lib/brand-tokens";
 import {


### PR DESCRIPTION
## Summary
- remove unused `Script` import from about page

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find module 'next/og' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ad15feeb0c8329b49ebb42a0be47df