### PR TITLE
feat(rev5): add "Streams" media-first feed

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -24,7 +24,12 @@ export default function Footer() {
             Privacy
           </Link>
         </nav>
-        <div className="text-xs text-gray-300">© {new Date().getFullYear()} WaterNewsGY</div>
+        <div className="text-xs text-gray-300">
+          © {new Date().getFullYear()} WaterNewsGY ·{' '}
+          <Link href="/streams" className="hover:underline">
+            Streams
+          </Link>
+        </div>
       </div>
     </footer>
   );

--- a/components/SmartMenu.tsx
+++ b/components/SmartMenu.tsx
@@ -33,6 +33,9 @@ export default function SmartMenu() {
       <Link href="/topics" className="hover:underline">
         Categories
       </Link>
+      <Link href="/streams" className="hover:underline">
+        Streams
+      </Link>
       <Link href="/credits" className="hover:underline">
         Credits
       </Link>

--- a/components/Streams/StreamCard.tsx
+++ b/components/Streams/StreamCard.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useState, type FC } from 'react';
+import type { MediaSlice } from '@/lib/types/media';
+import Link from 'next/link';
+import Image from 'next/image';
+import { cldImage, cldVideoPoster } from '@/lib/cloudinary';
+
+const StreamCard: FC<{ item: MediaSlice }> = ({ item }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => setActive(entry.isIntersecting && entry.intersectionRatio > 0.7));
+      },
+      { threshold: [0, 0.5, 0.7, 1] }
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const v = videoRef.current;
+    if (!v) return;
+    if (active) {
+      v.play().catch(() => {});
+    } else {
+      v.pause();
+    }
+  }, [active]);
+
+  const goLink = `/${item.article.slug}`;
+  const isVideo = item.type === 'video';
+  const poster = item.poster || (isVideo ? cldVideoPoster(item.src) : undefined);
+
+  return (
+    <div ref={ref} className="snap-start h-screen w-full flex items-center justify-center relative">
+      <div className="w-full h-full max-w-[700px] mx-auto relative">
+        <Link href={goLink} className="absolute top-3 left-3 right-3 z-20 flex justify-between items-center">
+          <div className="px-3 py-1 rounded-full bg-black/50 text-white text-sm backdrop-blur">
+            {item.article.title}
+          </div>
+          <div className="px-3 py-1 rounded-full bg-black/50 text-white text-sm backdrop-blur">Read story →</div>
+        </Link>
+        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-20">
+          <div className="px-3 py-1 rounded-full bg-black/40 text-white text-xs">Swipe / scroll for more</div>
+        </div>
+
+        <div className="w-full h-full relative bg-black">
+          {isVideo ? (
+            <video
+              ref={videoRef}
+              className="w-full h-full object-contain"
+              src={item.src}
+              poster={poster}
+              muted
+              loop
+              playsInline
+              preload="metadata"
+              controls={false}
+            />
+          ) : (
+            <Image
+              alt={item.article.title}
+              src={cldImage(item.src, { w: 1440 })}
+              fill
+              className="object-contain"
+              sizes="100vw"
+              priority={false}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StreamCard;

--- a/lib/models/article.schema.md
+++ b/lib/models/article.schema.md
@@ -1,0 +1,29 @@
+# Article mediaAssets — Rev5 (Streams)
+
+Extend Article documents with optional `mediaAssets` to power Streams precisely:
+
+```ts
+type MediaAsset = {
+  type: 'image' | 'video';
+  url?: string;          // absolute URL (e.g., Cloudinary delivery or mp4)
+  publicId?: string;     // Cloudinary publicId if you store IDs instead of URLs
+  poster?: string;       // optional image poster for video
+  width?: number;
+  height?: number;
+  duration?: number;     // seconds, optional
+  provider?: 'cloudinary' | 'static' | 'other';
+};
+```
+
+Stored as:
+```ts
+{
+  _id: ObjectId,
+  slug: string,
+  title: string,
+  // ...
+  mediaAssets?: MediaAsset[],
+}
+```
+
+`/api/media/streams` also falls back to `coverImage` or the first media URL found in `content` when `mediaAssets` is absent.

--- a/lib/server/cloudinary.ts
+++ b/lib/server/cloudinary.ts
@@ -1,0 +1,65 @@
+import { v2 as cloudinary } from "cloudinary";
+
+const url = process.env.CLOUDINARY_URL; // preferred single var
+if (url) {
+  cloudinary.config({ secure: true }); // CLOUDINARY_URL auto-parsed
+} else {
+  // fallback if you use separate vars (optional)
+  cloudinary.config({
+    cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+    api_key: process.env.CLOUDINARY_API_KEY,
+    api_secret: process.env.CLOUDINARY_API_SECRET,
+    secure: true,
+  });
+}
+
+export interface UploadedFile {
+  url: string;
+  public_id: string;
+  resource_type: string;
+  bytes: number;
+  width: number;
+  height: number;
+  format: string;
+}
+
+export async function uploadLocalFile(
+  filepath: string,
+  folder = "waternews/uploads"
+): Promise<UploadedFile> {
+  const res: any = await cloudinary.uploader.upload(filepath, {
+    folder,
+    resource_type: "auto",
+    // eager transforms later if needed
+  });
+  return {
+    url: res.secure_url,
+    public_id: res.public_id,
+    resource_type: res.resource_type,
+    bytes: res.bytes,
+    width: res.width,
+    height: res.height,
+    format: res.format,
+  };
+}
+
+export interface ListMediaOptions {
+  prefix?: string;
+  max_results?: number;
+  next_cursor?: string;
+}
+
+// NEW: list media for library
+export async function listMedia({
+  prefix = "waternews",
+  max_results = 40,
+  next_cursor,
+}: ListMediaOptions = {}): Promise<any> {
+  const res = await cloudinary.search
+    .expression(`folder:${prefix}*`)
+    .sort_by("created_at", "desc")
+    .max_results(max_results)
+    .next_cursor(next_cursor || undefined)
+    .execute();
+  return res; // { resources, next_cursor }
+}

--- a/lib/types/media.ts
+++ b/lib/types/media.ts
@@ -1,0 +1,17 @@
+export type MediaType = 'image' | 'video';
+
+export interface MediaSlice {
+  id: string;
+  type: MediaType;
+  src: string;
+  poster?: string;
+  width?: number;
+  height?: number;
+  duration?: number;
+  provider?: 'cloudinary' | 'static' | 'other';
+  article: {
+    id: string;
+    slug: string;
+    title: string;
+  };
+}

--- a/pages/api/inbox/create.ts
+++ b/pages/api/inbox/create.ts
@@ -4,7 +4,7 @@ import formidable from "formidable";
 import fs from "fs";
 import { getDb } from "@/lib/db";
 import { routeSubject } from "@/lib/cms-routing";
-import { uploadLocalFile } from "@/lib/cloudinary";
+import { uploadLocalFile } from "@/lib/server/cloudinary";
 
 export const config = { api: { bodyParser: false } };
 

--- a/pages/api/media/list.ts
+++ b/pages/api/media/list.ts
@@ -6,7 +6,7 @@ try {
   // Defer to runtime; avoids type resolution during build/typecheck
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   cloudinary = require('cloudinary').v2;
-  require('@/lib/cloudinary'); // keep your config side-effects
+  require('@/lib/server/cloudinary'); // keep your config side-effects
 } catch (_) {
   cloudinary = null;
 }

--- a/pages/api/media/streams.ts
+++ b/pages/api/media/streams.ts
@@ -1,0 +1,115 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { ObjectId } from 'mongodb';
+import { getDb } from '@/lib/db';
+import type { MediaSlice } from '@/lib/types/media';
+
+/**
+ * GET /api/media/streams?sort=latest|trending&page=1
+ * Returns a flattened list of media slices across published articles.
+ * Separate from existing /api/media/* endpoints to avoid collisions.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const sort = (req.query.sort as string) || 'latest';
+    const page = Math.max(parseInt((req.query.page as string) || '1', 10), 1);
+    const pageSize = 12;
+    const skip = (page - 1) * pageSize;
+
+    const db = await getDb();
+    if (!db) return res.status(500).json({ error: 'db_not_configured' });
+    const Articles = db.collection('articles');
+
+    const sortStage =
+      sort === 'trending'
+        ? { 'stats.score': -1 as const, publishedAt: -1 as const }
+        : { publishedAt: -1 as const, _id: -1 as const };
+
+    const cursor = Articles.find(
+      { status: 'published' },
+      {
+        projection: {
+          _id: 1,
+          slug: 1,
+          title: 1,
+          publishedAt: 1,
+          mediaAssets: 1,
+          coverImage: 1,
+          content: 1,
+        },
+        sort: sortStage,
+        skip,
+        limit: pageSize,
+      }
+    );
+
+    const docs = await cursor.toArray();
+
+    const flatten = (doc: any): MediaSlice[] => {
+      const articleBase = {
+        id: (doc._id as ObjectId).toString(),
+        slug: doc.slug,
+        title: doc.title,
+      };
+      const slices: MediaSlice[] = [];
+
+      // Preferred explicit media assets
+      if (Array.isArray(doc.mediaAssets) && doc.mediaAssets.length) {
+        for (const m of doc.mediaAssets) {
+          const id = `${articleBase.id}:${m.url || m.publicId || Math.random().toString(36).slice(2)}`;
+          slices.push({
+            id,
+            type: m.type === 'video' ? 'video' : 'image',
+            src: m.url || m.publicId,
+            poster: m.poster,
+            duration: m.duration,
+            width: m.width,
+            height: m.height,
+            provider: m.provider || 'other',
+            article: articleBase,
+          });
+        }
+        return slices;
+      }
+
+      // Fallback: coverImage
+      if (doc.coverImage) {
+        slices.push({
+          id: `${articleBase.id}:cover`,
+          type: 'image',
+          src: doc.coverImage,
+          article: articleBase,
+        });
+        return slices;
+      }
+
+      // Last resort: sniff first media URL in content
+      if (typeof doc.content === 'string') {
+        const imgMatch = doc.content.match(/https?:[^"' )]+\.(?:png|jpe?g|webp|gif)/i);
+        const vidMatch = doc.content.match(/https?:[^"' )]+\.(?:mp4|webm|m3u8)/i);
+        if (vidMatch) {
+          slices.push({
+            id: `${articleBase.id}:autoVid`,
+            type: 'video',
+            src: vidMatch[0],
+            article: articleBase,
+          });
+        } else if (imgMatch) {
+          slices.push({
+            id: `${articleBase.id}:autoImg`,
+            type: 'image',
+            src: imgMatch[0],
+            article: articleBase,
+          });
+        }
+      }
+
+      return slices;
+    };
+
+    const media = docs.flatMap(flatten);
+    res.status(200).json({ page, pageSize, count: media.length, items: media });
+  } catch (err: any) {
+    console.error(err);
+    res.status(500).json({ error: 'failed_to_load_streams' });
+  }
+}

--- a/pages/streams.tsx
+++ b/pages/streams.tsx
@@ -1,0 +1,81 @@
+import Head from 'next/head';
+import { useEffect, useRef, useState } from 'react';
+import type { MediaSlice } from '@/lib/types/media';
+import StreamCard from '@/components/Streams/StreamCard';
+
+export default function StreamsPage() {
+  const [items, setItems] = useState<MediaSlice[]>([]);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [done, setDone] = useState(false);
+  const sentinel = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const fetchPage = async () => {
+      if (loading || done) return;
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/media/streams?sort=latest&page=${page}`);
+        const data = await res.json();
+        setItems((prev) => prev.concat(data.items));
+        if (data.items.length === 0) setDone(true);
+      } catch {
+        // ignore
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchPage();
+  }, [page, done, loading]);
+
+  useEffect(() => {
+    const el = sentinel.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          if (e.isIntersecting) setPage((p) => p + 1);
+        });
+      },
+      { rootMargin: '200px' }
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  // Keyboard navigation: Up/Down by viewport height
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowDown') window.scrollBy({ top: window.innerHeight, behavior: 'smooth' });
+      if (e.key === 'ArrowUp') window.scrollBy({ top: -window.innerHeight, behavior: 'smooth' });
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  return (
+    <>
+      <Head>
+        <title>Streams | WaterNews</title>
+        <meta name="description" content="Quick-scroll media stream of WaterNews stories" />
+      </Head>
+      <main className="w-full h-screen overflow-y-scroll snap-y snap-mandatory no-scrollbar bg-black text-white">
+        {items.map((it) => (
+          <StreamCard key={it.id} item={it} />
+        ))}
+        <div ref={sentinel} className="h-[40vh] w-full flex items-center justify-center text-sm opacity-70">
+          {loading ? 'Loading more…' : done ? 'You’ve reached the end' : ''}
+        </div>
+      </main>
+      <style jsx global>{`
+        .no-scrollbar::-webkit-scrollbar {
+          display: none;
+        }
+        .no-scrollbar {
+          -ms-overflow-style: none;
+          scrollbar-width: none;
+        }
+      `}</style>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add MediaSlice type and Cloudinary helpers for media transforms
- implement `/api/media/streams` and `/streams` UI for snap-scrolling media feed
- update navigation to include Streams and document `mediaAssets` article schema

## Testing
- `npm test`
- `npm run typecheck`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b27d17ddfc832991ce5cf10349a484