### PR TITLE
Add ids to SectionCard components

### DIFF
--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -70,7 +70,7 @@ export default function AboutPage() {
         <p className="mt-2 font-serif text-base opacity-95 md:text-lg">{hero.subtitle}</p>
       </header>
       <main style={brandVars} className="mx-auto -mt-12 mb-16 max-w-5xl px-4">
-        <SectionCard className="mb-8">
+        <SectionCard id="about-mission" className="mb-8">
           <span
             className="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold"
             style={{ background: "var(--brand-tag-bg)", color: "var(--brand-tag-text)" }}
@@ -102,7 +102,7 @@ export default function AboutPage() {
         </SectionCard>
 
         <div className="mb-8 grid gap-8 lg:grid-cols-2">
-          <SectionCard>
+          <SectionCard id="about-who-we-are">
             <h2 className="text-2xl font-bold">{whoWeAre.title}</h2>
             {whoWeAre.paragraphs.map((p, i) => (
               <p key={i} className="mt-2 text-[15px] text-slate-700">
@@ -110,7 +110,7 @@ export default function AboutPage() {
               </p>
             ))}
           </SectionCard>
-          <SectionCard>
+          <SectionCard id="about-diaspora">
             <h2 className="text-2xl font-bold">{diaspora.title}</h2>
             <div className="mt-2 flow-root text-[15px] text-slate-700">
               <Image
@@ -126,7 +126,7 @@ export default function AboutPage() {
           </SectionCard>
         </div>
 
-        <SectionCard className="mb-8">
+        <SectionCard id="about-publish" className="mb-8">
           <h2 className="text-2xl font-bold">{publish.title}</h2>
           <p className="mt-2 text-[15px] text-slate-700">{publish.subtitle}</p>
           <div className="mt-4 grid gap-4 sm:grid-cols-3">
@@ -139,7 +139,7 @@ export default function AboutPage() {
           </div>
         </SectionCard>
 
-        <SectionCard className="mb-8">
+        <SectionCard id="about-values" className="mb-8">
           <h2 className="text-2xl font-bold">{values.title}</h2>
           <p className="mt-2 text-[15px] text-slate-700">{values.subtitle}</p>
           <div className="mt-4 grid gap-4 sm:grid-cols-3">
@@ -152,7 +152,7 @@ export default function AboutPage() {
           </div>
         </SectionCard>
 
-        <SectionCard className="mb-8">
+        <SectionCard id="about-leadership" className="mb-8">
           <span
             className="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold"
             style={{ background: "var(--brand-tag-bg)", color: "var(--brand-tag-text)" }}
@@ -188,7 +188,7 @@ export default function AboutPage() {
           </div>
         </SectionCard>
 
-        <SectionCard className="mb-8">
+        <SectionCard id="about-masthead" className="mb-8">
           <div>
             <Image
               src={masthead.image.src}
@@ -230,7 +230,7 @@ export default function AboutPage() {
 
         <div className="grid gap-8 lg:grid-cols-2">
           <div id="standards">
-            <SectionCard>
+              <SectionCard id="about-standards">
             <h2 className="text-2xl font-bold">{standards.title}</h2>
             <p className="mt-2 text-[15px] text-slate-700">{standards.intro}</p>
             <ul className="mt-3 list-disc space-y-1 pl-5 text-[15px] text-slate-700">
@@ -258,7 +258,7 @@ export default function AboutPage() {
             </div>
             </SectionCard>
           </div>
-          <SectionCard>
+            <SectionCard id="about-reach-us">
             <h2 className="text-2xl font-bold">{reachUs.title}</h2>
             <p className="mt-2 text-[15px] text-slate-700">{reachUs.desc}</p>
             <ul className="mt-4 space-y-4">

--- a/pages/about/leadership.tsx
+++ b/pages/about/leadership.tsx
@@ -78,12 +78,12 @@ export default function LeadershipPage() {
         <h1 className="text-4xl font-extrabold">Leadership Team</h1>
       </header>
       <main style={brandVars} className="mx-auto -mt-12 mb-16 max-w-5xl px-4">
-        <SectionCard>
+          <SectionCard id="leadership-intro">
           <p className="text-[15px] text-slate-700">
             Our executives steer WaterNews with accountability, innovation, and a commitment to regional voices.
           </p>
         </SectionCard>
-        <SectionCard className="mt-8">
+          <SectionCard id="leadership-team" className="mt-8">
           <div className="grid gap-6 sm:grid-cols-2">
             {leaders.map((p) => (
               <article key={p.name} className="text-center">

--- a/pages/careers.tsx
+++ b/pages/careers.tsx
@@ -21,12 +21,12 @@ export default function CareersPage() {
         <h1 className="text-4xl font-extrabold">Careers</h1>
       </header>
       <main className="mx-auto -mt-12 mb-16 max-w-4xl px-4">
-        <SectionCard className="mb-8">
+        <SectionCard id="careers-intro" className="mb-8">
           <p className="text-[15px] text-slate-700">
             We're growing a network of writers, editors, and technologists. Current openings are listed below.
           </p>
         </SectionCard>
-        <SectionCard>
+        <SectionCard id="careers-open-roles">
           <h2 className="text-xl font-bold">Open Roles</h2>
           <ul className="mt-2 list-disc space-y-2 pl-5 text-[15px] text-slate-700">
             <li>News Reporter (freelance)</li>

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -91,7 +91,7 @@ export default function ContactPage() {
       </Head>
       <div style={{ minHeight: "70vh" }}>
         <Page title={current.hero.title} subtitle={current.hero.subtitle}>
-          <SectionCard>
+          <SectionCard id="contact-form">
           {subject === "tip" && current.meta && current.fieldsets.some((f) => f.type === "file") && (
             <div className="mb-3 space-y-1 text-sm text-slate-600">
               {current.meta.anonymousReassure && <p>{current.meta.anonymousReassure}</p>}

--- a/pages/credits.tsx
+++ b/pages/credits.tsx
@@ -54,7 +54,10 @@ export default function CreditsPage() {
         <div className="grid gap-6">
           {credits.map((group) => (
             <div key={group.group}>
-              <SectionCard title={group.group}>
+                <SectionCard
+                  id={`credits-${group.group.toLowerCase().replace(/\s+/g, '-')}`}
+                  title={group.group}
+                >
                 <ul className="space-y-2 text-[15px] text-slate-700">
                   {group.items.map((item) => (
                     <li key={item.name}>

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -23,7 +23,7 @@ export default function FAQ() {
         title="FAQ"
         subtitle="Answers for readers and visitors. For member help, see the NewsRoom dashboard."
       >
-        <SectionCard>
+          <SectionCard id="faq-content">
           <div style={brandVars} className="space-y-6">
             <section>
               <h2 className="font-medium">How do I submit a story tip?</h2>

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -7,7 +7,7 @@ export default function Login() {
   return (
     <Page title="Log in" subtitle="Access the Newsroom to draft and publish.">
       <div className="grid gap-6">
-        <SectionCard>
+          <SectionCard id="login-form">
           {/* Keep your existing NextAuth buttons or credentials form here */}
           <a href="/api/auth/signin" className="px-4 py-2 rounded-md bg-black text-white hover:bg-gray-900 inline-block">
             Continue with email

--- a/pages/newsroom/collab.tsx
+++ b/pages/newsroom/collab.tsx
@@ -90,7 +90,7 @@ export default function Collab() {
           Toggle visibility to let other authors discover and offer help on your draft.
         </Callout>
         <div className="grid gap-6 lg:grid-cols-2">
-          <SectionCard title="My drafts (visibility)">
+            <SectionCard id="collab-my-drafts" title="My drafts (visibility)">
             {loading ? (
               <div>Loading…</div>
             ) : mine.length === 0 ? (
@@ -123,7 +123,7 @@ export default function Collab() {
               </ul>
             )}
           </SectionCard>
-          <SectionCard title="Network drafts">
+            <SectionCard id="collab-network-drafts" title="Network drafts">
             {loading ? (
               <div>Loading…</div>
             ) : network.length === 0 ? (

--- a/pages/newsroom/help.tsx
+++ b/pages/newsroom/help.tsx
@@ -10,14 +10,14 @@ export default function NewsroomHelp() {
         <Callout title="TL;DR">
           Draft → Add media → Submit for review → (optional) Schedule → Publish
         </Callout>
-        <SectionCard title="Writing">
+          <SectionCard id="newsroom-help-writing" title="Writing">
           <ul className="list-disc list-inside text-sm text-gray-700">
             <li>Use headings and short paragraphs for scannability.</li>
             <li>Add captions and alt text for accessibility.</li>
             <li>Link sources — we encourage transparent citations.</li>
           </ul>
         </SectionCard>
-        <SectionCard title="Media">
+          <SectionCard id="newsroom-help-media" title="Media">
           <ul className="list-disc list-inside text-sm text-gray-700">
             <li>Prefer horizontal images ≥ 1600px on the long edge.</li>
             <li>Use the library to reuse approved assets.</li>

--- a/pages/newsroom/media.tsx
+++ b/pages/newsroom/media.tsx
@@ -38,7 +38,7 @@ export default function Media() {
   return (
     <Page title="Media Library" subtitle="Search and reuse newsroom images and video.">
       <div className="grid gap-6">
-        <SectionCard>
+          <SectionCard id="media-search">
           <form onSubmit={onSearch} className="flex gap-2">
             <input
               type="text"
@@ -53,7 +53,7 @@ export default function Media() {
             Shows recent items by default. Searches call Cloudinary only when you submit.
           </p>
         </SectionCard>
-        <SectionCard>
+          <SectionCard id="media-results">
           {loading ? (
             <p className="text-gray-600">Loading…</p>
           ) : items.length === 0 ? (

--- a/pages/newsroom/notice-board.tsx
+++ b/pages/newsroom/notice-board.tsx
@@ -92,7 +92,7 @@ export default function NoticeBoard() {
           Use this space for platform notes, suggestions, and coordination.
         </Callout>
         <div id="new">
-          <SectionCard title="Post a notice">
+            <SectionCard id="notice-board-new" title="Post a notice">
             <form onSubmit={onPost} className="space-y-3">
               <input
                 className="w-full border px-3 py-2 rounded"
@@ -116,7 +116,7 @@ export default function NoticeBoard() {
             </form>
           </SectionCard>
         </div>
-        <SectionCard title="All notices">
+          <SectionCard id="notice-board-list" title="All notices">
           {loading ? (
             <div>Loading…</div>
           ) : items.length === 0 ? (

--- a/pages/newsroom/posts/index.tsx
+++ b/pages/newsroom/posts/index.tsx
@@ -64,7 +64,7 @@ export default function MyPosts() {
   return (
     <Page title="My Posts" subtitle="Published articles you’ve authored">
       <div className="grid gap-6">
-        <SectionCard title="Search">
+          <SectionCard id="posts-search" title="Search">
           <form onSubmit={(e) => e.preventDefault()} className="flex gap-2">
             <input
               className="flex-1 border px-3 py-2 rounded"
@@ -74,7 +74,7 @@ export default function MyPosts() {
             />
           </form>
         </SectionCard>
-        <SectionCard title="Published">
+          <SectionCard id="posts-published" title="Published">
           {loading ? (
             <div>Loading…</div>
           ) : visible.length === 0 ? (

--- a/pages/newsroom/profile.tsx
+++ b/pages/newsroom/profile.tsx
@@ -8,10 +8,10 @@ export default function Profile() {
   return (
     <Page title="Profile & Settings" subtitle="Update your details, photo, and preferences.">
       <div className="grid gap-6 sm:grid-cols-2">
-        <SectionCard title="Profile photo">
+          <SectionCard id="newsroom-profile-photo" title="Profile photo">
           <ProfilePhotoForm />
         </SectionCard>
-        <SectionCard title="Account">
+          <SectionCard id="newsroom-account" title="Account">
           <p className="text-sm text-gray-700">Edit display name, handle, and contact preferences.</p>
           {/* Existing settings form goes here */}
         </SectionCard>

--- a/pages/newsroom/writer-dashboard.tsx
+++ b/pages/newsroom/writer-dashboard.tsx
@@ -31,7 +31,7 @@ export default function WriterDashboard() {
   return (
     <DashboardLayout title="Writer Dashboard" subtitle="Your newsroom overview">
       <div className="grid gap-6">
-        <SectionCard>
+          <SectionCard id="writer-dashboard-stats">
           <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
             <KPI title="Drafts" value={stats?.drafts ?? 0} data={stats?.spark?.drafts ?? []} />
             <KPI title="Scheduled" value={stats?.scheduled ?? 0} data={stats?.spark?.scheduled ?? []} />
@@ -45,7 +45,7 @@ export default function WriterDashboard() {
           </div>
         </SectionCard>
         <div className="grid lg:grid-cols-2 gap-6">
-          <SectionCard title="Quick actions">
+            <SectionCard id="writer-dashboard-actions" title="Quick actions">
             <div className="flex flex-wrap gap-3">
               <Link
                 href="/newsroom"
@@ -73,7 +73,7 @@ export default function WriterDashboard() {
               </Link>
             </div>
           </SectionCard>
-          <SectionCard title="Tips">
+            <SectionCard id="writer-dashboard-tips" title="Tips">
             <ul className="list-disc list-inside text-sm text-gray-700">
               <li>
                 Attach media directly from the editor via <em>/</em> menu or drag-drop.

--- a/pages/notifications.tsx
+++ b/pages/notifications.tsx
@@ -26,7 +26,7 @@ export default function NotificationsPage() {
     <Page title="Notifications" subtitle="Mentions, assignments, reviews, and publication updates.">
       <div className="grid gap-6">
         <Callout variant="info">Notifications appear here and in the bell menu. Older items may auto-archive.</Callout>
-        <SectionCard>
+          <SectionCard id="notifications-list">
           {loading && <div>Loading…</div>}
           {!loading && (!items || items.length === 0) && <div>No notifications yet.</div>}
           {!loading && items && (

--- a/pages/prefs.tsx
+++ b/pages/prefs.tsx
@@ -38,7 +38,7 @@ export default function Prefs() {
   }
   return (
     <Page title="Preferences" subtitle="Control notifications and reading experience.">
-      <SectionCard>
+        <SectionCard id="prefs-form">
         <form onSubmit={onSave} className="space-y-5">
           <div>
             <label className="flex items-center gap-2">

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -16,7 +16,7 @@ export default function Privacy() {
           <Callout variant="info">
             We keep things simple: only what’s necessary to run the site and improve your experience.
           </Callout>
-          <SectionCard>
+            <SectionCard id="privacy-collection">
           <div className="prose max-w-none">
             <h3>What we collect</h3>
             <ul>
@@ -30,7 +30,7 @@ export default function Privacy() {
             <p>Update or delete your account anytime in <strong>Newsroom → Profile &amp; Settings</strong>.</p>
           </div>
         </SectionCard>
-        <SectionCard>
+          <SectionCard id="privacy-governance">
           <div className="prose max-w-none">
             <h3>Governance &amp; Compliance</h3>
             <p>

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -26,7 +26,7 @@ export default function ProfilePage() {
   return (
     <Page title="Your Account" subtitle="Manage profile and settings.">
       <div className="grid gap-6">
-        <SectionCard title="Writer tools">
+          <SectionCard id="profile-writer-tools" title="Writer tools">
           <ul className="list-disc list-inside text-sm text-gray-700">
             <li><a className="underline" href="/newsroom">Open Newsroom</a></li>
             <li><a className="underline" href="/newsroom/posts">My Posts</a></li>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -23,15 +23,15 @@ export default function SearchPage() {
   return (
     <Page title="Search" subtitle="Find stories, authors, and topics.">
       <div className="grid gap-6">
-        <SectionCard>
+          <SectionCard id="search-form">
           <form onSubmit={onSubmit} className="flex gap-2">
             <input className="flex-1 border px-3 py-2 rounded" value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search articles…" />
             <button className="px-4 py-2 rounded-md bg-black text-white hover:bg-gray-900">Search</button>
           </form>
         </SectionCard>
-        {loading && <SectionCard>Searching…</SectionCard>}
+          {loading && <SectionCard id="search-loading">Searching…</SectionCard>}
         {results && (
-          <SectionCard title="Results">
+            <SectionCard id="search-results" title="Results">
             <ul className="space-y-3">
               {results.map((r) => (
                 <li key={r.slug} className="border rounded p-3 hover:bg-gray-50">


### PR DESCRIPTION
## Summary
- add `id` props to all SectionCard instances under `pages/` for section-level control

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af9f31bf888329b3a6504d4a51d195