### PR TITLE
feat: copy draft media on publish

### DIFF
--- a/lib/models/article.schema.md
+++ b/lib/models/article.schema.md
@@ -35,4 +35,16 @@ Stored as:
 4) Reorder assets (top = first in Streams). For videos, set a poster.
 5) Click Save mediaAssets.
 
-> If you attach to a Draft and then publish, ensure your publish pipeline copies mediaAssets to the Article. If not yet wired, attach directly to the published Article after publishing.
+> If you attach to a Draft and then publish, ensure your publish pipeline copies mediaAssets to the Article.
+> If not yet wired, attach directly to the published Article after publishing.
+
+### Guaranteed copy during publish
+If you prefer to keep using the existing publish flow, call:
+
+```
+POST /api/newsroom/drafts/:id/publish-with-media
+```
+
+This endpoint:
+1) Invokes your current `/api/newsroom/drafts/:id/publish`.
+2) Copies `draft.mediaAssets` → `article.mediaAssets` (skips if article already has media unless `?force=true`).

--- a/lib/server/streams-copy.ts
+++ b/lib/server/streams-copy.ts
@@ -1,0 +1,58 @@
+import { ObjectId } from 'mongodb';
+import { getDb } from '../db';
+
+const isValidObjectId = (id: string) => /^[0-9a-fA-F]{24}$/.test(id);
+
+type CopyArgs = {
+  draftId: string;
+  articleId?: string | null;
+  slug?: string | null;
+  force?: boolean;
+};
+
+export async function copyDraftMediaAssetsToArticle(args: CopyArgs) {
+  const { draftId, articleId, slug, force = false } = args;
+  const db = await getDb();
+  const Drafts = db.collection('drafts');
+  const Articles = db.collection('articles');
+
+  if (!isValidObjectId(draftId)) {
+    return { copied: false, reason: 'invalid_draft_id' as const };
+  }
+
+  const draft = await Drafts.findOne(
+    { _id: new ObjectId(draftId) },
+    { projection: { mediaAssets: 1, slug: 1 } }
+  );
+  if (!draft) return { copied: false, reason: 'draft_not_found' as const };
+  const mediaAssets = Array.isArray(draft.mediaAssets) ? draft.mediaAssets : [];
+  if (!mediaAssets.length) return { copied: false, reason: 'no_media_on_draft' as const };
+
+  // Resolve target article
+  let filter: any = null;
+  if (articleId && isValidObjectId(articleId)) {
+    filter = { _id: new ObjectId(articleId) };
+  } else if (slug || draft.slug) {
+    filter = { slug: slug || draft.slug };
+  } else {
+    return { copied: false, reason: 'no_article_selector' as const };
+  }
+
+  if (!force) {
+    const existing = await Articles.findOne(filter, { projection: { _id: 1, mediaAssets: 1, slug: 1 } });
+    if (!existing) return { copied: false, reason: 'article_not_found' as const };
+    if (Array.isArray(existing.mediaAssets) && existing.mediaAssets.length) {
+      return { copied: false, reason: 'article_already_has_media' as const };
+    }
+  }
+
+  const res = await Articles.updateOne(
+    filter,
+    { $set: { mediaAssets, updatedAt: new Date() } }
+  );
+  return {
+    copied: res.matchedCount > 0 && res.modifiedCount > 0,
+    reason: res.matchedCount ? 'ok' : ('article_not_found' as const),
+  };
+}
+

--- a/pages/api/newsroom/drafts/[id]/publish-with-media.ts
+++ b/pages/api/newsroom/drafts/[id]/publish-with-media.ts
@@ -1,0 +1,85 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+import { copyDraftMediaAssetsToArticle } from '@/lib/server/streams-copy';
+import { getDb } from '@/lib/db';
+import { ObjectId } from 'mongodb';
+
+const isValidObjectId = (id: string) => /^[0-9a-fA-F]{24}$/.test(id);
+
+/**
+ * POST /api/newsroom/drafts/:id/publish-with-media?force=true|false
+ * 1) Calls existing /api/newsroom/drafts/:id/publish (for your normal pipeline)
+ * 2) Copies draft.mediaAssets -> article.mediaAssets (if article has none, or force=true)
+ *
+ * Uses NEXTAUTH_URL to call the internal publish route and forwards newsroom session cookies.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) return res.status(401).json({ error: 'unauthorized' });
+
+  const draftId = req.query.id as string;
+  if (!draftId || !isValidObjectId(draftId)) {
+    return res.status(400).json({ error: 'invalid_draft_id' });
+  }
+
+  const force = String(req.query.force || '').toLowerCase() === 'true';
+  const base = process.env.NEXTAUTH_URL; // e.g. https://waternews.onrender.com
+  if (!base) return res.status(500).json({ error: 'missing_NEXTAUTH_URL' });
+
+  // Call the existing publish endpoint, forwarding session cookies for auth
+  const cookie = req.headers.cookie || '';
+  const publishUrl = `${base}/api/newsroom/drafts/${encodeURIComponent(draftId)}/publish`;
+  const pubResp = await fetch(publishUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      // forward session cookies so next-auth authorizes this server-side call
+      ...(cookie ? { cookie } : {}),
+    },
+    // forward payload if your pipeline expects it (e.g., { publishAt, sectionId, ... })
+    body: req.body && typeof req.body === 'string' ? req.body : JSON.stringify(req.body || {}),
+  });
+
+  let publishData: any = null;
+  try {
+    publishData = await pubResp.json();
+  } catch {
+    // keep as null if no JSON
+  }
+
+  if (!pubResp.ok) {
+    return res.status(pubResp.status).json({ error: 'publish_failed', detail: publishData || null });
+  }
+
+  // Try to extract article identifiers from publish response or fallback to draft
+  let articleId: string | null = publishData?.articleId || publishData?.article?._id || publishData?.post?._id || null;
+  let slug: string | null = publishData?.slug || publishData?.article?.slug || publishData?.post?.slug || null;
+
+  if (!articleId && !slug) {
+    // Fallback: read draft for its slug; most pipelines publish using draft.slug
+    const db = await getDb();
+    const draft = await db.collection('drafts').findOne(
+      { _id: new ObjectId(draftId) },
+      { projection: { slug: 1 } }
+    );
+    slug = (draft as any)?.slug || null;
+  }
+
+  const copyRes = await copyDraftMediaAssetsToArticle({ draftId, articleId, slug, force });
+
+  return res.status(200).json({
+    ok: true,
+    publish: publishData,
+    mediaAssetsCopied: copyRes.copied,
+    reason: copyRes.reason,
+    articleId,
+    slug,
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `copyDraftMediaAssetsToArticle` util to migrate draft media assets to the published article
- expose `/api/newsroom/drafts/:id/publish-with-media` endpoint that publishes draft then copies media assets
- document new publish-with-media flow in article schema

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b28199e5a48329a9b0e19d2a09593c