### PR TITLE
Fix admin section updates and cron collection handling

### DIFF
--- a/pages/admin/sections/index.tsx
+++ b/pages/admin/sections/index.tsx
@@ -28,20 +28,30 @@ export default function AdminSections() {
     };
   }, []);
 
-  async function toggle(id: string, current: boolean) {
-    const next = !current;
+  async function toggle(id: string) {
+    let previous: boolean | undefined;
     setItems((prev) =>
-      prev.map((it) => (it.id === id ? { ...it, enabled: next } : it))
+      prev.map((it) => {
+        if (it.id === id) {
+          previous = it.enabled;
+          return { ...it, enabled: !it.enabled };
+        }
+        return it;
+      })
     );
     try {
       await fetch("/api/admin/sections", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id, enabled: next }),
+        body: JSON.stringify({ id, enabled: !previous }),
       });
     } catch (e) {
       setItems((prev) =>
-        prev.map((it) => (it.id === id ? { ...it, enabled: current } : it))
+        prev.map((it) =>
+          it.id === id && previous !== undefined
+            ? { ...it, enabled: previous }
+            : it
+        )
       );
     }
   }
@@ -63,7 +73,7 @@ export default function AdminSections() {
                 <input
                   type="checkbox"
                   checked={s.enabled}
-                  onChange={() => toggle(s.id, s.enabled)}
+                  onChange={() => toggle(s.id)}
                 />
                 <span className="text-sm">{s.enabled ? "On" : "Off"}</span>
               </label>

--- a/pages/api/admin/cron/ensure-posters.ts
+++ b/pages/api/admin/cron/ensure-posters.ts
@@ -17,7 +17,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const since = new Date(Date.now() - 14 * 24 * 3600 * 1000);
   const q = { updatedAt: { $gte: since } };
-  const fields = { projection: { _id: 1, mediaAssets: 1 } };
+  const fields = { projection: { _id: 1, mediaAssets: 1, slug: 1 } };
   const articles = await Articles.find(q, fields).toArray();
   const drafts = await Drafts.find(q, fields).toArray();
 

--- a/pages/api/admin/is-admin.ts
+++ b/pages/api/admin/is-admin.ts
@@ -7,6 +7,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const session = await getServerSession(req, res, authOptions);
   const email = (session?.user as any)?.email as string | null;
   const isAdmin =
-    (await isAdminEmail(email)) || (await isAdminUser(email));
+    !!email && ((await isAdminEmail(email)) || (await isAdminUser(email)));
   return res.status(200).json({ isAdmin });
 }

--- a/pages/api/admin/sections/index.ts
+++ b/pages/api/admin/sections/index.ts
@@ -21,11 +21,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   if (req.method === "PUT") {
-    const { id, enabled, context } = req.body || {};
+    const body = req.body || {};
+    const { id } = body;
     if (!id) return res.status(400).json({ error: "id required" });
-    const update: any = {};
-    if (enabled !== undefined) update.enabled = !!enabled;
-    if (context !== undefined) update.context = context;
+    const update: Record<string, any> = {};
+    if (Object.prototype.hasOwnProperty.call(body, "enabled")) {
+      update.enabled = !!body.enabled;
+    }
+    if (Object.prototype.hasOwnProperty.call(body, "context")) {
+      update.context = body.context;
+    }
     const section = await Section.findOneAndUpdate(
       { id },
       { $set: update },


### PR DESCRIPTION
## Summary
- avoid overwriting section flags when `enabled` or `context` not present
- use functional state updates for optimistic and rollback toggles
- gate admin access on email and database role checks
- include `slug` when scanning for missing video posters

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b4a68393f08329b2a3dcfd85971983