### PR TITLE
feat: add middleware and stream telemetry

### DIFF
--- a/components/Streams/StreamCard.tsx
+++ b/components/Streams/StreamCard.tsx
@@ -4,10 +4,14 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { cldImage, cldVideoPoster } from '@/lib/cloudinary';
 
-const StreamCard: FC<{ item: MediaSlice }> = ({ item }) => {
+const StreamCard: FC<{ item: MediaSlice; onActive?: (item: MediaSlice) => void }> = ({
+  item,
+  onActive,
+}) => {
   const ref = useRef<HTMLDivElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
   const [active, setActive] = useState(false);
+  const activated = useRef(false);
 
   useEffect(() => {
     const el = ref.current;
@@ -31,6 +35,17 @@ const StreamCard: FC<{ item: MediaSlice }> = ({ item }) => {
       v.pause();
     }
   }, [active]);
+
+  // Notify page when this card becomes active (once per activation streak)
+  useEffect(() => {
+    if (active && !activated.current) {
+      activated.current = true;
+      onActive?.(item);
+    }
+    if (!active) {
+      activated.current = false;
+    }
+  }, [active, item, onActive]);
 
   const goLink = `/${item.article.slug}`;
   const isVideo = item.type === 'video';

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+// Transparently rewrite newsroom draft publish → publish-with-media
+export function middleware(req: NextRequest) {
+  const { pathname, search } = req.nextUrl;
+  // Match /api/newsroom/drafts/:id/publish exactly
+  const m = pathname.match(/^\/api\/newsroom\/drafts\/([^/]+)\/publish$/);
+  if (m && req.method === 'POST') {
+    const id = m[1];
+    const url = req.nextUrl.clone();
+    url.pathname = `/api/newsroom/drafts/${id}/publish-with-media`;
+    url.search = search; // preserve any ?force=true etc.
+    return NextResponse.rewrite(url);
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/api/newsroom/drafts/:path*/publish'],
+};
+

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-dom": "18.3.1",
     "nodemailer": "^6.9.8",
     "socket.io": "^4.7.5",
-    "socket.io-client": "^4.7.5"
+    "socket.io-client": "^4.7.5",
+    "swr": "^2.2.2"
   },
   "optionalDependencies": {
     "cloudinary": "^1.41.2"

--- a/pages/streams.tsx
+++ b/pages/streams.tsx
@@ -1,32 +1,30 @@
 import Head from 'next/head';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
+import useSWRInfinite from 'swr/infinite';
 import type { MediaSlice } from '@/lib/types/media';
 import StreamCard from '@/components/Streams/StreamCard';
 
-export default function StreamsPage() {
-  const [items, setItems] = useState<MediaSlice[]>([]);
-  const [page, setPage] = useState(1);
-  const [loading, setLoading] = useState(false);
-  const [done, setDone] = useState(false);
-  const sentinel = useRef<HTMLDivElement>(null);
+type Resp = { page: number; pageSize: number; count: number; items: MediaSlice[] };
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
-  useEffect(() => {
-    const fetchPage = async () => {
-      if (loading || done) return;
-      setLoading(true);
-      try {
-        const res = await fetch(`/api/media/streams?sort=latest&page=${page}`);
-        const data = await res.json();
-        setItems((prev) => prev.concat(data.items));
-        if (data.items.length === 0) setDone(true);
-      } catch {
-        // ignore
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchPage();
-  }, [page, done, loading]);
+export default function StreamsPage() {
+  // URL sort param: latest | trending
+  const params = new URLSearchParams(typeof window === 'undefined' ? '' : window.location.search);
+  const sort = (params.get('sort') === 'trending' ? 'trending' : 'latest') as 'latest' | 'trending';
+
+  const getKey = (pageIndex: number, previousPageData: Resp | null) => {
+    if (previousPageData && previousPageData.items.length === 0) return null;
+    const page = pageIndex + 1;
+    return `/api/media/streams?sort=${sort}&page=${page}`;
+  };
+
+  const { data, size, setSize, isValidating } = useSWRInfinite<Resp>(getKey, fetcher, {
+    revalidateOnFocus: false,
+  });
+
+  const items = (data || []).flatMap((d) => d.items);
+  const sentinel = useRef<HTMLDivElement>(null);
+  const seen = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     const el = sentinel.current;
@@ -34,14 +32,14 @@ export default function StreamsPage() {
     const io = new IntersectionObserver(
       (entries) => {
         entries.forEach((e) => {
-          if (e.isIntersecting) setPage((p) => p + 1);
+          if (e.isIntersecting) setSize((p) => p + 1);
         });
       },
       { rootMargin: '200px' }
     );
     io.observe(el);
     return () => io.disconnect();
-  }, []);
+  }, [setSize]);
 
   // Keyboard navigation: Up/Down by viewport height
   useEffect(() => {
@@ -53,20 +51,45 @@ export default function StreamsPage() {
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
+  function onActive(item: MediaSlice) {
+    if (seen.current.has(item.id)) return;
+    seen.current.add(item.id);
+    // Fire-and-forget telemetry; /api/telemetry/events already exists in your repo
+    fetch('/api/telemetry/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'streams_view',
+        itemId: item.id,
+        mediaType: item.type,
+        articleId: item.article.id,
+        slug: item.article.slug,
+        ts: Date.now(),
+      }),
+    }).catch(() => {});
+  }
+
   return (
     <>
       <Head>
         <title>Streams | WaterNews</title>
         <meta name="description" content="Quick-scroll media stream of WaterNews stories" />
       </Head>
-      <main className="w-full h-screen overflow-y-scroll snap-y snap-mandatory no-scrollbar bg-black text-white">
-        {items.map((it) => (
-          <StreamCard key={it.id} item={it} />
-        ))}
-        <div ref={sentinel} className="h-[40vh] w-full flex items-center justify-center text-sm opacity-70">
-          {loading ? 'Loading more…' : done ? 'You’ve reached the end' : ''}
+      <div className="w-full bg-black text-white">
+        <div className="max-w-[700px] mx-auto py-2 flex gap-2 px-3 text-sm">
+          <SortButton label="Latest" active={sort === 'latest'} href="/streams?sort=latest" />
+          <SortButton label="Trending" active={sort === 'trending'} href="/streams?sort=trending" />
+          <div className="ml-auto opacity-70">Streams</div>
         </div>
-      </main>
+        <main className="h-screen overflow-y-scroll snap-y snap-mandatory no-scrollbar">
+          {items.map((it) => (
+            <StreamCard key={it.id} item={it} onActive={onActive} />
+          ))}
+          <div ref={sentinel} className="h-[40vh] w-full flex items-center justify-center text-sm opacity-70">
+            {isValidating ? 'Loading more…' : 'You’ve reached the end'}
+          </div>
+        </main>
+      </div>
       <style jsx global>{`
         .no-scrollbar::-webkit-scrollbar {
           display: none;
@@ -79,3 +102,18 @@ export default function StreamsPage() {
     </>
   );
 }
+
+function SortButton({ label, active, href }: { label: string; active: boolean; href: string }) {
+  return (
+    <a
+      href={href}
+      className={[
+        'px-3 py-1 rounded-full border',
+        active ? 'bg-white text-black border-white' : 'border-white/30 hover:bg-white/10',
+      ].join(' ')}
+    >
+      {label}
+    </a>
+  );
+}
+

--- a/types/swr.d.ts
+++ b/types/swr.d.ts
@@ -1,0 +1,4 @@
+declare module 'swr/infinite' {
+  const useSWRInfinite: <T = any>(getKey: any, fetcher: any, config?: any) => any;
+  export default useSWRInfinite;
+}


### PR DESCRIPTION
## Summary
- rewrite newsroom publish route to publish-with-media via middleware
- track active stream items and send telemetry
- add sorting controls using SWR infinite loading

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find module 'next/server')*


------
https://chatgpt.com/codex/tasks/task_e_68b38649143483299897ed982ec9eca1