### PR TITLE
refactor: use ReactNode type import in Page

### DIFF
--- a/frontend/components/UX/Page.tsx
+++ b/frontend/components/UX/Page.tsx
@@ -1,4 +1,5 @@
 import { colors } from "@/lib/brand-tokens";
+import type { ReactNode } from "react";
 
 export default function Page({
   title,
@@ -8,8 +9,8 @@ export default function Page({
 }: {
   title: string;
   subtitle?: string;
-  actions?: React.ReactNode;
-  children: React.ReactNode;
+  actions?: ReactNode;
+  children: ReactNode;
 }) {
   return (
     <>


### PR DESCRIPTION
## Summary
- import ReactNode type from react for Page component
- replace React.ReactNode usage with ReactNode

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find module 'next/og' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ad160421c48329879a0979aaee83ea