### PR TITLE
Fix membership relation and enforce unique checkout intent

### DIFF
--- a/prisma/migrations/20250924000000_add_unique_checkout_intent/migration.sql
+++ b/prisma/migrations/20250924000000_add_unique_checkout_intent/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "OrgSubscription" ADD CONSTRAINT "OrgSubscription_checkoutIntentId_key" UNIQUE ("checkoutIntentId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,13 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model OrgSubscription {
+  id               Int    @id @default(autoincrement())
+  checkoutIntentId String @unique
+}

--- a/src/lib/subscriptions/activate.ts
+++ b/src/lib/subscriptions/activate.ts
@@ -1,0 +1,42 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export async function activateSubscriptionFromIntent(
+  checkoutIntentId: string,
+  orgId: string,
+) {
+  const intent = await prisma.checkoutIntent.findUnique({
+    where: { id: checkoutIntentId },
+    include: {
+      user: {
+        select: {
+          id: true,
+          email: true,
+          memberships: true,
+        },
+      },
+    },
+  });
+
+  if (!intent) throw new Error("Checkout intent not found");
+
+  const subscription = await prisma.orgSubscription.upsert({
+    where: { checkoutIntentId },
+    update: {},
+    create: {
+      orgId,
+      checkoutIntentId,
+    },
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      orgId,
+      action: "SUBSCRIPTION_CREATED",
+      userId: intent.user.id,
+    },
+  });
+
+  return subscription;
+}


### PR DESCRIPTION
## Summary
- select memberships when loading checkout intent user
- guard subscription activation with upsert on unique checkoutIntentId
- add unique constraint and migration for checkoutIntentId

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `DATABASE_URL="postgresql://user:pass@localhost:5432/db" pnpm dlx prisma migrate dev --name "add_unique_checkout_intent"` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b8391408088329b742a1f3fba54ef6