### PR TITLE
feat: add id and enabled to SectionCard

### DIFF
--- a/components/UX/SectionCard.tsx
+++ b/components/UX/SectionCard.tsx
@@ -1,18 +1,29 @@
 import React from "react";
 
+export interface SectionCardProps {
+  title?: string;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+  className?: string;
+  id?: string;
+  enabled?: boolean;
+}
+
 export default function SectionCard({
   title,
   children,
   footer,
   className = "",
-}: {
-  title?: string;
-  children: React.ReactNode;
-  footer?: React.ReactNode;
-  className?: string;
-}) {
+  id,
+  enabled,
+}: SectionCardProps) {
+  if (enabled === false) return null;
+
   return (
-    <section className={`p-5 rounded-xl ring-1 ring-gray-200 bg-white/70 backdrop-blur ${className}`}>
+    <section
+      id={id}
+      className={`p-5 rounded-xl ring-1 ring-gray-200 bg-white/70 backdrop-blur ${className}`}
+    >
       {title && <h2 className="text-lg font-semibold mb-3">{title}</h2>}
       <div>{children}</div>
       {footer && <div className="mt-4">{footer}</div>}


### PR DESCRIPTION
## Summary
- accept `id` and `enabled` props in SectionCard and export prop type
- render `<section>` with id and return null when disabled

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68af9e791da883299adc4b0cb1029551