### PR TITLE
chore: add date-fns dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "formidable": "^3.5.1",
     "mongoose": "^8.6.0",
     "mongodb": "^6.6.0",
+    "date-fns": "^2.30.0",
     "next": "14.2.31",
     "next-auth": "^4.24.7",
     "react": "18.3.1",


### PR DESCRIPTION
## Summary
- add date-fns dependency so builds can resolve date utilities

## Testing
- `npm run typecheck`
- `npm test` *(fails: Cannot find package 'tsx')*


------
https://chatgpt.com/codex/tasks/task_e_68b89b7903688329adb444c202d92403