### PR TITLE
Fix admin section toggle state handling

### DIFF
--- a/pages/admin/sections/index.tsx
+++ b/pages/admin/sections/index.tsx
@@ -29,29 +29,22 @@ export default function AdminSections() {
   }, []);
 
   async function toggle(id: string) {
-    let previous: boolean | undefined;
+    const current = items.find((it) => it.id === id)?.enabled;
+    if (current === undefined) return;
+
     setItems((prev) =>
-      prev.map((it) => {
-        if (it.id === id) {
-          previous = it.enabled;
-          return { ...it, enabled: !it.enabled };
-        }
-        return it;
-      })
+      prev.map((it) => (it.id === id ? { ...it, enabled: !current } : it))
     );
+
     try {
       await fetch("/api/admin/sections", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id, enabled: !previous }),
+        body: JSON.stringify({ id, enabled: !current }),
       });
     } catch (e) {
       setItems((prev) =>
-        prev.map((it) =>
-          it.id === id && previous !== undefined
-            ? { ...it, enabled: previous }
-            : it
-        )
+        prev.map((it) => (it.id === id ? { ...it, enabled: current } : it))
       );
     }
   }


### PR DESCRIPTION
## Summary
- capture current enabled value before updating state
- use captured state for optimistic update and API request
- avoid mutating previous array in state updater

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b4c0ce461c8329a3ca640523e77e31