### PR TITLE
chore: enforce TypeScript-only linting and add type-check CI

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+        working-directory: frontend
+      - run: npm run typecheck
+        working-directory: frontend

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "next/core-web-vitals",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "overrides": [
+    {
+      "files": ["**/*.js"],
+      "rules": {
+        "no-restricted-syntax": [
+          "error",
+          {
+            "selector": "Program",
+            "message": "JavaScript files are not allowed. Use TypeScript instead."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,14 +14,14 @@
     "axios": "^1.6.8",
     "bcryptjs": "^2.4.3",
     "formidable": "^3.5.1",
-    "mongoose": "^8.6.0",
+    "marked": "^12.0.2",
     "mongodb": "^6.6.0",
+    "mongoose": "^8.6.0",
     "next": "14.2.31",
     "next-auth": "^4.24.7",
+    "nodemailer": "^6.9.8",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "marked": "^12.0.2",
-    "nodemailer": "^6.9.8",
     "socket.io": "^4.7.5",
     "socket.io-client": "^4.7.5"
   },
@@ -29,13 +29,16 @@
     "cloudinary": "^1.41.2"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.14",
-    "postcss": "^8.4.21",
-    "tailwindcss": "^3.3.2",
-    "typescript": "^5.5.4",
     "@types/node": "^20.14.10",
     "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0"
+    "@types/react-dom": "^18.3.0",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
+    "autoprefixer": "^10.4.14",
+    "eslint": "^8.57.0",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.2",
+    "typescript": "^5.5.4"
   },
   "engines": {
     "node": ">=18 <=22"


### PR DESCRIPTION
## Summary
- add ESLint config extending TypeScript rules and forbidding `.js`
- include ESLint & @typescript-eslint packages
- add CI workflow running `npm run typecheck`

## Testing
- `npm run typecheck`
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad30ea3a1c83299184090f539aa9ae