### PR TITLE
add prisma client dependency and node typings for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "nodemailer": "^6.9.8",
     "socket.io": "^4.7.5",
     "socket.io-client": "^4.7.5",
-    "swr": "^2.2.2"
+    "swr": "^2.2.2",
+    "@prisma/client": "^5.16.2"
   },
   "optionalDependencies": {
     "cloudinary": "^1.41.2"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
@@ -26,7 +27,8 @@
       "@/utils/*": ["utils/*"]
     },
     // Prefer local shims and only use node_modules/@types if present
-    "typeRoots": ["./types", "./node_modules/@types"]
+    "typeRoots": ["./types", "./node_modules/@types"],
+    "types": ["node", "react", "react-dom"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "pages/api/**/*.ts"],
   "exclude": ["node_modules", "scripts"]

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -6,3 +6,13 @@ declare var process: NodeJS.Process;
 declare var __dirname: string;
 declare var module: any;
 declare var global: any;
+
+declare module 'node:test' {
+  export const mock: any;
+  export const test: any;
+}
+
+declare module 'node:assert/strict' {
+  const assert: any;
+  export default assert;
+}

--- a/types/prisma-client.d.ts
+++ b/types/prisma-client.d.ts
@@ -1,0 +1,7 @@
+declare module '@prisma/client' {
+  export class PrismaClient {
+    checkoutIntent: any;
+    orgSubscription: any;
+    auditLog: any;
+  }
+}


### PR DESCRIPTION
## Summary
- add `@prisma/client` dependency
- allow importing ts extensions and include node typings
- provide minimal type stubs for node test modules and Prisma client

## Testing
- `npm run typecheck`
- `npm test` *(fails: Cannot find package 'tsx' imported from /workspace/WaterNews/)*

------
https://chatgpt.com/codex/tasks/task_e_68b8608e2f7c8329852e0266003cb215