### PR TITLE
fix: run og image route on node runtime

### DIFF
--- a/frontend/pages/api/og/[slug].tsx
+++ b/frontend/pages/api/og/[slug].tsx
@@ -5,7 +5,7 @@ import { dbConnect } from '@/lib/server/db';
 import Post from '@/models/Post';
 import { colors, LOGO_MARK } from '@/lib/brandkits/rev2';
 
-export const config = { runtime: 'edge' };
+export const runtime = 'nodejs';
 
 export default async function handler(req: NextRequest) {
   if (req.method !== 'GET') {


### PR DESCRIPTION
## Summary
- switch OG image API route from edge to node runtime

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adc5f385e88329aba67cc7204f7ad6