### PR TITLE
chore: remove unnecessary React import

### DIFF
--- a/frontend/pages/privacy.tsx
+++ b/frontend/pages/privacy.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Head from "next/head";
 import Page from "@/components/UX/Page";
 import SectionCard from "@/components/UX/SectionCard";


### PR DESCRIPTION
## Summary
- clean up privacy page by removing unused React import

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'next/og')*

------
https://chatgpt.com/codex/tasks/task_e_68ad1609abd88329b72edc69343933cf