### PR TITLE
feat: record subscription activation timestamp

### DIFF
--- a/src/lib/subscriptions/__tests__/activate.test.ts
+++ b/src/lib/subscriptions/__tests__/activate.test.ts
@@ -31,8 +31,10 @@ test('auto-populates orgId from single membership', async (t) => {
 
   assert.equal(captured.orgId, 'org1');
   assert.equal(captured.status, 'active');
+  assert.equal(typeof captured.activatedAt, 'string');
   assert.equal(audit.mock.callCount(), 1);
   assert.equal(subscription.orgId, 'org1');
+  assert.equal(subscription.activatedAt, captured.activatedAt);
 });
 
 test('pending status when multiple memberships', async (t) => {
@@ -53,6 +55,8 @@ test('pending status when multiple memberships', async (t) => {
   const subscription = await activateSubscriptionFromIntent('chk2');
 
   assert.equal(captured.status, 'pending_assignment');
+  assert.equal(captured.activatedAt, undefined);
   assert.equal(audit.mock.callCount(), 0);
   assert.equal(subscription.status, 'pending_assignment');
+  assert.equal(subscription.activatedAt, undefined);
 });

--- a/src/lib/subscriptions/activate.ts
+++ b/src/lib/subscriptions/activate.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from "@prisma/client";
+import { formatISO } from "date-fns";
 
 export const prisma = new PrismaClient();
 
@@ -29,14 +30,20 @@ export async function activateSubscriptionFromIntent(
       : undefined);
 
   const status = resolvedOrgId ? "active" : "pending_assignment";
+  const activatedAt = formatISO(new Date());
 
   const subscription = await prisma.orgSubscription.upsert({
     where: { checkoutIntentId },
-    update: { orgId: resolvedOrgId, status },
+    update: {
+      orgId: resolvedOrgId,
+      status,
+      ...(resolvedOrgId ? { activatedAt } : {}),
+    },
     create: {
       orgId: resolvedOrgId,
       checkoutIntentId,
       status,
+      ...(resolvedOrgId ? { activatedAt } : {}),
     },
   });
 


### PR DESCRIPTION
## Summary
- record activation time for subscriptions using date-fns
- extend tests to cover activation timestamp

## Testing
- `npm test` *(fails: Cannot find package 'tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68b8a01df1208329adc9f6761ded79eb