### PR TITLE
Remove unused profile photo copy data file

### DIFF
--- a/data/profilePhotoCopy.ts
+++ b/data/profilePhotoCopy.ts
@@ -1,9 +1,0 @@
-export const profilePhotoCopy = {
-  label: "Profile photo",
-  help: "Upload a photo or avatar (JPG/PNG/WebP, square, 512×512+, ≤2 MB). We’ll crop it to a circle. Logos are OK for organizations.",
-  errors: {
-    tooLarge: "File too large (≤2 MB).",
-    badType: "Use JPG, PNG, or WebP.",
-    generic: "Something went wrong. Try again."
-  }
-};


### PR DESCRIPTION
## Summary
- remove unused `data/profilePhotoCopy.ts`

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0611546608329953933c52b77c909