### PR TITLE
feat: lock cron endpoints to WATERNEWS_CRON_SECRET

### DIFF
--- a/.github/workflows/streams-indexes.yml
+++ b/.github/workflows/streams-indexes.yml
@@ -1,0 +1,16 @@
+name: Streams – Ensure Indexes
+on:
+  schedule:
+    - cron: "5 3 1 * *" # monthly at 03:05 UTC
+  workflow_dispatch:
+jobs:
+  call-endpoint:
+    runs-on: ubuntu-latest
+    env:
+      BASE_URL: https://waternews.onrender.com
+    steps:
+      - name: Ensure DB indexes
+        run: |
+          curl -fsS -X POST -H "Authorization: Bearer ${{ secrets.WATERNEWS_CRON_SECRET }}" \
+            "$BASE_URL/api/admin/cron/ensure-indexes"
+

--- a/.github/workflows/streams-posters.yml
+++ b/.github/workflows/streams-posters.yml
@@ -1,0 +1,16 @@
+name: Streams – Ensure Posters
+on:
+  schedule:
+    - cron: "7 * * * *" # hourly, offset to avoid :00 (UTC)
+  workflow_dispatch:
+jobs:
+  call-endpoint:
+    runs-on: ubuntu-latest
+    env:
+      BASE_URL: https://waternews.onrender.com
+    steps:
+      - name: Ensure posters on recent media
+        run: |
+          curl -fsS -X POST -H "Authorization: Bearer ${{ secrets.WATERNEWS_CRON_SECRET }}" \
+            "$BASE_URL/api/admin/cron/ensure-posters"
+

--- a/.github/workflows/streams-trending.yml
+++ b/.github/workflows/streams-trending.yml
@@ -1,0 +1,16 @@
+name: Streams – Trending Refresh
+on:
+  schedule:
+    - cron: "3,18,33,48 * * * *" # every ~15 min, offset from :00 (UTC)
+  workflow_dispatch:
+jobs:
+  call-endpoint:
+    runs-on: ubuntu-latest
+    env:
+      BASE_URL: https://waternews.onrender.com
+    steps:
+      - name: Refresh trending cache
+        run: |
+          curl -fsS -H "Authorization: Bearer ${{ secrets.WATERNEWS_CRON_SECRET }}" \
+            "$BASE_URL/api/admin/cron/trending-refresh?hours=48&n=100"
+

--- a/lib/server/cron-auth.ts
+++ b/lib/server/cron-auth.ts
@@ -1,0 +1,27 @@
+import { getServerSession } from 'next-auth/next';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { authOptions } from '../../pages/api/auth/[...nextauth]';
+
+export function isAdminEmail(email?: string | null) {
+  if (!email) return false;
+  const list = (process.env.ADMIN_EMAILS || '')
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  return list.includes(email.toLowerCase());
+}
+
+export async function isCronAuthorized(req: NextApiRequest, res: NextApiResponse) {
+  // Allow: signed-in admin
+  const session = await getServerSession(req, res, authOptions);
+  if (session && isAdminEmail((session.user as any)?.email)) return true;
+
+  // Allow: Bearer token via WATERNEWS_CRON_SECRET only
+  const header = req.headers.authorization || '';
+  const token = header.startsWith('Bearer ') ? header.slice(7) : null;
+  if (token && process.env.WATERNEWS_CRON_SECRET && token === process.env.WATERNEWS_CRON_SECRET)
+    return true;
+
+  return false;
+}
+

--- a/pages/api/admin/cron/ensure-indexes.ts
+++ b/pages/api/admin/cron/ensure-indexes.ts
@@ -1,27 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../../auth/[...nextauth]';
+import { isCronAuthorized } from '../../../../lib/server/cron-auth';
 import { getDb } from '../../../../lib/server/db';
-
-function isAdminEmail(email?: string | null) {
-  if (!email) return false;
-  const list = (process.env.ADMIN_EMAILS || '')
-    .split(',')
-    .map((s) => s.trim().toLowerCase())
-    .filter(Boolean);
-  return list.includes(email.toLowerCase());
-}
 
 /**
  * POST /api/admin/cron/ensure-indexes
  * Creates helpful indexes if missing.
  */
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const session = await getServerSession(req, res, authOptions);
-  const isAdmin = !!session && isAdminEmail((session.user as any)?.email);
-  const tokenOk =
-    !!process.env.PATWUA_API_KEY && req.headers.authorization === `Bearer ${process.env.PATWUA_API_KEY}`;
-  if (!isAdmin && !tokenOk) return res.status(401).json({ error: 'unauthorized' });
+  if (!(await isCronAuthorized(req, res))) return res.status(401).json({ error: 'unauthorized' });
 
   const db = await getDb();
   await db.collection('streams_events').createIndex({ ts: -1 });

--- a/pages/api/admin/cron/ensure-posters.ts
+++ b/pages/api/admin/cron/ensure-posters.ts
@@ -1,17 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getServerSession } from 'next-auth/next';
-import { authOptions } from '../../auth/[...nextauth]';
+import { isCronAuthorized } from '../../../../lib/server/cron-auth';
 import { getDb } from '../../../../lib/server/db';
 import { ObjectId } from 'mongodb';
-
-function isAdminEmail(email?: string | null) {
-  if (!email) return false;
-  const list = (process.env.ADMIN_EMAILS || '')
-    .split(',')
-    .map((s) => s.trim().toLowerCase())
-    .filter(Boolean);
-  return list.includes(email.toLowerCase());
-}
 
 /**
  * POST /api/admin/cron/ensure-posters
@@ -19,11 +9,7 @@ function isAdminEmail(email?: string | null) {
  * (External videos are skipped.)
  */
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const session = await getServerSession(req, res, authOptions);
-  const isAdmin = !!session && isAdminEmail((session.user as any)?.email);
-  const tokenOk =
-    !!process.env.PATWUA_API_KEY && req.headers.authorization === `Bearer ${process.env.PATWUA_API_KEY}`;
-  if (!isAdmin && !tokenOk) return res.status(401).json({ error: 'unauthorized' });
+  if (!(await isCronAuthorized(req, res))) return res.status(401).json({ error: 'unauthorized' });
 
   const db = await getDb();
   const Articles = db.collection('articles');


### PR DESCRIPTION
## Summary
- secure cron endpoints with `WATERNEWS_CRON_SECRET` and helper
- add scheduled workflows hitting cron endpoints

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b475ff5470832986a0b3756090dcec