### PR TITLE
Add Section model and admin API with hook

### DIFF
--- a/lib/useSections.ts
+++ b/lib/useSections.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+
+/** Fetches section enablement map from admin API. */
+export function useSections() {
+  const [sections, setSections] = useState<Record<string, boolean> | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch("/api/admin/sections");
+        const data = await res.json();
+        if (!cancelled) setSections(data?.map || {});
+      } catch {
+        if (!cancelled) setSections({});
+      }
+    }
+    load();
+    return () => { cancelled = true; };
+  }, []);
+  return sections;
+}

--- a/models/Section.ts
+++ b/models/Section.ts
@@ -1,0 +1,20 @@
+import mongoose, { Schema, models, model, type Model } from "mongoose";
+
+export interface SectionDoc {
+  _id: string;
+  id: string;
+  enabled: boolean;
+  context?: Record<string, any> | null;
+}
+
+const SectionSchema = new Schema<SectionDoc>(
+  {
+    id: { type: String, required: true, unique: true, index: true },
+    enabled: { type: Boolean, default: true },
+    context: { type: Schema.Types.Mixed, default: null },
+  },
+  { timestamps: true }
+);
+
+const Section = (models.Section as Model<SectionDoc>) || model<SectionDoc>("Section", SectionSchema);
+export default Section;

--- a/pages/api/admin/sections/index.ts
+++ b/pages/api/admin/sections/index.ts
@@ -1,0 +1,37 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/pages/api/auth/[...nextauth]";
+import { isAdminEmail, isAdminUser } from "@/lib/admin-auth";
+import { dbConnect } from "@/lib/server/db";
+import Section from "@/models/Section";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email || null;
+  const admin = email && ((await isAdminEmail(email)) || (await isAdminUser(email)));
+  if (!admin) return res.status(401).json({ error: "Unauthorized" });
+
+  await dbConnect();
+
+  if (req.method === "GET") {
+    const docs = await Section.find().lean();
+    const map: Record<string, boolean> = {};
+    for (const d of docs) map[d.id] = !!d.enabled;
+    return res.json({ ok: true, sections: docs, map });
+  }
+
+  if (req.method === "PUT") {
+    const { id, enabled, context } = req.body || {};
+    if (!id) return res.status(400).json({ error: "id required" });
+    const update: any = { enabled: !!enabled };
+    if (context !== undefined) update.context = context;
+    const section = await Section.findOneAndUpdate(
+      { id },
+      { $set: update },
+      { upsert: true, new: true }
+    ).lean();
+    return res.json({ ok: true, section });
+  }
+
+  return res.status(405).end();
+}


### PR DESCRIPTION
## Summary
- add `Section` Mongoose model to store feature sections
- introduce `/api/admin/sections` for listing and updating sections
- provide `useSections` hook for fetching section enablement map

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68afa03c15548329a0511dd712e6e1e8