### PR TITLE
Rev.4 — Restore Tailwind utilities & layout grid

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# Review required for critical layout and style files
+/tailwind.config.ts @waternews/maintainers
+/styles/globals.css @waternews/maintainers
+/components/Newsroom/GlobalShell.tsx @waternews/maintainers
+/components/UX/Page.tsx @waternews/maintainers
+/components/UX/SectionCard.tsx @waternews/maintainers
+/lib/brand-tokens.ts @waternews/maintainers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+## Pre-merge Checklist
+
+- [ ] Did you change Tailwind content globs?
+- [ ] Does _app.tsx still import globals.css first?
+- [ ] Did you add any wrapper that forces flex-col site-wide?
+- [ ] Did you rename a brand token or CSS variable?

--- a/components/Newsroom/GlobalShell.tsx
+++ b/components/Newsroom/GlobalShell.tsx
@@ -304,10 +304,13 @@ function ResponsiveShell({ children }: { children: React.ReactNode }) {
       </a>
       {/* Mobile sticky bar */}
       <MobileTopBar />
-      <div className="flex">
+      <div
+        className="lg:grid lg:gap-8"
+        style={{ gridTemplateColumns: `${railW}px minmax(0,1fr)` }}
+      >
         {/* Desktop rail */}
         <aside
-          className="hidden md:block sticky top-0 h-screen shrink-0 border-r bg-white/70 backdrop-blur"
+          className="hidden lg:block sticky top-0 h-screen border-r bg-white/70 backdrop-blur"
           style={{ width: railW }}
         >
           <RailContents />
@@ -317,7 +320,7 @@ function ResponsiveShell({ children }: { children: React.ReactNode }) {
           <RailContents />
         </MobileDrawer>
         {/* Main content */}
-        <div className="flex-1 min-w-0 md:ml-0">{children}</div>
+        <div className="min-w-0">{children}</div>
       </div>
     </div>
   );

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,6 @@
 import type { AppProps } from 'next/app';
-import { SessionProvider } from 'next-auth/react';
 import '@/styles/globals.css';
+import { SessionProvider } from 'next-auth/react';
 import Head from 'next/head';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 @font-face {
   font-family: 'Inter';
   src: url('/fonts/Inter-Variable.woff2') format('woff2');
@@ -11,10 +15,6 @@
   font-weight: 300 900;
   font-display: swap;
 }
-
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
 
 /* subtle highlight for search matches */
 mark {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,13 @@ import type { Config } from "tailwindcss";
 
 const config: Config = {
   darkMode: "class",
-  content: ["./pages/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./lib/**/*.{js,ts,jsx,tsx,mdx}",
+    "./layouts/**/*.{js,ts,jsx,tsx,mdx}",
+    "./styles/**/*.{css}",
+  ],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- expand Tailwind content globs so utilities compile from pages, components, lib and styles
- ensure global CSS loads base/components/utilities first and is imported before other modules
- switch GlobalShell to a desktop grid layout and add guardrails for critical style files

## Testing
- `npm test`
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b27493c9ac832998d5e5cc5ea79cbd