### PR TITLE
Add alt text for leadership images

### DIFF
--- a/frontend/pages/about/index.tsx
+++ b/frontend/pages/about/index.tsx
@@ -167,7 +167,7 @@ export default function AboutPage() {
               <article key={p.name} className="text-center">
                 <Image
                   src={p.photo}
-                  alt=""
+                  alt={p.name}
                   width={96}
                   height={96}
                   className="mx-auto rounded-full object-cover"

--- a/frontend/pages/about/leadership.tsx
+++ b/frontend/pages/about/leadership.tsx
@@ -90,7 +90,7 @@ export default function LeadershipPage() {
                 {p.photo ? (
                   <Image
                     src={p.photo}
-                    alt=""
+                    alt={p.name}
                     width={96}
                     height={96}
                     className="mx-auto rounded-full object-cover"


### PR DESCRIPTION
## Summary
- add descriptive alt text for leadership team photos
- add leader names to about page highlight images
- verified no remaining headshot images have empty alt attributes

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find module 'next/og')*

------
https://chatgpt.com/codex/tasks/task_e_68ad1607099483298dabc640c81b9016