### PR TITLE
Fix admin section updates and ensure cron poster targets correct collection

### DIFF
--- a/pages/admin/sections/index.tsx
+++ b/pages/admin/sections/index.tsx
@@ -30,7 +30,9 @@ export default function AdminSections() {
 
   async function toggle(id: string, current: boolean) {
     const next = !current;
-    setItems(items.map((it) => (it.id === id ? { ...it, enabled: next } : it)));
+    setItems((prev) =>
+      prev.map((it) => (it.id === id ? { ...it, enabled: next } : it))
+    );
     try {
       await fetch("/api/admin/sections", {
         method: "PUT",
@@ -38,7 +40,9 @@ export default function AdminSections() {
         body: JSON.stringify({ id, enabled: next }),
       });
     } catch (e) {
-      setItems(items.map((it) => (it.id === id ? { ...it, enabled: current } : it)));
+      setItems((prev) =>
+        prev.map((it) => (it.id === id ? { ...it, enabled: current } : it))
+      );
     }
   }
 

--- a/pages/api/admin/cron/ensure-posters.ts
+++ b/pages/api/admin/cron/ensure-posters.ts
@@ -29,8 +29,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return url.replace('/video/upload/', `/video/upload/f_auto,q_70,w_1080/`).replace(/\.mp4($|\?)/, '.jpg$1');
   }
 
-  async function processColl(coll: any) {
-    for (const doc of coll as any[]) {
+  async function processColl(docs: any[], collection: any) {
+    for (const doc of docs) {
       const assets = Array.isArray(doc.mediaAssets) ? doc.mediaAssets : [];
       let changed = false;
       for (const m of assets) {
@@ -44,14 +44,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }
       if (changed) {
         const id = doc._id as ObjectId;
-        await (doc.slug ? Articles : Drafts).updateOne({ _id: id }, { $set: { mediaAssets: assets, updatedAt: new Date() } });
+        await collection.updateOne(
+          { _id: id },
+          { $set: { mediaAssets: assets, updatedAt: new Date() } }
+        );
         updated++;
       }
     }
   }
 
-  await processColl(articles);
-  await processColl(drafts);
+  await processColl(articles, Articles);
+  await processColl(drafts, Drafts);
 
   return res.status(200).json({ ok: true, updated });
 }

--- a/pages/api/admin/is-admin.ts
+++ b/pages/api/admin/is-admin.ts
@@ -1,11 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { isAdminEmail } from '../../../lib/server/cron-auth';
+import { isAdminEmail, isAdminUser } from '@/lib/admin-auth';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
-  const email = (session?.user as any)?.email as string | undefined;
-  const isAdmin = isAdminEmail(email);
+  const email = (session?.user as any)?.email as string | null;
+  const isAdmin =
+    (await isAdminEmail(email)) || (await isAdminUser(email));
   return res.status(200).json({ isAdmin });
 }

--- a/pages/api/admin/sections/index.ts
+++ b/pages/api/admin/sections/index.ts
@@ -23,7 +23,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method === "PUT") {
     const { id, enabled, context } = req.body || {};
     if (!id) return res.status(400).json({ error: "id required" });
-    const update: any = { enabled: !!enabled };
+    const update: any = {};
+    if (enabled !== undefined) update.enabled = !!enabled;
     if (context !== undefined) update.context = context;
     const section = await Section.findOneAndUpdate(
       { id },


### PR DESCRIPTION
## Summary
- allow partial section updates without overwriting `enabled`
- use functional state updates when toggling section switches
- verify admin status via email or user role
- update poster cron to target Articles or Drafts explicitly

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b4877e22dc83298775026b5120374e