### PR TITLE
Fix workflow secret conditions

### DIFF
--- a/.github/workflows/streams-indexes.yml
+++ b/.github/workflows/streams-indexes.yml
@@ -8,10 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BASE_URL: https://waternews.onrender.com
+      WATERNEWS_CRON_SECRET: ${{ secrets.WATERNEWS_CRON_SECRET }}
     steps:
       - name: Ensure DB indexes
-        if: ${{ secrets.WATERNEWS_CRON_SECRET }}
+        if: ${{ env.WATERNEWS_CRON_SECRET != '' }}
         run: |
-          curl -fsS -X POST -H "Authorization: Bearer ${{ secrets.WATERNEWS_CRON_SECRET }}" \
+          curl -fsS -X POST -H "Authorization: Bearer $WATERNEWS_CRON_SECRET" \
             "$BASE_URL/api/admin/cron/ensure-indexes"
 

--- a/.github/workflows/streams-posters.yml
+++ b/.github/workflows/streams-posters.yml
@@ -8,10 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BASE_URL: https://waternews.onrender.com
+      WATERNEWS_CRON_SECRET: ${{ secrets.WATERNEWS_CRON_SECRET }}
     steps:
       - name: Ensure posters on recent media
-        if: ${{ secrets.WATERNEWS_CRON_SECRET }}
+        if: ${{ env.WATERNEWS_CRON_SECRET != '' }}
         run: |
-          curl -fsS -X POST -H "Authorization: Bearer ${{ secrets.WATERNEWS_CRON_SECRET }}" \
+          curl -fsS -X POST -H "Authorization: Bearer $WATERNEWS_CRON_SECRET" \
             "$BASE_URL/api/admin/cron/ensure-posters"
 

--- a/.github/workflows/streams-trending.yml
+++ b/.github/workflows/streams-trending.yml
@@ -8,10 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BASE_URL: https://waternews.onrender.com
+      WATERNEWS_CRON_SECRET: ${{ secrets.WATERNEWS_CRON_SECRET }}
     steps:
       - name: Refresh trending cache
-        if: ${{ secrets.WATERNEWS_CRON_SECRET }}
+        if: ${{ env.WATERNEWS_CRON_SECRET != '' }}
         run: |
-          curl -fsS -H "Authorization: Bearer ${{ secrets.WATERNEWS_CRON_SECRET }}" \
+          curl -fsS -H "Authorization: Bearer $WATERNEWS_CRON_SECRET" \
             "$BASE_URL/api/admin/cron/trending-refresh?hours=48&n=100"
 


### PR DESCRIPTION
## Summary
- assign `WATERNEWS_CRON_SECRET` to an environment variable in cron workflows
- guard workflow steps with explicit non-empty secret check
- reference secret via environment variable in curl calls

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b4c0d618cc83299ddfa16fb7b96e3b