### PR TITLE
Bypass publish middleware for internal calls and copy media to posts

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -3,7 +3,13 @@ import type { NextRequest } from 'next/server';
 
 // Transparently rewrite newsroom draft publish → publish-with-media
 export function middleware(req: NextRequest) {
-  const { pathname, search } = req.nextUrl;
+  const { pathname, search, searchParams } = req.nextUrl;
+
+  // Skip rewrite when marked as an internal request
+  const internalHeader = (req as any).headers?.get?.('x-internal-request');
+  const isInternal = internalHeader === '1' || searchParams.get('internal') === '1';
+  if (isInternal) return NextResponse.next();
+
   // Match /api/newsroom/drafts/:id/publish exactly
   const m = pathname.match(/^\/api\/newsroom\/drafts\/([^/]+)\/publish$/);
   if (m && req.method === 'POST') {


### PR DESCRIPTION
## Summary
- Skip middleware rewrite when requests are marked internal
- Send internal marker when publish-with-media calls publish
- Move streams copy logic from articles to posts collection

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b48f6f76b48329ab2f8ac97309ebd6