### PR TITLE
feat: add checkout intent models

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "build": "npm run typecheck && next build",
     "start": "next start",
-    "test": "echo \"ok\"",
+    "test": "node --test --loader tsx src/lib/subscriptions/__tests__/activate.test.ts",
     "postinstall": "node -v && npm -v",
     "migrate-avatar-to-profilePhoto": "tsx scripts/migrate-avatar-to-profilePhoto.ts"
   },

--- a/prisma/migrations/20250925000000_add_subscription_models/migration.sql
+++ b/prisma/migrations/20250925000000_add_subscription_models/migration.sql
@@ -1,0 +1,25 @@
+CREATE TABLE "User" (
+  "id" TEXT PRIMARY KEY,
+  "email" TEXT NOT NULL UNIQUE,
+  "memberships" TEXT[],
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE "CheckoutIntent" (
+  "id" TEXT PRIMARY KEY,
+  "userId" TEXT NOT NULL REFERENCES "User"("id"),
+  "orgId" TEXT
+);
+
+CREATE TABLE "AuditLog" (
+  "id" SERIAL PRIMARY KEY,
+  "orgId" TEXT NOT NULL,
+  "action" TEXT NOT NULL,
+  "userId" TEXT NOT NULL REFERENCES "User"("id"),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+ALTER TABLE "OrgSubscription" ADD COLUMN "orgId" TEXT;
+ALTER TABLE "OrgSubscription" ADD COLUMN "status" TEXT NOT NULL DEFAULT 'active';
+ALTER TABLE "OrgSubscription" ADD CONSTRAINT "OrgSubscription_checkoutIntentId_fkey" FOREIGN KEY ("checkoutIntentId") REFERENCES "CheckoutIntent"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,7 +7,35 @@ generator client {
   provider = "prisma-client-js"
 }
 
+model User {
+  id          String   @id @default(cuid())
+  email       String   @unique
+  memberships String[]
+  checkoutIntents CheckoutIntent[]
+  auditLogs   AuditLog[]
+}
+
+model CheckoutIntent {
+  id        String @id
+  user      User   @relation(fields: [userId], references: [id])
+  userId    String
+  orgId     String?
+  orgSubscription OrgSubscription?
+}
+
 model OrgSubscription {
-  id               Int    @id @default(autoincrement())
-  checkoutIntentId String @unique
+  id               Int              @id @default(autoincrement())
+  checkoutIntent   CheckoutIntent   @relation(fields: [checkoutIntentId], references: [id])
+  checkoutIntentId String           @unique
+  orgId            String?
+  status           String           @default("active")
+}
+
+model AuditLog {
+  id        Int      @id @default(autoincrement())
+  orgId     String
+  action    String
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String
+  createdAt DateTime @default(now())
 }

--- a/src/lib/subscriptions/__tests__/activate.test.ts
+++ b/src/lib/subscriptions/__tests__/activate.test.ts
@@ -1,0 +1,58 @@
+import { mock, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+mock.module('@prisma/client', () => {
+  class PrismaClient {
+    checkoutIntent = { findUnique: async () => null };
+    orgSubscription = { upsert: async () => null };
+    auditLog = { create: async () => null };
+  }
+  return { PrismaClient };
+});
+
+const { activateSubscriptionFromIntent, prisma } = await import('../activate.ts');
+
+test('auto-populates orgId from single membership', async (t) => {
+  t.mock.method(prisma.checkoutIntent, 'findUnique', async () => ({
+    id: 'chk1',
+    orgId: undefined,
+    user: { id: 'user1', email: 'u@example.com', memberships: ['org1'] },
+  }));
+
+  let captured: any;
+  t.mock.method(prisma.orgSubscription, 'upsert', async (args) => {
+    captured = args.create;
+    return { ...args.create };
+  });
+
+  const audit = t.mock.method(prisma.auditLog, 'create', async () => ({}));
+
+  const subscription = await activateSubscriptionFromIntent('chk1');
+
+  assert.equal(captured.orgId, 'org1');
+  assert.equal(captured.status, 'active');
+  assert.equal(audit.mock.callCount(), 1);
+  assert.equal(subscription.orgId, 'org1');
+});
+
+test('pending status when multiple memberships', async (t) => {
+  t.mock.method(prisma.checkoutIntent, 'findUnique', async () => ({
+    id: 'chk2',
+    orgId: undefined,
+    user: { id: 'user1', email: 'u@example.com', memberships: ['org1', 'org2'] },
+  }));
+
+  let captured: any;
+  t.mock.method(prisma.orgSubscription, 'upsert', async (args) => {
+    captured = args.create;
+    return { ...args.create };
+  });
+
+  const audit = t.mock.method(prisma.auditLog, 'create', async () => ({}));
+
+  const subscription = await activateSubscriptionFromIntent('chk2');
+
+  assert.equal(captured.status, 'pending_assignment');
+  assert.equal(audit.mock.callCount(), 0);
+  assert.equal(subscription.status, 'pending_assignment');
+});

--- a/src/lib/subscriptions/activate.ts
+++ b/src/lib/subscriptions/activate.ts
@@ -1,10 +1,10 @@
 import { PrismaClient } from "@prisma/client";
 
-const prisma = new PrismaClient();
+export const prisma = new PrismaClient();
 
 export async function activateSubscriptionFromIntent(
   checkoutIntentId: string,
-  orgId: string,
+  orgId?: string,
 ) {
   const intent = await prisma.checkoutIntent.findUnique({
     where: { id: checkoutIntentId },
@@ -21,22 +21,34 @@ export async function activateSubscriptionFromIntent(
 
   if (!intent) throw new Error("Checkout intent not found");
 
+  const resolvedOrgId =
+    orgId ??
+    intent.orgId ??
+    (intent.user.memberships.length === 1
+      ? intent.user.memberships[0]
+      : undefined);
+
+  const status = resolvedOrgId ? "active" : "pending_assignment";
+
   const subscription = await prisma.orgSubscription.upsert({
     where: { checkoutIntentId },
-    update: {},
+    update: { orgId: resolvedOrgId, status },
     create: {
-      orgId,
+      orgId: resolvedOrgId,
       checkoutIntentId,
+      status,
     },
   });
 
-  await prisma.auditLog.create({
-    data: {
-      orgId,
-      action: "SUBSCRIPTION_CREATED",
-      userId: intent.user.id,
-    },
-  });
+  if (resolvedOrgId) {
+    await prisma.auditLog.create({
+      data: {
+        orgId: resolvedOrgId,
+        action: "SUBSCRIPTION_CREATED",
+        userId: intent.user.id,
+      },
+    });
+  }
 
   return subscription;
 }


### PR DESCRIPTION
## Summary
- add Prisma models for users, checkout intents, subscriptions, and audit logs
- resolve subscription org from checkout intent or memberships and log creation
- cover activation flow with node:test specs

## Testing
- `npm test` *(fails: Cannot find package 'tsx')*
- `npm run typecheck` *(fails: Cannot find module 'node:test')*

------
https://chatgpt.com/codex/tasks/task_e_68b84570df588329af1f80d303784f89