### PR TITLE
feat(rev5-d): Streams analytics (sink + admin dashboard)

### DIFF
--- a/lib/server/db.ts
+++ b/lib/server/db.ts
@@ -1,3 +1,4 @@
 export { dbConnect } from '../mongodb';
+export { getDb } from '../db';
 
 

--- a/lib/telemetry.ts
+++ b/lib/telemetry.ts
@@ -19,7 +19,8 @@ export function getStreamsSessionId() {
 
 export function postEvent(type: string, payload: Record<string, any>) {
   if (typeof window === 'undefined') return;
-  const url = '/api/telemetry/events';
+  // Use our dedicated Streams telemetry endpoint so we control storage/aggregation.
+  const url = '/api/telemetry/streams';
   const body = JSON.stringify({ type, sid: getStreamsSessionId(), ...payload });
   try {
     if ('sendBeacon' in navigator) {

--- a/pages/admin/analytics/streams.tsx
+++ b/pages/admin/analytics/streams.tsx
@@ -1,0 +1,94 @@
+import Head from 'next/head';
+import useSWR from 'swr';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../../api/auth/[...nextauth]';
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+export async function getServerSideProps(ctx: any) {
+  const session = await getServerSession(ctx.req, ctx.res, authOptions);
+  if (!session) {
+    return { redirect: { destination: '/login?next=/admin/analytics/streams', permanent: false } };
+  }
+  const admins = (process.env.ADMIN_EMAILS || '').split(',').map((s) => s.trim().toLowerCase());
+  if (!admins.includes((session.user?.email || '').toLowerCase())) {
+    return { notFound: true };
+  }
+  return { props: {} };
+}
+
+export default function StreamsAnalyticsPage() {
+  const { data, error } = useSWR('/api/admin/analytics/streams?days=7', fetcher, { refreshInterval: 30000 });
+  const rows: any[] = data?.rows || [];
+  return (
+    <>
+      <Head>
+        <title>Admin · Streams Analytics</title>
+      </Head>
+      <main className="max-w-6xl mx-auto px-4 py-6">
+        <h1 className="text-2xl font-semibold mb-1">Streams Analytics</h1>
+        <p className="text-gray-600 mb-6">Views, dwell time, and completion (last 7 days).</p>
+        {error && <div className="text-red-600">Failed to load.</div>}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+          <StatCard label="Tracked slugs" value={rows.length} />
+          <StatCard label="Top views" value={Math.max(0, ...rows.map((r) => r.views || 0))} />
+          <StatCard label="Top completion" value={`${Math.round(Math.max(0, ...rows.map((r) => (r.completionRate || 0) * 100)))}%`} />
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="text-left border-b">
+                <Th>Slug</Th>
+                <Th>Views</Th>
+                <Th>Avg Dwell</Th>
+                <Th>Plays</Th>
+                <Th>Completes</Th>
+                <Th>Completion</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.slug} className="border-b hover:bg-gray-50">
+                  <Td><a className="text-blue-600 hover:underline" href={`/${r.slug}`}>{r.slug}</a></Td>
+                  <Td>{r.views}</Td>
+                  <Td>{formatMs(r.avgDwellMs)}</Td>
+                  <Td>{r.plays}</Td>
+                  <Td>{r.completes}</Td>
+                  <Td>{Math.round((r.completionRate || 0) * 100)}%</Td>
+                </tr>
+              ))}
+              {rows.length === 0 && (
+                <tr><td className="py-6 text-center text-gray-500" colSpan={6}>No data yet.</td></tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </main>
+    </>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div className="p-4 border rounded bg-white shadow-sm">
+      <div className="text-xs uppercase text-gray-500">{label}</div>
+      <div className="text-2xl font-semibold">{value}</div>
+    </div>
+  );
+}
+
+function Th({ children }: { children: any }) {
+  return <th className="py-2 pr-4 font-semibold">{children}</th>;
+}
+function Td({ children }: { children: any }) {
+  return <td className="py-2 pr-4">{children}</td>;
+}
+function formatMs(ms: number) {
+  if (!ms) return '0s';
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rs = s % 60;
+  return `${m}m ${rs}s`;
+}
+

--- a/pages/api/admin/analytics/streams.ts
+++ b/pages/api/admin/analytics/streams.ts
@@ -1,0 +1,102 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getDb } from '../../../../lib/server/db';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../../auth/[...nextauth]';
+
+function isAdminEmail(email?: string | null) {
+  if (!email) return false;
+  const list = (process.env.ADMIN_EMAILS || '').split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
+  return list.includes(email.toLowerCase());
+}
+
+/**
+ * GET /api/admin/analytics/streams?from=2025-08-01&to=2025-08-31
+ * or /api/admin/analytics/streams?days=7  (default)
+ *
+ * Returns per-slug metrics: views, avgDwellMs, plays, completes, completionRate
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session || !isAdminEmail((session.user as any)?.email)) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+  const db = await getDb();
+  const coll = db.collection('streams_events');
+
+  const now = Date.now();
+  const { from, to, days } = req.query as { from?: string; to?: string; days?: string };
+  let startTs: number;
+  let endTs: number;
+  if (from || to) {
+    startTs = from ? Date.parse(from) : now - 7 * 24 * 3600 * 1000;
+    endTs = to ? Date.parse(to) : now;
+  } else {
+    const d = Math.max(1, Math.min(90, parseInt(days || '7', 10) || 7));
+    startTs = now - d * 24 * 3600 * 1000;
+    endTs = now;
+  }
+
+  // Views per slug
+  const viewsAgg = await coll
+    .aggregate([
+      { $match: { type: 'streams_view', ts: { $gte: startTs, $lt: endTs } } },
+      { $group: { _id: '$slug', views: { $sum: 1 } } },
+      { $project: { _id: 0, slug: '$_id', views: 1 } },
+    ])
+    .toArray();
+
+  // Dwell: focus end events carry dwellMs
+  const dwellAgg = await coll
+    .aggregate([
+      { $match: { type: 'streams_focus', ts: { $gte: startTs, $lt: endTs }, phase: 'end' } },
+      { $group: { _id: '$slug', totalDwellMs: { $sum: '$dwellMs' }, ends: { $sum: 1 } } },
+      { $project: { _id: 0, slug: '$_id', avgDwellMs: { $cond: [{ $gt: ['$ends', 0] }, { $divide: ['$totalDwellMs', '$ends'] }, 0] } } },
+    ])
+    .toArray();
+
+  // Completion rate = completes / plays
+  const playsAgg = await coll
+    .aggregate([
+      { $match: { type: 'streams_video_play', ts: { $gte: startTs, $lt: endTs } } },
+      { $group: { _id: '$slug', plays: { $sum: 1 } } },
+      { $project: { _id: 0, slug: '$_id', plays: 1 } },
+    ])
+    .toArray();
+
+  const completesAgg = await coll
+    .aggregate([
+      { $match: { type: 'streams_video_complete', ts: { $gte: startTs, $lt: endTs } } },
+      { $group: { _id: '$slug', completes: { $sum: 1 } } },
+      { $project: { _id: 0, slug: '$_id', completes: 1 } },
+    ])
+    .toArray();
+
+  // Merge
+  const bySlug = new Map<string, any>();
+  for (const v of viewsAgg) bySlug.set(v.slug, { slug: v.slug, views: v.views });
+  for (const d of dwellAgg) bySlug.set(d.slug, { ...(bySlug.get(d.slug) || { slug: d.slug, views: 0 }), avgDwellMs: d.avgDwellMs });
+  for (const p of playsAgg) bySlug.set(p.slug, { ...(bySlug.get(p.slug) || { slug: p.slug, views: 0 }), plays: p.plays });
+  for (const c of completesAgg) bySlug.set(c.slug, { ...(bySlug.get(c.slug) || { slug: c.slug, views: 0 }), completes: c.completes });
+
+  const rows = Array.from(bySlug.values()).map((r) => {
+    const plays = r.plays || 0;
+    const completes = r.completes || 0;
+    const completionRate = plays > 0 ? completes / plays : 0;
+    return {
+      slug: r.slug,
+      views: r.views || 0,
+      avgDwellMs: Math.round(r.avgDwellMs || 0),
+      plays,
+      completes,
+      completionRate,
+    };
+  });
+
+  rows.sort((a, b) => b.views - a.views);
+
+  return res.status(200).json({
+    range: { from: new Date(startTs).toISOString(), to: new Date(endTs).toISOString() },
+    rows,
+  });
+}
+

--- a/pages/api/telemetry/streams.ts
+++ b/pages/api/telemetry/streams.ts
@@ -1,0 +1,37 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getDb } from '../../../lib/server/db';
+
+/**
+ * POST /api/telemetry/streams
+ * Accepts any "streams_*" events and stores them in the "streams_events" collection.
+ * Body: { type: 'streams_*', sid?: string, ts?: number, ...props }
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+  try {
+    const payload = req.body && typeof req.body === 'object' ? req.body : {};
+    const { type } = payload as { type?: string };
+    if (!type || !/^streams_/.test(type)) {
+      return res.status(400).json({ error: 'invalid_type' });
+    }
+    // Normalize event
+    const now = Date.now();
+    const doc = {
+      ...payload,
+      ip: (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() || (req as any).socket?.remoteAddress || null,
+      ua: req.headers['user-agent'] || null,
+      ts: Number.isFinite((payload as any).ts) ? (payload as any).ts : now,
+      receivedAt: now,
+    };
+    const db = await getDb();
+    await db.collection('streams_events').insertOne(doc);
+    return res.status(200).json({ ok: true });
+  } catch (e) {
+    console.error(e);
+    return res.status(500).json({ error: 'telemetry_insert_failed' });
+  }
+}
+

--- a/types/swr-infinite.d.ts
+++ b/types/swr-infinite.d.ts
@@ -1,0 +1,4 @@
+declare module 'swr/infinite' {
+  const useSWRInfinite: <T = any>(getKey: any, fetcher: any, config?: any) => any;
+  export default useSWRInfinite;
+}

--- a/types/swr.d.ts
+++ b/types/swr.d.ts
@@ -1,4 +1,4 @@
-declare module 'swr/infinite' {
-  const useSWRInfinite: <T = any>(getKey: any, fetcher: any, config?: any) => any;
-  export default useSWRInfinite;
+declare module 'swr' {
+  const useSWR: <T = any>(key: any, fetcher: any, config?: any) => any;
+  export default useSWR;
 }


### PR DESCRIPTION
## Summary
- route telemetry through dedicated `/api/telemetry/streams` sink and store in `streams_events`
- expose admin analytics endpoint aggregating views, dwell time and completion
- add admin dashboard to visualize stream metrics over last 7 days

## Testing
- `npm test`
- `npm run typecheck`
- `npm install` *(fails: 403 Forbidden for formidable)*

------
https://chatgpt.com/codex/tasks/task_e_68b392b8328c83299df1585c61f0263a