### PR TITLE
docs: add build and start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,37 @@ npm run migrate-avatar-to-profilePhoto
 Ensure required environment variables such as `MONGODB_URI` are set before
 running a script.
 
+## Build and Start
+
+Build the application using your preferred package manager:
+
+- **pnpm**:
+
+  ```bash
+  corepack enable && pnpm install --frozen-lockfile && pnpm build
+  ```
+
+- **npm**:
+
+  ```bash
+  npm ci && npm run build
+  ```
+
+To run the server with database migrations applied:
+
+- **pnpm**:
+
+  ```bash
+  pnpm prisma migrate deploy && pnpm start
+  ```
+
+- **npm**:
+
+  ```bash
+  npx prisma migrate deploy && npm start
+  ```
+
+
 ## Routes
 - `/news/[slug]` – canonical article view.
 - `/article/[slug]` – legacy path now redirected to `/news/[slug]`.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev -p 3000",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "build": "npm run typecheck && next build",
-    "start": "next start",
+    "start": "npx prisma migrate deploy && next start",
     "test": "node --test --loader tsx src/lib/subscriptions/__tests__/activate.test.ts",
     "postinstall": "node -v && npm -v",
     "migrate-avatar-to-profilePhoto": "tsx scripts/migrate-avatar-to-profilePhoto.ts"


### PR DESCRIPTION
## Summary
- document build commands for pnpm or npm and how to start with database migrations
- ensure `npm start` runs Prisma migrations before launching Next.js

## Testing
- `npm test` *(fails: Cannot find package 'tsx')*
- `npm run build` *(fails: Cannot find module 'date-fns')*

------
https://chatgpt.com/codex/tasks/task_e_68b8d9ad4ca8832995609d5d254dd643