### PR TITLE
chore: simplify npm configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
 registry=https://registry.npmjs.org/
-@types:registry=https://registry.npmjs.org/
-always-auth=false


### PR DESCRIPTION
## Summary
- remove scoped registry settings and keep npm config simple

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@prisma%2fclient)*
- `npm test` *(fails: Cannot find package 'tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68b8d99903b88329bc966ff5814566c4