### PR TITLE
chore: convert next config to JavaScript

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,5 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
+/** @type {import('next').NextConfig} */
+const nextConfig = {
   reactStrictMode: false,
   images: {
     // Modern config (replaces deprecated images.domains)
@@ -52,4 +51,4 @@ const nextConfig: NextConfig = {
   // },
 };
 
-export default nextConfig;
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- refactor Next.js config from TypeScript to JavaScript and switch to `module.exports`

## Testing
- `npm run build` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden for package formidable)*

------
https://chatgpt.com/codex/tasks/task_e_68adc3b22bdc8329afe73e7e79549a68