### PR TITLE
fix: restore site layout via PostCSS config

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,8 +1,6 @@
-const config = {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
   },
 };
-
-export default config;


### PR DESCRIPTION
## Summary
- ensure PostCSS config is recognized by Next by switching to CommonJS `postcss.config.cjs`
- include Tailwind and autoprefixer plugins to restore styling

## Testing
- `npm test`
- `npm run build` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/formidable)*

------
https://chatgpt.com/codex/tasks/task_e_68b27b2c6a008329bcd3ccaf7ba7d022